### PR TITLE
Update ports for endpoints sample.

### DIFF
--- a/endpoints/getting-started/Dockerfile.custom
+++ b/endpoints/getting-started/Dockerfile.custom
@@ -1,4 +1,4 @@
 FROM golang:onbuild
-EXPOSE 8081
-ENV PORT 8081
+EXPOSE 8080
+ENV PORT 8080
 ENTRYPOINT ["go-wrapper", "run"]

--- a/endpoints/getting-started/container-engine.yaml
+++ b/endpoints/getting-started/container-engine.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   ports:
   - port: 80
-    targetPort: 8080
+    targetPort: 8081
     protocol: TCP
     name: http
   selector:
@@ -42,15 +42,15 @@ spec:
       - name: esp
         image: b.gcr.io/endpoints/endpoints-runtime:0.3
         args: [
-          "-p", "8080",
-          "-a", "127.0.0.1:8081",
+          "-p", "8081",
+          "-a", "127.0.0.1:8080",
           "-s", "SERVICE_NAME",
           "-v", "SERVICE_VERSION",
         ]
       # [END esp]
         ports:
-          - containerPort: 8080
-      - name: echo
-        image: gcr.io/google-samples/go-echo:1.0
-        ports:
           - containerPort: 8081
+      - name: echo
+        image: gcr.io/google-samples/echo-go:1.0
+        ports:
+          - containerPort: 8080


### PR DESCRIPTION
Need to switch ports of containers to match other languages.

`gcr.io/google-samples/echo-go:1.0` is updated and pushed to listen on 8080.