### PR TITLE
Removing "application:" & "version:"

### DIFF
--- a/docs/appengine/taskqueue/app.yaml
+++ b/docs/appengine/taskqueue/app.yaml
@@ -1,6 +1,4 @@
 // [START securing_urls]
-application: hello-tasks
-version: 1
 runtime: go
 api_version: go1
 


### PR DESCRIPTION
Updating code sample to align with docs and the support for "gcloud app deploy":

https://cloud.google.com/appengine/docs/standard/go/taskqueue/push/creating-handlers#securing_task_handler_urls