### PR TITLE
travis: remove 'go get golang.org/x/tools/cmd/vet'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ before_install:
 
 install:
 - go get -t -v ./...
-- go get golang.org/x/tools/cmd/vet
 
 script:
 - go test -v ./...


### PR DESCRIPTION
This has been removed (it moved into the main Go tree)