### PR TITLE
testing: add environment variables for Cloud KMS tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ before_install:
 - if [ $SYSTEM_TESTS ]; then
     openssl aes-256-cbc -K $encrypted_e44ee91b46d4_key -iv $encrypted_e44ee91b46d4_iv -in key.json.enc -out key.json -d;
     export GOOGLE_APPLICATION_CREDENTIALS="$(pwd)/key.json";
+    export GOLANG_SAMPLES_KMS_KEYRING=ring1
+    export GOLANG_SAMPLES_KMS_CRYPTOKEY=key1
 
     curl https://storage.googleapis.com/gimme-proj/linux_amd64/gimmeproj > gimmeproj && chmod +x gimmeproj;
     ./gimmeproj version;

--- a/testing/cloudbuild/run.bash
+++ b/testing/cloudbuild/run.bash
@@ -4,6 +4,8 @@ set -e
 
 mv key.json /tmp/key.json
 export GOOGLE_APPLICATION_CREDENTIALS=/tmp/key.json
+export GOLANG_SAMPLES_KMS_KEYRING=ring1
+export GOLANG_SAMPLES_KMS_CRYPTOKEY=key1
 
 curl https://storage.googleapis.com/gimme-proj/linux_amd64/gimmeproj > /bin/gimmeproj && chmod +x /bin/gimmeproj;
 gimmeproj version;


### PR DESCRIPTION
golang-samples-tests{,2-10} all have Cloud KMS enabled and a key at
global/ring1/key1.