### PR TITLE
all: add retry support for flaky tests

### DIFF
--- a/internal/testutil/retry.go
+++ b/internal/testutil/retry.go
@@ -1,0 +1,108 @@
+// Copyright 2016 Google Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+package testutil
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func Flaky(t *testing.T, max int, sleep time.Duration, f func(r *R)) bool {
+	for attempt := 1; attempt <= max; attempt++ {
+		r := &R{t: t, Attempt: attempt, log: &bytes.Buffer{}}
+
+		last := attempt == max
+		done := make(chan bool)
+		go func() {
+			defer close(done)
+			f(r)
+		}()
+		<-done
+		success := !r.retry && !r.fail
+
+		if success || last || r.fail {
+			state := "FAIL"
+			if success {
+				state = "SUCCESS"
+				if r.log.Len() == 0 {
+					return true
+				}
+			}
+			t.Logf("Attempt %d: %s%s", attempt, state, r.log.String())
+			if !success {
+				t.Fail()
+			}
+		}
+		if success {
+			return true
+		}
+		if !r.retry {
+			break
+		}
+		time.Sleep(sleep)
+	}
+	return false
+}
+
+type R struct {
+	Attempt int
+
+	t     *testing.T
+	retry bool
+	fail  bool
+	log   *bytes.Buffer
+}
+
+func (r *R) Retry() {
+	r.retry = true
+}
+
+func (r *R) RetryNow() {
+	r.retry = true
+	runtime.Goexit()
+}
+
+func (r *R) FailNow() {
+	r.fail = true
+	runtime.Goexit()
+}
+
+func (r *R) Fail() {
+	r.fail = true
+}
+
+func (r *R) Retryf(s string, v ...interface{}) {
+	r.logf(s, v...)
+	r.Retry()
+}
+
+func (r *R) Fatalf(s string, v ...interface{}) {
+	r.logf(s, v...)
+	r.Fail()
+	runtime.Goexit()
+}
+
+func (r *R) Logf(s string, v ...interface{}) {
+	r.logf(s, v...)
+}
+
+func (r *R) logf(s string, v ...interface{}) {
+	fmt.Fprint(r.log, "\n")
+	fmt.Fprint(r.log, lineNumber())
+	fmt.Fprintf(r.log, s, v...)
+}
+
+func lineNumber() string {
+	_, file, line, ok := runtime.Caller(3) // logf, public func, user function
+	if !ok {
+		return ""
+	}
+	return filepath.Base(file) + ":" + strconv.Itoa(line) + ": "
+}

