### PR TITLE
docs/appengine/config: wrap lines to prevent scrollbars in docs

### DIFF
--- a/docs/appengine/config/appconfig.txt
+++ b/docs/appengine/config/appconfig.txt
@@ -28,7 +28,8 @@ handlers:
 // [START script_example]
 handlers:
 
-# The root URL (/) is handled by the Go application. No other URLs match this pattern.
+# The root URL (/) is handled by the Go application. 
+# No other URLs match this pattern.
 - url: /
   script: _go_app
 
@@ -36,7 +37,8 @@ handlers:
 - url: /index\.html
   script: _go_app
 
-# A regular expression indicating that it should be handled by the Go application.
+# A regular expression indicating that it should be handled 
+# by the Go application.
 - url: /browse/(books|videos|tools)
   script: _go_app
 


### PR DESCRIPTION
Fixing unnessesary scrolling and text that gets hidden in the large reference table caused by long comments: https://cloud.google.com/appengine/docs/go/config/appref#handlers_script