### PR TITLE
Add missing newline in header when listing tasks.

### DIFF
--- a/datastore/tasks/tasks.go
+++ b/datastore/tasks/tasks.go
@@ -185,7 +185,7 @@ func DeleteTask(ctx context.Context, client *datastore.Client, taskID int64) err
 func PrintTasks(w io.Writer, tasks []*Task) {
 	// Use a tab writer to help make results pretty.
 	tw := tabwriter.NewWriter(w, 8, 8, 1, ' ', 0) // Min cell size of 8.
-	fmt.Fprintf(tw, "ID\tDescription\tStatus")
+	fmt.Fprintf(tw, "ID\tDescription\tStatus\n")
 	for _, t := range tasks {
 		if t.Done {
 			fmt.Fprintf(tw, "%d\t%s\tdone\n", t.id, t.Desc)


### PR DESCRIPTION
Output before:

`>` list
ID               Description Status5659313586569216 blar9   created 2016-04-04 21:30:07.840395 -0700 PDT
5634472569470976 blar8       created 2016-04-04 21:30:16.45611 -0700 PDT

Output after:
`>` list
ID               Description Status
5659313586569216 blar9       created 2016-04-04 21:30:07.840395 -0700 PDT
5634472569470976 blar8       created 2016-04-04 21:30:16.45611 -0700 PDT
