### PR TITLE
bigquery: update example for new bigquery client surface

### DIFF
--- a/bigquery/syncquery/syncquery.go
+++ b/bigquery/syncquery/syncquery.go
@@ -11,6 +11,7 @@ import (
 	"os"
 
 	"cloud.google.com/go/bigquery"
+	"google.golang.org/api/iterator"
 
 	"golang.org/x/net/context"
 )
@@ -52,13 +53,15 @@ func Query(proj, q string) ([]bigquery.ValueList, error) {
 
 	var rows []bigquery.ValueList
 
-	for iter.Next(ctx) {
+	for {
 		var row bigquery.ValueList
-		if err := iter.Get(&row); err != nil {
+		err := iter.Next(&row)
+		if err == iterator.Done {
+			return rows, nil
+		}
+		if err != nil {
 			return nil, err
 		}
 		rows = append(rows, row)
 	}
-
-	return rows, iter.Err()
 }


### PR DESCRIPTION
Change iterator to new methods.

Also, return nil instead of rows so far on error, to be idiomatic.