### PR TITLE
Add style section to CONTRIBUTING.md.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,15 @@
 1. Make changes, commit to your fork.
 1. Send a pull request with your changes.
 
-# Testing
+## Style
 
-## Running system tests
+Ensure that your sample is formatted using
+[gofmt](https://golang.org/cmd/gofmt/) and that it passes [go
+vet](https://golang.org/cmd/vet/) without errors or warnings.
+
+## Testing
+
+### Running system tests
 
 Set the `GOLANG_SAMPLES_PROJECT_ID` environment variable to a suitable test project.
 


### PR DESCRIPTION
I want to make https://github.com/GoogleCloudPlatform/Template/wiki/style.html point at the appropriate repositories rather than having the tools linked there.