### PR TITLE
bigquery: use int64 instead of int when reading values

### DIFF
--- a/bigquery/simpleapp/simpleapp.go
+++ b/bigquery/simpleapp/simpleapp.go
@@ -70,11 +70,11 @@ func printResults(w io.Writer, iter *bigquery.RowIterator) error {
 		for _, t := range ts {
 			record := t.([]bigquery.Value)
 			title := record[0].(string)
-			cnt := record[1].(int)
+			cnt := record[1].(int64)
 			fmt.Fprintf(w, "\t%s: %d\n", title, cnt)
 		}
 
-		words := row[1].(int)
+		words := row[1].(int64)
 		fmt.Fprintf(w, "total unique words: %d\n", words)
 	}
 }


### PR DESCRIPTION
A breaking change was made in the client package:
https://code-review.googlesource.com/#/c/9331/

Update the sample to reflect this change.