### PR TITLE
bigquery: add synchronous query sample

### DIFF
--- a/bigquery/syncquery/syncquery.go
+++ b/bigquery/syncquery/syncquery.go
@@ -1,0 +1,64 @@
+// Copyright 2016 Google Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+// Command syncquery queries a Google BigQuery dataset.
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"cloud.google.com/go/bigquery"
+
+	"golang.org/x/net/context"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("usage: ", os.Args[0], "'query text'")
+		os.Exit(1)
+	}
+	proj := os.Getenv("GCLOUD_PROJECT")
+	if proj == "" {
+		fmt.Println("GCLOUD_PROJECT environment variable must be set.")
+		os.Exit(1)
+	}
+
+	rows, err := Query(proj, os.Args[1])
+	if err != nil {
+		log.Fatalln(err)
+	}
+	for _, row := range rows {
+		fmt.Println(row)
+	}
+}
+
+// Query returns a slice of the reults of a query.
+func Query(proj, q string) ([]bigquery.ValueList, error) {
+	ctx := context.Background()
+
+	client, err := bigquery.NewClient(ctx, proj)
+	if err != nil {
+		return nil, err
+	}
+
+	query := client.Query(q)
+	iter, err := query.Read(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var rows []bigquery.ValueList
+
+	for iter.Next(ctx) {
+		var row bigquery.ValueList
+		if err := iter.Get(&row); err != nil {
+			return nil, err
+		}
+		rows = append(rows, row)
+	}
+
+	return rows, iter.Err()
+}

--- a/bigquery/syncquery/syncquery_test.go
+++ b/bigquery/syncquery/syncquery_test.go
@@ -1,0 +1,27 @@
+// Copyright 2016 Google Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+)
+
+func TestQuery(t *testing.T) {
+	tc := testutil.SystemTest(t)
+
+	rows, err := Query(tc.ProjectID, "SELECT corpus FROM publicdata:samples.shakespeare GROUP BY corpus;")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, row := range rows {
+		if row[0] == "romeoandjuliet" {
+			return
+		}
+	}
+	t.Errorf("got rows: %q; want romeoandjuliet", rows)
+}


### PR DESCRIPTION
@broady Please take a look.

I would have added an "asynchronous query" like https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/bigquery/api/async_query.py but I couldn't figure out how to use the "jobs" API with the bigquery client. Filed: https://github.com/GoogleCloudPlatform/gcloud-golang/issues/327

Also, I wanted to support standard SQL syntax instead of or in addition to legacy SQL syntax (the default), but I couldn't find a parameter for it. Filed https://github.com/GoogleCloudPlatform/gcloud-golang/issues/326