### PR TITLE
Updated files for use with "gcloud app deploy"

### DIFF
--- a/docs/appengine/config/appconfig.txt
+++ b/docs/appengine/config/appconfig.txt
@@ -1,6 +1,4 @@
 // [START about_app_yaml_example]
-application: myapp
-version: alpha-001
 runtime: go
 api_version: go1
 
@@ -71,8 +69,6 @@ handlers:
 //[END auth_fail_action_example]
 
 //[START expiration_example]
-application: myapp
-version: alpha-001
 runtime: go
 api_version: go1
 

--- a/docs/appengine/config/cron.txt
+++ b/docs/appengine/config/cron.txt
@@ -1,6 +1,4 @@
 // [START securing_URLs_for_cron]
-application: hello-cron
-version: 1
 runtime: go
 api_version: go1
 

--- a/docs/appengine/modules/converting.txt
+++ b/docs/appengine/modules/converting.txt
@@ -11,31 +11,25 @@ backends:
 // [END sample_1]
 
 // [START sample_2]
-application: myapp
-module: memdb
-version: uno
+service: memdb
 instance_class: B8
 manual_scaling:
   instances: 5
 // [END sample_2]
 
 // [START sample_3]
-application: myapp
-module: worker
-version: uno
-# For failfast functionality, please use the ‘X-AppEngine-FailFast’ header on requests made to this module.
+service: worker
+# For failfast functionality, please use the ‘X-AppEngine-FailFast’ header on requests made to this service.
 manual_scaling:
   instances: 1
 handlers:
-# If a module has an /_ah/start handler, it should be listed first.
+# If a service has an /_ah/start handler, it should be listed first.
 - url: /_ah/start
   script: _go_app
 // [END sample_3]
 
 // [START sample_4]
-application: myapp
-module: cmdline
-version: uno
+service: cmdline
 basic_scaling:
   max_instances: 1
 // [END sample_4]

--- a/docs/appengine/modules/index.txt
+++ b/docs/appengine/modules/index.txt
@@ -37,7 +37,6 @@ api_version: go1
 
 // [START example_2]
 service: mobile-frontend
-version: uno
 runtime: go
 api_version: go1
 

--- a/docs/appengine/modules/index.txt
+++ b/docs/appengine/modules/index.txt
@@ -1,7 +1,5 @@
 // [START manual_scaling]
-application: simple-sample
-module: my_module
-version: uno
+service: my_service
 runtime: go
 api_version: go1
 instance_class: B8
@@ -10,9 +8,7 @@ manual_scaling:
 // [END manual_scaling]
 
 // [START basic_scaling]
-application: simple-sample
-module: my_module
-version: uno
+service: my_service
 runtime: go
 api_version: go1
 instance_class: B8
@@ -22,9 +18,7 @@ basic_scaling:
 // [END basic_scaling]
 
 // [START automatic_scaling]
-application: simple-sample
-module: my_module
-version: uno
+service: my_service
 runtime: go
 api_version: go1
 instance_class: F2
@@ -37,15 +31,12 @@ automatic_scaling:
 // [END automatic_scaling]
 
 // [START example_1]
-application: simple-sample
-version: uno
 runtime: go
 api_version: go1
 // [END example_1]
 
 // [START example_2]
-application: simple-sample
-module: mobile-frontend
+service: mobile-frontend
 version: uno
 runtime: go
 api_version: go1
@@ -56,9 +47,7 @@ automatic_scaling:
 // [END example_2]
 
 // [START example_3]
-application: simple-sample
-module: my-module
-version: uno
+service: my_service
 runtime: go
 api_version: go1
 

--- a/docs/appengine/modules/routing.txt
+++ b/docs/appengine/modules/routing.txt
@@ -1,41 +1,38 @@
 // [START sample_1]
-application: simple-sample
-# No version required; this does routing independent of version.
-
 dispatch:
-  # Default module serves the typical web resources and all static resources.
+  # Default service serves the typical web resources and all static resources.
   - url: "*/favicon.ico"
-    module: default
+    service: default
 
-  # Default module serves simple hostname request.
+  # Default service serves simple hostname request.
   - url: "simple-sample.appspot.com/"
-    module: default
+    service: default
 
   # Send all mobile traffic to the mobile frontend.
   - url: "*/mobile/*"
-    module: mobile-frontend
+    service: mobile-frontend
 
   # Send all work to the one static backend.
   - url: "*/work/*"
-    module: static-backend
+    service: static-backend
 // [END sample_1]
 
 // [START sample_2]
-# Send any path that begins with “simple-sample.appspot.com/mobile” to the mobile-frontend module.
+# Send any path that begins with “simple-sample.appspot.com/mobile” to the mobile-frontend service.
 - url: "simple-sample.appspot.com/mobile*"
-  module: mobile-frontend
+  service: mobile-frontend
 
-# Send any domain/sub-domain with a path that starts with “work” to the static backend module.
+# Send any domain/sub-domain with a path that starts with “work” to the static backend service.
 - url: "*/work*"
-  module: static-backend
+  service: static-backend
 // [END sample_2]
 
 // [START sample_3]
 # Matches the path "/fun", but not "/fun2" or "/fun/other".
 - url: "*/fun"
-  module: mobile-frontend
+  service: mobile-frontend
 
 # Matches the hostname "customer1.myapp.com", but not "1.customer1.myapp.com".
 - url: "customer1.myapp.com/*"
-  module: static-backend
+  service: static-backend
 // [END sample_3]

--- a/docs/appengine/tools/uploadingdata.txt
+++ b/docs/appengine/tools/uploadingdata.txt
@@ -8,5 +8,5 @@ import _ "google.golang.org/appengine/remote_api"
 // [END setting_up_remote_api_2]
 
 // [START setting_up_remote_api_3]
-goapp deploy <app-directory>
+gcloud app deploy app.yaml
 // [END setting_up_remote_api_3]


### PR DESCRIPTION
All the Go language docs for App Engine have been updated to use the new "gcloud" tool commands so these files (which are imported) also need to be updated. Changes include:

1. Removed the unsupported: "application:" and "version:" elements
2. Replaced all references of "module" with "service"
3. Replace use of "goapp" with "gcloud app deploy"

The following docs are affected:
https://cloud.google.com/appengine/docs/standard/go/tools/remoteapi/
https://cloud.google.com/appengine/docs/standard/go/config/appref
https://cloud.google.com/appengine/docs/standard/go/modules/converting
https://cloud.google.com/appengine/docs/standard/go/config/dispatchref
https://cloud.google.com/appengine/docs/standard/go/configuration-files
https://cloud.google.com/appengine/docs/standard/go/config/cron