### PR TITLE
getting-started/bookshelf: use bare struct for profile

### DIFF
--- a/getting-started/bookshelf/app/app.go
+++ b/getting-started/bookshelf/app/app.go
@@ -110,7 +110,7 @@ func listMineHandler(w http.ResponseWriter, r *http.Request) *appError {
 		return nil
 	}
 
-	books, err := bookshelf.DB.ListBooksCreatedBy(user.Id)
+	books, err := bookshelf.DB.ListBooksCreatedBy(user.ID)
 	if err != nil {
 		return appErrorf(err, "could not list books: %v", err)
 	}
@@ -187,7 +187,7 @@ func bookFromForm(r *http.Request) (*bookshelf.Book, error) {
 		if user != nil {
 			// Logged in.
 			book.CreatedBy = user.DisplayName
-			book.CreatedByID = user.Id
+			book.CreatedByID = user.ID
 		} else {
 			// Not logged in.
 			book.SetCreatorAnonymous()

--- a/getting-started/bookshelf/app/auth.go
+++ b/getting-started/bookshelf/app/auth.go
@@ -35,7 +35,7 @@ const (
 func init() {
 	// Gob encoding for gorilla/sessions
 	gob.Register(&oauth2.Token{})
-	gob.Register(&plus.Person{})
+	gob.Register(&Profile{})
 }
 
 // loginHandler initiates an OAuth flow to authenticate the user.
@@ -160,7 +160,7 @@ func logoutHandler(w http.ResponseWriter, r *http.Request) *appError {
 
 // profileFromSession retreives the Google+ profile from the default session.
 // Returns nil if the profile cannot be retreived (e.g. user is logged out).
-func profileFromSession(r *http.Request) *plus.Person {
+func profileFromSession(r *http.Request) *Profile {
 	session, err := bookshelf.SessionStore.Get(r, defaultSessionID)
 	if err != nil {
 		return nil
@@ -169,21 +169,22 @@ func profileFromSession(r *http.Request) *plus.Person {
 	if !ok || !tok.Valid() {
 		return nil
 	}
-	profile, ok := session.Values[googleProfileSessionKey].(*plus.Person)
+	profile, ok := session.Values[googleProfileSessionKey].(*Profile)
 	if !ok {
 		return nil
 	}
 	return profile
 }
 
+type Profile struct {
+	ID, DisplayName, ImageURL string
+}
+
 // stripProfile returns a subset of a plus.Person.
-func stripProfile(p *plus.Person) *plus.Person {
-	return &plus.Person{
-		Id:          p.Id,
+func stripProfile(p *plus.Person) *Profile {
+	return &Profile{
+		ID:          p.Id,
 		DisplayName: p.DisplayName,
-		Image:       p.Image,
-		Etag:        p.Etag,
-		Name:        p.Name,
-		Url:         p.Url,
+		ImageURL:    p.Image.Url,
 	}
 }

--- a/getting-started/bookshelf/app/template.go
+++ b/getting-started/bookshelf/app/template.go
@@ -11,8 +11,6 @@ import (
 	"net/http"
 	"path/filepath"
 
-	"google.golang.org/api/plus/v1"
-
 	"github.com/GoogleCloudPlatform/golang-samples/getting-started/bookshelf"
 )
 
@@ -42,7 +40,7 @@ func (tmpl *appTemplate) Execute(w http.ResponseWriter, r *http.Request, data in
 	d := struct {
 		Data        interface{}
 		AuthEnabled bool
-		Profile     *plus.Person
+		Profile     *Profile
 		LoginURL    string
 		LogoutURL   string
 	}{

--- a/getting-started/bookshelf/app/templates/base.html
+++ b/getting-started/bookshelf/app/templates/base.html
@@ -32,8 +32,8 @@
         <button class="btn btn-default">Log out</button>
       </form>
       <div class="navbar-text navbar-right">
-        {{if .Profile.Image.Url}}
-          <img class="img-circle" width="24" src="{{.Profile.Image.Url}}">
+        {{if .Profile.ImageURL}}
+          <img class="img-circle" width="24" src="{{.Profile.ImageURL}}">
         {{end}}
         <span>{{.Profile.DisplayName}}</span>
       </div>


### PR DESCRIPTION
encoding/gob is used to serialize structs to the cookie, which means the
full type information is serialized. This was causing the cookie to
execeed the 4096 byte limit.

Fixes #137.