--- a/internal/testutil/retry.go
+++ b/internal/testutil/retry.go
@@ -19,11 +19,10 @@ import (
 // Use the provided *testutil.R instead of a *testing.T from the function.
 func Flaky(t *testing.T, maxAttempts int, sleep time.Duration, f func(r *R)) bool {
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		r := &R{t: t, Attempt: attempt, log: &bytes.Buffer{}}
+		r := &R{Attempt: attempt, log: &bytes.Buffer{}}
 
 		f(r)
 
-		// successful, no need to log anything.
 		if !r.failed {
 			if r.log.Len() != 0 {
 				t.Logf("Success after %d attempts:%s", attempt, r.log.String())
@@ -46,7 +45,6 @@ type R struct {
 	// The number of current attempt.
 	Attempt int
 
-	t      *testing.T
 	failed bool
 	log    *bytes.Buffer
 }

--- a/internal/testutil/retry.go
+++ b/internal/testutil/retry.go
@@ -14,10 +14,10 @@ import (
 	"time"
 )
 
-// Flaky runs function f for up to maxAttempts times until f returns successfully, and reports whether f was run successfully.
+// Retry runs function f for up to maxAttempts times until f returns successfully, and reports whether f was run successfully.
 // It will sleep for the given period between invocations of f.
 // Use the provided *testutil.R instead of a *testing.T from the function.
-func Flaky(t *testing.T, maxAttempts int, sleep time.Duration, f func(r *R)) bool {
+func Retry(t *testing.T, maxAttempts int, sleep time.Duration, f func(r *R)) bool {
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		r := &R{Attempt: attempt, log: &bytes.Buffer{}}
 
@@ -54,8 +54,8 @@ func (r *R) Fail() {
 	r.failed = true
 }
 
-// Failf is equivalent to Logf followed by Fail.
-func (r *R) Failf(s string, v ...interface{}) {
+// Errorf is equivalent to Logf followed by Fail.
+func (r *R) Errorf(s string, v ...interface{}) {
 	r.logf(s, v...)
 	r.Fail()
 }

--- a/internal/testutil/retry_test.go
+++ b/internal/testutil/retry_test.go
@@ -14,9 +14,7 @@ func TestRetry(t *testing.T) {
 		if r.Attempt == 2 {
 			return
 		}
-
-		// Retry once.
-		r.Retry()
+		r.Fail()
 	})
 }
 
@@ -31,7 +29,7 @@ func TestRetryAttempts(t *testing.T) {
 		if r.Attempt == 5 {
 			return
 		}
-		r.Retry()
+		r.Fail()
 	})
 
 	if attempts != 5 {

--- a/internal/testutil/retry_test.go
+++ b/internal/testutil/retry_test.go
@@ -1,0 +1,40 @@
+// Copyright 2016 Google Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+package testutil
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRetry(t *testing.T) {
+	Flaky(t, 5, time.Millisecond, func(r *R) {
+		if r.Attempt == 2 {
+			return
+		}
+
+		// Retry once.
+		r.Retry()
+	})
+}
+
+func TestRetryAttempts(t *testing.T) {
+	var attempts int
+	Flaky(t, 10, time.Millisecond, func(r *R) {
+		r.Logf("This line should appear only once.")
+		r.Logf("attempt=%d", r.Attempt)
+		attempts = r.Attempt
+
+		// Retry 5 times.
+		if r.Attempt == 5 {
+			return
+		}
+		r.Retry()
+	})
+
+	if attempts != 5 {
+		t.Errorf("attempts=%d; want %d", attempts, 5)
+	}
+}

--- a/internal/testutil/retry_test.go
+++ b/internal/testutil/retry_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestRetry(t *testing.T) {
-	Flaky(t, 5, time.Millisecond, func(r *R) {
+	Retry(t, 5, time.Millisecond, func(r *R) {
 		if r.Attempt == 2 {
 			return
 		}
@@ -20,7 +20,7 @@ func TestRetry(t *testing.T) {
 
 func TestRetryAttempts(t *testing.T) {
 	var attempts int
-	Flaky(t, 10, time.Millisecond, func(r *R) {
+	Retry(t, 10, time.Millisecond, func(r *R) {
 		r.Logf("This line should appear only once.")
 		r.Logf("attempt=%d", r.Attempt)
 		attempts = r.Attempt

--- a/logging/simplelog/simplelog_test.go
+++ b/logging/simplelog/simplelog_test.go
@@ -48,15 +48,15 @@ func TestSimplelog(t *testing.T) {
 	writeEntry(client)
 	structuredWrite(client)
 
-	testutil.Flaky(t, 10, time.Second, func(r *testutil.R) {
+	testutil.Retry(t, 10, time.Second, func(r *testutil.R) {
 		entries, err := getEntries(adminClient, tc.ProjectID)
 		if err != nil {
-			r.Failf("getEntries: %v", err)
+			r.Errorf("getEntries: %v", err)
 			return
 		}
 
 		if got, want := len(entries), 2; got != want {
-			r.Failf("len(entries) = %d; want %d", got, want)
+			r.Errorf("len(entries) = %d; want %d", got, want)
 			return
 		}
 
@@ -69,7 +69,7 @@ func TestSimplelog(t *testing.T) {
 		for want, entry := range wantContain {
 			msg := fmt.Sprintf("%s", entry.Payload)
 			if !strings.Contains(msg, want) {
-				r.Failf("want %q to contain %q", msg, want)
+				r.Errorf("want %q to contain %q", msg, want)
 			}
 		}
 	})

--- a/logging/simplelog/simplelog_test.go
+++ b/logging/simplelog/simplelog_test.go
@@ -48,28 +48,29 @@ func TestSimplelog(t *testing.T) {
 	writeEntry(client)
 	structuredWrite(client)
 
-	time.Sleep(5 * time.Second)
-
-	entries, err := getEntries(adminClient, tc.ProjectID)
-	if err != nil {
-		t.Fatalf("getEntries: %v", err)
-	}
-
-	if got, want := len(entries), 2; got != want {
-		t.Fatalf("len(entries) = %d; want %d", got, want)
-	}
-
-	wantContain := map[string]*logging.Entry{
-		"Anything":                            entries[0],
-		"The payload can be any type!":        entries[0],
-		"infolog is a standard Go log.Logger": entries[1],
-	}
-
-	for want, entry := range wantContain {
-		msg := fmt.Sprintf("%s", entry.Payload)
-		if !strings.Contains(msg, want) {
-			t.Errorf("want %q to contain %q", msg, want)
+	testutil.Flaky(t, 10, time.Second, func(r *testutil.R) {
+		entries, err := getEntries(adminClient, tc.ProjectID)
+		if err != nil {
+			r.Failf("getEntries: %v", err)
+			return
 		}
-	}
 
+		if got, want := len(entries), 2; got != want {
+			r.Failf("len(entries) = %d; want %d", got, want)
+			return
+		}
+
+		wantContain := map[string]*logging.Entry{
+			"Anything":                            entries[0],
+			"The payload can be any type!":        entries[0],
+			"infolog is a standard Go log.Logger": entries[1],
+		}
+
+		for want, entry := range wantContain {
+			msg := fmt.Sprintf("%s", entry.Payload)
+			if !strings.Contains(msg, want) {
+				r.Failf("want %q to contain %q", msg, want)
+			}
+		}
+	})
 }

--- a/pubsub/subscriptions/main_test.go
+++ b/pubsub/subscriptions/main_test.go
@@ -80,10 +80,10 @@ func TestCreate(t *testing.T) {
 func TestList(t *testing.T) {
 	c := setup(t)
 
-	testutil.Flaky(t, 10, time.Second, func(r *testutil.R) {
+	testutil.Retry(t, 10, time.Second, func(r *testutil.R) {
 		subs, err := list(c)
 		if err != nil {
-			r.Failf("failed to list subscriptions: %v", err)
+			r.Errorf("failed to list subscriptions: %v", err)
 			return
 		}
 
@@ -97,7 +97,7 @@ func TestList(t *testing.T) {
 		for i, sub := range subs {
 			subNames[i] = sub.ID()
 		}
-		r.Failf("got %+v; want a list with subscription %q", subNames, subID)
+		r.Errorf("got %+v; want a list with subscription %q", subNames, subID)
 	})
 }
 

--- a/pubsub/subscriptions/main_test.go
+++ b/pubsub/subscriptions/main_test.go
@@ -23,7 +23,7 @@ const (
 	topicID = "golang-samples-topic"
 )
 
-var once sync.Once // guards cleanup related operations that needs to be executed only for once.
+var once sync.Once // guards cleanup related operations in setup.
 
 func setup(t *testing.T) *pubsub.Client {
 	ctx := context.Background()
@@ -36,7 +36,7 @@ func setup(t *testing.T) *pubsub.Client {
 
 	// Cleanup resources from the previous failed tests.
 	once.Do(func() {
-		// create a topic to subscribe to.
+		// Create a topic.
 		topic = client.Topic(topicID)
 		ok, err := topic.Exists(ctx)
 		if err != nil {
@@ -48,7 +48,7 @@ func setup(t *testing.T) *pubsub.Client {
 			}
 		}
 
-		// delete the sub if already exists
+		// Delete the sub if already exists.
 		sub := client.Subscription(subID)
 		ok, err = sub.Exists(ctx)
 		if err != nil {
@@ -80,30 +80,25 @@ func TestCreate(t *testing.T) {
 func TestList(t *testing.T) {
 	c := setup(t)
 
-	var ok bool
-	var subs []*pubsub.Subscription
-outer:
-	for attempts := 0; attempts < 5; attempts++ {
-		var err error
-		subs, err = list(c)
+	testutil.Flaky(t, 10, time.Second, func(r *testutil.R) {
+		subs, err := list(c)
 		if err != nil {
-			t.Fatalf("failed to list subscriptions: %v", err)
+			r.Failf("failed to list subscriptions: %v", err)
+			return
 		}
+
 		for _, sub := range subs {
 			if sub.ID() == subID {
-				ok = true
-				break outer
+				return // PASS
 			}
 		}
-		time.Sleep(2 * time.Second)
-	}
-	if !ok {
+
 		subNames := make([]string, len(subs))
 		for i, sub := range subs {
 			subNames[i] = sub.ID()
 		}
-		t.Fatalf("got %+v; want a list with subscription %q", subNames, subID)
-	}
+		r.Failf("got %+v; want a list with subscription %q", subNames, subID)
+	})
 }
 
 func TestIAM(t *testing.T) {

--- a/pubsub/topics/main_test.go
+++ b/pubsub/topics/main_test.go
@@ -45,10 +45,10 @@ func TestCreate(t *testing.T) {
 func TestList(t *testing.T) {
 	c := setup(t)
 
-	testutil.Flaky(t, 10, time.Second, func(r *testutil.R) {
+	testutil.Retry(t, 10, time.Second, func(r *testutil.R) {
 		topics, err := list(c)
 		if err != nil {
-			r.Failf("failed to list topics: %v", err)
+			r.Errorf("failed to list topics: %v", err)
 		}
 
 		for _, t := range topics {
@@ -61,7 +61,7 @@ func TestList(t *testing.T) {
 		for i, t := range topics {
 			topicNames[i] = t.ID()
 		}
-		r.Failf("got %+v; want a list with topic = %q", topicNames, topicID)
+		r.Errorf("got %+v; want a list with topic = %q", topicNames, topicID)
 	})
 }
 

--- a/pubsub/topics/main_test.go
+++ b/pubsub/topics/main_test.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -43,21 +44,25 @@ func TestCreate(t *testing.T) {
 
 func TestList(t *testing.T) {
 	c := setup(t)
-	topics, err := list(c)
-	if err != nil {
-		t.Fatalf("failed to list topics: %v", err)
-	}
-	var ok bool
-	for _, t := range topics {
-		// TODO(jbd): Fix HasSuffix when
-		if t.ID() == topicID {
-			ok = true
-			break
+
+	testutil.Flaky(t, 10, time.Second, func(r *testutil.R) {
+		topics, err := list(c)
+		if err != nil {
+			r.Failf("failed to list topics: %v", err)
 		}
-	}
-	if !ok {
-		t.Errorf("got %+v; want a list with topic = %q", topics, topicID)
-	}
+
+		for _, t := range topics {
+			if t.ID() == topicID {
+				return // PASS
+			}
+		}
+
+		topicNames := make([]string, len(topics))
+		for i, t := range topics {
+			topicNames[i] = t.ID()
+		}
+		r.Failf("got %+v; want a list with topic = %q", topicNames, topicID)
+	})
 }
 
 func TestPublish(t *testing.T) {


### PR DESCRIPTION
Test output is only written for the final attempt.

A similar interface to *testing.T is provided to each attempt.

```
$ go test -v ./internal/testutil/
=== RUN   TestRetry
--- PASS: TestRetry (0.00s)
=== RUN   TestRetryAttempts
--- PASS: TestRetryAttempts (0.00s)
    retry.go:29: Success after 5 attempts:
        retry_test.go:24: This line should appear only once.
        retry_test.go:25: attempt=5
PASS
ok      github.com/GoogleCloudPlatform/golang-samples/internal/testutil 0.023s
```
