### PR TITLE
Update x-issuer and x-jwks_uri flags

### DIFF
--- a/endpoints/getting-started/openapi.yaml
+++ b/endpoints/getting-started/openapi.yaml
@@ -135,21 +135,21 @@ securityDefinitions:
     authorizationUrl: ""
     flow: "implicit"
     type: "oauth2"
-    x-issuer: "accounts.google.com"
-    x-jwks_uri: "https://www.googleapis.com/oauth2/v1/certs"
+    x-google-issuer: "accounts.google.com"
+    x-google-jwks_uri: "https://www.googleapis.com/oauth2/v1/certs"
   # This section configures authentication using Firebase Auth.
   firebase:
     authorizationUrl: ""
     flow: "implicit"
     type: "oauth2"
-    x-issuer: "https://securetoken.google.com/YOUR-PROJECT-ID"
-    x-jwks_uri: "https://www.googleapis.com/service_accounts/v1/metadata/x509/securetoken@system.gserviceaccount.com"
+    x-google-issuer: "https://securetoken.google.com/YOUR-PROJECT-ID"
+    x-google-jwks_uri: "https://www.googleapis.com/service_accounts/v1/metadata/x509/securetoken@system.gserviceaccount.com"
       # This section configures authentication using Auth0 (https://auth0.com).
   auth0_jwk:
     # Update YOUR-ACCOUNT-NAME with your Auth0 account name.
     authorizationUrl: "https://YOUR-ACCOUNT-NAME.auth0.com/authorize"
     flow: "implicit"
     type: "oauth2"
-    x-issuer: "https://YOUR-ACCOUNT-NAME.auth0.com/"
+    x-google-issuer: "https://YOUR-ACCOUNT-NAME.auth0.com/"
     # Update this with your service account's email address.
-    x-jwks_uri: "https://YOUR-ACCOUNT-NAME.auth0.com/.well-known/jwks.json"
+    x-google-jwks_uri: "https://YOUR-ACCOUNT-NAME.auth0.com/.well-known/jwks.json"


### PR DESCRIPTION
Incorporate new prefix for x-issuer and x-jwks_uri flags. Stops gcloud throwing warnings when sample openapi.yaml is deployed.