### PR TITLE
add missing argument to error printf

### DIFF
--- a/getting-started/bookshelf/pubsub_worker/worker.go
+++ b/getting-started/bookshelf/pubsub_worker/worker.go
@@ -90,7 +90,7 @@ func subscribe() {
 			log.Printf("[ID %d] Processing.", id)
 			go func() {
 				if err := update(id); err != nil {
-					log.Printf("[ID %d] could not update: %v", err)
+					log.Printf("[ID %d] could not update: %v", id, err)
 					return
 				}
 


### PR DESCRIPTION
This pull request adds a missing "id" argument to an error printf in the bookshelf pub/sub worker sample module.