### PR TITLE
Fix datastore references in bookshelf go sample

### DIFF
--- a/getting-started/bookshelf/db_datastore.go
+++ b/getting-started/bookshelf/db_datastore.go
@@ -68,7 +68,7 @@ func (db *datastoreDB) AddBook(b *Book) (id int64, err error) {
 	if err != nil {
 		return 0, fmt.Errorf("datastoredb: could not put Book: %v", err)
 	}
-	return k.ID(), nil
+	return k.ID, nil
 }
 
 // DeleteBook removes a given book by its ID.
@@ -105,7 +105,7 @@ func (db *datastoreDB) ListBooks() ([]*Book, error) {
 	}
 
 	for i, k := range keys {
-		books[i].ID = k.ID()
+		books[i].ID = k.ID
 	}
 
 	return books, nil
@@ -131,7 +131,7 @@ func (db *datastoreDB) ListBooksCreatedBy(userID string) ([]*Book, error) {
 	}
 
 	for i, k := range keys {
-		books[i].ID = k.ID()
+		books[i].ID = k.ID
 	}
 
 	return books, nil


### PR DESCRIPTION
Updated to work with this recent change in the datastore library: https://github.com/GoogleCloudPlatform/google-cloud-go/commit/d34ae6f898bfb6962913d1092f2283bbe228c42f