### PR TITLE
docs/managed_vms/cloudsql: use FUSE connection string

### DIFF
--- a/docs/managed_vms/cloudsql/app.yaml
+++ b/docs/managed_vms/cloudsql/app.yaml
@@ -7,12 +7,21 @@ automatic_scaling:
 #[START env]
 env_variables:
   # See https://github.com/go-sql-driver/mysql
-  MYSQL_CONNECTION: user:password@tcp(127.0.0.1:3306)/dbname
+  #
+  # Replace INSTANCE_CONNECTION_NAME with the same value as in the
+  # beta_settings section below.
+  MYSQL_CONNECTION: user:password@unix(/cloudsql/INSTANCE_CONNECTION_NAME)/dbname
+  #
+  # If you're testing locally using the Cloud SQL proxy with TCP,
+  # instead use the "tcp" dialer by setting the environment variable:
+  # MYSQL_CONNECTION=user:password@tcp(127.0.0.1:3306)/dbname
 #[END env]
 
 #[START cloudsql_settings]
-# Replace INSTANCE_CONNECTION_NAME with the value obtained  when configuring your
+# Replace INSTANCE_CONNECTION_NAME with the value obtained when configuring your
 # Cloud SQL instance, available from the Google Cloud Console or from the Cloud SDK.
+# For SQL v2 instances, this should be in the form of "project:region:instance".
+# Cloud SQL v1 instances are not supported.
 beta_settings:
-    cloud_sql_instances: INSTANCE_CONNECTION_NAME
+  cloud_sql_instances: INSTANCE_CONNECTION_NAME
 #[END cloudsql_settings]


### PR DESCRIPTION
The TCP proxy is not bound to the loopback address. The FUSE proxy
works, though.

Add some other instructions on what the connection string should look
like and what the TCP proxy address should be when testing locally.