### PR TITLE
Adding example for Cloud Dataproc

### DIFF
--- a/dataproc/README.md
+++ b/dataproc/README.md
@@ -1,0 +1,42 @@
+# Google Cloud Dataproc Go sample
+
+This directory contains a Go sample for
+[Google Cloud Dataproc](https://cloud.google.com/dataproc).
+This sample does the following to show an example use of Cloud Dataproc:
+
+1. Create a cluster
+1. Submit a PySpark job to the cluster
+1. Get a link to the job output once the job completes
+1. Delete the cluster
+
+## Using this sample
+To use this sample, you will need:
+
+* An active Google Cloud Platform account
+* A project within your account
+* A [Google Cloud Storage](https://cloud.google.com/storage) bucket
+
+Once you have those, you can run this sample by doing the following. Please
+note, this example will use the included PySpark example `pyspark_sort.py` in
+this repository:
+
+1. Set your [GOPATH](https://github.com/golang/go/wiki/GOPATH)
+1. Get this repository by running
+`go get -d github.com/GoogleCloudPlatform/golang-samples`
+4. Change directories to `$GOPATH/src/github.com/evilsoapbox/golang-samples`
+5. Install dependancies
+    go get -d golang.org/x/net/context
+    go get -d golang.org/x/oauth2/google
+    go get -d google.golang.org/api/dataproc/v1
+    go get -d google.golang.org/api/storage/v1
+6. Run the sample script:
+`go run dataproc.go -bucket YOUR_BUCKET -pyspark-file pyspark_sort.py
+-project YOUR_PROJECT -zone YOUR_ZONE -cluster-name YOUR_CLUSTER_NAME`
+
+In the command above, you will need to specify your own values for several
+options, all of which are required:
+
+* `-bucket` - Your Google Cloud Storage bucket for holding the PySpark file
+* `-project` - Your Google Cloud Platform project ID
+* `-zone` - The zone you wish to use, such as `us-central1-f`
+* `-cluster-name` - The name your cluster will be given

--- a/dataproc/dataproc.go
+++ b/dataproc/dataproc.go
@@ -263,9 +263,8 @@ func submitJob(service *dataproc.Service, storageClient *storage.Client, filepat
 	return jobID, err
 }
 
-// getClusterDetails gets details about the cluster in the specified cluster config.
+// getClusterDetails returns details about a cluster with the specified cluster config.
 func getClusterDetails(service *dataproc.Service, cluster clusterConfig) (details clusterDetails, err error) {
-	// Get a list of clusters
 	clusters, err := listClusters(service, cluster.project, cluster.region)
 	if err != nil {
 		return details, err

--- a/dataproc/dataproc.go
+++ b/dataproc/dataproc.go
@@ -1,0 +1,313 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This script creates a Google Cloud Dataproc cluster
+// submits a job to the cluster and then deletes the cluster
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2/google"
+
+	dataproc "google.golang.org/api/dataproc/v1"
+	storage "google.golang.org/api/storage/v1"
+)
+
+const (
+	// Filename of example job (Python) file uploaded to Cloud Storage
+	exampleJobName = "test-file"
+
+	// Allows for full access to Google Cloud Platform products
+	scope = "https://www.googleapis.com/auth/cloud-platform"
+
+	// Compute URI base
+	computeUriBase = "https://www.googleapis.com/compute/v1/projects/%s/zones/%s"
+)
+
+var (
+	bucketName  = flag.String("bucket", "", "GCS Bucket for storage of job file")
+	clusterName = flag.String("cluster-name", "", "Name of cluster")
+	projectID   = flag.String("project", "", "Your cloud project ID.")
+	pysparkFile = flag.String("pyspark-file", "", "PySpark Job file")
+	regionID    = flag.String("region", "global", "Your cloud project region.")
+	zoneID      = flag.String("zone", "", "Cloud Platform zone")
+)
+
+// Get a Cloud Dataproc service object
+func GetDataprocService() (service *dataproc.Service) {
+	client, err := google.DefaultClient(context.Background(), scope)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create a new Dataproc service
+	service, err = dataproc.New(client)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return service
+}
+
+// Get a Cloud Storage service object
+func GetStorageService() (service *storage.Service) {
+	client, err := google.DefaultClient(context.Background(), scope)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create a new storage service
+	service, err = storage.New(client)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return service
+}
+
+// Create a Cloud Dataproc cluster
+func CreateCluster(service *dataproc.Service, name string, region string,
+	project string, zone string) (response string, err error) {
+	// Create a gceConfig object for the cluster
+	gceConfig := dataproc.GceClusterConfig{
+		ZoneUri: fmt.Sprintf(computeUriBase, project, zone),
+	}
+
+	// Create a cluserConfig for the cluster
+	clusterConfig := dataproc.ClusterConfig{
+		GceClusterConfig: &gceConfig,
+	}
+
+	// Create a cluster object
+	cluster := dataproc.Cluster{
+		ClusterName: name,
+		ProjectId:   project,
+		Config:      &clusterConfig,
+	}
+
+	// Create the cluster
+	res, err := service.Projects.Regions.Clusters.Create(project, region, &cluster).Do()
+
+	// Handle creation errors
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return fmt.Sprintf("%s", res), err
+}
+
+// Delete the Cloud Dataproc cluster
+func DeleteCluster(service *dataproc.Service, project string, region string, name string) (response string, err error) {
+	// Delete the cluster
+	res, err := service.Projects.Regions.Clusters.Delete(project, region, name).Do()
+
+	// Handle deletion errors
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return fmt.Sprintf("%s", res), err
+}
+
+// Get metadata about a cluster
+func GetClusterDataByName(service *dataproc.Service, name string) (clusterData []string) {
+	clusters, _ := ListClusters(service)
+	for _, item := range clusters {
+		if item[0] == name {
+			return item
+		}
+	}
+
+	return nil
+}
+
+// Get the link to a job's output
+func GetJobOutput(storageService *storage.Service, projectId string, clusterId string, outputBucket string, jobId string) {
+	objectName := fmt.Sprintf("google-cloud-dataproc-metainfo/%s/jobs/%s/driveroutput.000000000", clusterId, jobId)
+
+	// URL encode the object name
+	u, err := url.Parse(objectName)
+	if err != nil {
+		log.Fatal(err)
+	}
+	encodedObjectName := u.EscapedPath()
+
+	if res, err := storageService.Objects.Get(outputBucket, encodedObjectName).Do(); err == nil {
+		fmt.Println(fmt.Printf("The media download link for the output is:\n\n%s.\n\n", res.MediaLink))
+		fmt.Printf("The media download link for %v/%v is %v.\n", outputBucket, res.Name, res.MediaLink)
+	} else {
+		log.Fatal(fmt.Sprintf("Failed to get %s/%s: %s.", outputBucket, encodedObjectName, err))
+	}
+}
+
+// Get the status of a job
+func GetJobStatus(service *dataproc.Service, jobId string, project string, region string) (status string, err error) {
+	//Get the Job's status
+	res, err := service.Projects.Regions.Jobs.Get(project, region, jobId).Do()
+
+	return res.Status.State, err
+}
+
+func ListClusters(service *dataproc.Service) (clusters [][]string, err error) {
+	// List all clusters in a project for a given region
+	res, err := service.Projects.Regions.Clusters.List(*projectID, *regionID).Do()
+
+	for _, item := range res.Clusters {
+		clusterDetails := []string{
+			item.ClusterName,
+			item.ClusterUuid,
+			item.Status.State,
+			item.Config.ConfigBucket,
+		}
+		clusters = append(clusters, clusterDetails)
+	}
+
+	return clusters, err
+}
+
+func SubmitJob(service *dataproc.Service, stroageService *storage.Service, filepath string, project string, bucket string, cluster string) (jobId string, err error) {
+	// Error if the file does not exist
+	if _, err := os.Stat(filepath); os.IsNotExist(err) {
+		log.Fatal("File does not exist")
+	}
+
+	// Upload the file to GCS
+	job_filename_parts := strings.Split(filepath, "/")
+	filename := job_filename_parts[len(job_filename_parts)-1]
+	object := &storage.Object{Name: filename}
+	file, err := os.Open(filepath)
+	if err != nil {
+		log.Fatal("Error opening %q: %v", filepath, err)
+	}
+	_, uploadError := stroageService.Objects.Insert(bucket, object).Media(file).Do()
+	if uploadError != nil {
+		log.Fatal("Error uploading file to GCS", filepath, err)
+	}
+
+	// Submit the PySpark job
+	placement := dataproc.JobPlacement{
+		ClusterName: cluster,
+	}
+	pySparkJob := dataproc.PySparkJob{
+		MainPythonFileUri: "gs://" + bucket + "/" + filename,
+	}
+	jobID := "test-job-" + fmt.Sprintf("%v", time.Now().Unix())
+	jobReference := dataproc.JobReference{
+		JobId:     jobID,
+		ProjectId: project,
+	}
+	job := dataproc.Job{
+		Placement:  &placement,
+		PysparkJob: &pySparkJob,
+		Reference:  &jobReference,
+	}
+	jobRequest := dataproc.SubmitJobRequest{
+		Job: &job,
+	}
+
+	_, jobError := service.Projects.Regions.Jobs.Submit(*projectID, "global", &jobRequest).Do()
+	return jobID, jobError
+}
+
+func WaitForCluster(service *dataproc.Service, name string) (running bool, err error) {
+	for running == false {
+		clusterData := GetClusterDataByName(service, name)
+		if clusterData[2] == "RUNNING" {
+			running = true
+		}
+
+		// Sleep for one second
+		time.Sleep(1000 * time.Millisecond)
+	}
+	return running, err
+}
+
+// Wait for a job to complete
+func WaitForJob(service *dataproc.Service, jobId string, project string, region string) (finished bool, err error) {
+	for finished == false {
+		jobStatus, err := GetJobStatus(service, jobId, project, region)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if jobStatus == "DONE" {
+			finished = true
+		}
+
+		// Sleep for one second
+		time.Sleep(1000 * time.Millisecond)
+	}
+
+	return finished, err
+}
+
+func main() {
+	// Parse command line arguments
+	flag.Parse()
+
+	// Check for required flags (golang flags does not support?)
+	if *bucketName == "" || *clusterName == "" || *projectID == "" || *pysparkFile == "" || *regionID == "" || *zoneID == "" {
+		log.Fatal("Incorrect arguments specified see 'go-dataproc -help' for help")
+	}
+
+	// Create a new Dataproc service
+	service := GetDataprocService()
+
+	// Create a new storage service
+	storageService := GetStorageService()
+
+	// Create a cluster
+	_, create_error := CreateCluster(service, *clusterName, *regionID, *projectID, *zoneID)
+	if create_error != nil {
+		log.Fatal(create_error)
+	}
+	fmt.Println("Cluster created")
+
+	// Wait on the cluster to become active
+	fmt.Println("Waiting for cluster to be ready")
+	_, clusterWaitError := WaitForCluster(service, *clusterName)
+	if clusterWaitError != nil {
+		log.Fatal(clusterWaitError)
+	}
+
+	// Submit a job to the cluster
+	fmt.Println("Submitting job")
+	jobId, job_error := SubmitJob(service, storageService, *pysparkFile, *projectID, *bucketName, *clusterName)
+	if job_error != nil {
+		log.Fatal(job_error)
+	}
+
+	// Wait for the job to complete
+	fmt.Println("Waiting for job to complete")
+	WaitForJob(service, jobId, *projectID, *regionID)
+	fmt.Println("Job is finished")
+
+	// Get the job outputBucket
+	clusterData := GetClusterDataByName(service, *clusterName)
+	GetJobOutput(storageService, *projectID, clusterData[1], clusterData[3], jobId)
+
+	// Delete the cluster
+	_, delete_error := DeleteCluster(service, *projectID, *regionID, *clusterName)
+	if delete_error != nil {
+		log.Fatal(delete_error)
+	}
+	fmt.Println("Cluster deleted")
+	fmt.Printf("Done...")
+}
+

--- a/dataproc/dataproc_test.go
+++ b/dataproc/dataproc_test.go
@@ -1,0 +1,26 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests for the Cloud Dataproc Go code sample
+package main
+
+// This testing suite uses the flags defined in the main package file
+// and will fail to work properly unless proper flags are specified
+import (
+	"testing"
+)
+
+// Tests the main() function of the Cloud Dataproc code sample
+func TestMain(t *testing.T) {
+	main()
+}
+

--- a/dataproc/pyspark_sort.py
+++ b/dataproc/pyspark_sort.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Sample pyspark script to be uploaded to Cloud Storage and run on
+Cloud Dataproc.
+
+Note this file is not intended to be run directly, but run inside a PySpark
+environment.
+"""
+
+# [START pyspark]
+import pyspark
+
+sc = pyspark.SparkContext()
+rdd = sc.parallelize(['Hello,', 'world!', 'dog', 'elephant', 'panther'])
+words = sorted(rdd.collect())
+print words
+# [END pyspark]

--- a/dataproc/pyspark_sort.py
+++ b/dataproc/pyspark_sort.py
@@ -1,15 +1,6 @@
-#!/usr/bin/env python
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright 2016 Google Inc. All rights reserved.
+# Use of this source code is governed by the Apache 2.0
+# license that can be found in the LICENSE file.
 
 """ Sample pyspark script to be uploaded to Cloud Storage and run on
 Cloud Dataproc.


### PR DESCRIPTION
Go example for Google Cloud Dataproc. This sample follows a pretty basic (and common) Cloud Dataproc pattern:
1. Create cluster
2. Submit job
3. Get job output
4. Delete cluster

A sample PySpark job is also included in the repository.
