### PR TITLE
bigtable: move bigtable examples to golang-samples

### DIFF
--- a/bigtable/helloworld/README.md
+++ b/bigtable/helloworld/README.md
@@ -1,0 +1,46 @@
+# Cloud Bigtable Hello World in Go
+
+This is a simple application that demonstrates using the [Google Cloud APIs Go
+Client Library](https://github.com/GoogleCloudPlatform/google-cloud-go) to connect
+to and interact with Cloud Bigtable.
+
+## Prerequisites
+
+1. Set up Cloud Console.
+  1. Go to the [Cloud Console](https://cloud.google.com/console) and create or select your project.
+     You will need the project ID later.
+  1. Go to **Settings > Project Billing Settings** and enable billing.
+  1. Select **APIs & Auth > APIs**.
+  1. Enable the **Cloud Bigtable API** and the **Cloud Bigtable Admin API**.
+  (You may need to search for the API).
+1. Set up gcloud.
+  1. `gcloud components update`
+  1. `gcloud auth login`
+  1. `gcloud config set project PROJECT_ID`
+1. Provision a Cloud Bigtable instance
+  1. Follow the instructions in the [user
+documentation](https://cloud.google.com/bigtable/docs/creating-instance) to
+create a Google Cloud Platform project and Cloud Bigtable instance if necessary.
+  1. You'll need to reference your project id and instance id to run the application.
+
+## Running
+
+1. From the hello_world example folder, `go run main.go -project PROJECT_ID -instance INSTANCE_ID`, substituting your project id and instance id.
+
+## Cleaning up
+
+To avoid incurring extra charges to your Google Cloud Platform account, remove
+the resources created for this sample.
+
+1.  Go to the Clusters page in the [Cloud
+    Console](https://console.cloud.google.com).
+
+    [Go to the Clusters page](https://console.cloud.google.com/project/_/bigtable/clusters)
+
+1.  Click the cluster name.
+
+1.  Click **Delete**.
+
+    ![Delete](https://cloud.google.com/bigtable/img/delete-quickstart-cluster.png)
+
+1. Type the cluster ID, then click **Delete** to delete the cluster.

--- a/bigtable/helloworld/main.go
+++ b/bigtable/helloworld/main.go
@@ -1,0 +1,157 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Hello world is a sample program demonstrating use of the Bigtable client
+// library to perform basic CRUD operations
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+
+	"cloud.google.com/go/bigtable"
+	"golang.org/x/net/context"
+)
+
+// User-provided constants.
+const (
+	tableName        = "Hello-Bigtable"
+	columnFamilyName = "cf1"
+	columnName       = "greeting"
+)
+
+var greetings = []string{"Hello World!", "Hello Cloud Bigtable!", "Hello golang!"}
+
+// sliceContains reports whether the provided string is present in the given slice of strings.
+func sliceContains(list []string, target string) bool {
+	for _, s := range list {
+		if s == target {
+			return true
+		}
+	}
+	return false
+}
+
+func main() {
+	project := flag.String("project", "", "The Google Cloud Platform project ID. Required.")
+	instance := flag.String("instance", "", "The Google Cloud Bigtable instance ID. Required.")
+	flag.Parse()
+
+	for _, f := range []string{"project", "instance"} {
+		if flag.Lookup(f).Value.String() == "" {
+			log.Fatalf("The %s flag is required.", f)
+		}
+	}
+
+	ctx := context.Background()
+
+	// Set up admin client, tables, and column families.
+	// NewAdminClient uses Application Default Credentials to authenticate.
+	adminClient, err := bigtable.NewAdminClient(ctx, *project, *instance)
+	if err != nil {
+		log.Fatalf("Could not create admin client: %v", err)
+	}
+
+	tables, err := adminClient.Tables(ctx)
+	if err != nil {
+		log.Fatalf("Could not fetch table list: %v", err)
+	}
+
+	if !sliceContains(tables, tableName) {
+		log.Printf("Creating table %s", tableName)
+		if err := adminClient.CreateTable(ctx, tableName); err != nil {
+			log.Fatalf("Could not create table %s: %v", tableName, err)
+		}
+	}
+
+	tblInfo, err := adminClient.TableInfo(ctx, tableName)
+	if err != nil {
+		log.Fatalf("Could not read info for table %s: %v", tableName, err)
+	}
+
+	if !sliceContains(tblInfo.Families, columnFamilyName) {
+		if err := adminClient.CreateColumnFamily(ctx, tableName, columnFamilyName); err != nil {
+			log.Fatalf("Could not create column family %s: %v", columnFamilyName, err)
+		}
+	}
+
+	// Set up Bigtable data operations client.
+	// NewClient uses Application Default Credentials to authenticate.
+	client, err := bigtable.NewClient(ctx, *project, *instance)
+	if err != nil {
+		log.Fatalf("Could not create data operations client: %v", err)
+	}
+
+	tbl := client.Open(tableName)
+	muts := make([]*bigtable.Mutation, len(greetings))
+	rowKeys := make([]string, len(greetings))
+
+	log.Printf("Writing greeting rows to table")
+	for i, greeting := range greetings {
+		muts[i] = bigtable.NewMutation()
+		muts[i].Set(columnFamilyName, columnName, bigtable.Now(), []byte(greeting))
+
+		// Each row has a unique row key.
+		//
+		// Note: This example uses sequential numeric IDs for simplicity, but
+		// this can result in poor performance in a production application.
+		// Since rows are stored in sorted order by key, sequential keys can
+		// result in poor distribution of operations across nodes.
+		//
+		// For more information about how to design a Bigtable schema for the
+		// best performance, see the documentation:
+		//
+		//     https://cloud.google.com/bigtable/docs/schema-design
+		rowKeys[i] = fmt.Sprintf("%s%d", columnName, i)
+	}
+
+	rowErrs, err := tbl.ApplyBulk(ctx, rowKeys, muts)
+	if err != nil {
+		log.Fatalf("Could not apply bulk row mutation: %v", err)
+	}
+	if rowErrs != nil {
+		for _, rowErr := range rowErrs {
+			log.Printf("Error writing row: %v", rowErr)
+		}
+		log.Fatalf("Could not write some rows")
+	}
+
+	log.Printf("Getting a single greeting by row key:")
+	row, err := tbl.ReadRow(ctx, rowKeys[0], bigtable.RowFilter(bigtable.ColumnFilter(columnName)))
+	if err != nil {
+		log.Fatalf("Could not read row with key %s: %v", rowKeys[0], err)
+	}
+	log.Printf("\t%s = %s\n", rowKeys[0], string(row[columnFamilyName][0].Value))
+
+	log.Printf("Reading all greeting rows:")
+	err = tbl.ReadRows(ctx, bigtable.PrefixRange(columnName), func(row bigtable.Row) bool {
+		item := row[columnFamilyName][0]
+		log.Printf("\t%s = %s\n", item.Row, string(item.Value))
+		return true
+	}, bigtable.RowFilter(bigtable.ColumnFilter(columnName)))
+
+	if err = client.Close(); err != nil {
+		log.Fatalf("Could not close data operations client: %v", err)
+	}
+
+	log.Printf("Deleting the table")
+	if err = adminClient.DeleteTable(ctx, tableName); err != nil {
+		log.Fatalf("Could not delete table %s: %v", tableName, err)
+	}
+
+	if err = adminClient.Close(); err != nil {
+		log.Fatalf("Could not close admin client: %v", err)
+	}
+}

--- a/bigtable/helloworld/main.go
+++ b/bigtable/helloworld/main.go
@@ -1,16 +1,6 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2016 Google Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
 
 // Hello world is a sample program demonstrating use of the Bigtable client
 // library to perform basic CRUD operations

--- a/bigtable/search/search.go
+++ b/bigtable/search/search.go
@@ -1,0 +1,453 @@
+/*
+Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Search is a sample web server that uses Cloud Bigtable as the storage layer
+// for a simple document-storage and full-text-search service.
+// It has four functions:
+// - Initialize and clear the table.
+// - Add a document.  This adds the content of a user-supplied document to the
+//   Bigtable, and adds references to the document to an index in the Bigtable.
+//   The document is indexed under each unique word in the document.
+// - Search the index.  This returns documents containing each word in a user
+//   query, with snippets and links to view the whole document.
+// - Copy table.  This copies the documents and index from another table and
+//   adds them to the current one.
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"html/template"
+	"io"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+
+	"cloud.google.com/go/bigtable"
+	"golang.org/x/net/context"
+)
+
+var (
+	addTemplate = template.Must(template.New("").Parse(`<html><body>
+Added {{.Title}}
+</body></html>`))
+
+	contentTemplate = template.Must(template.New("").Parse(`<html><body>
+<b>{{.Title}}</b><br><br>
+{{.Content}}
+</body></html>`))
+
+	searchTemplate = template.Must(template.New("").Parse(`<html><body>
+Results for <b>{{.Query}}</b>:<br><br>
+{{range .Results}}
+<a href="/content?name={{.Title}}">{{.Title}}</a><br>
+<i>{{.Snippet}}</i><br><br>
+{{end}}
+</body></html>`))
+)
+
+const (
+	indexColumnFamily   = "i"
+	contentColumnFamily = "c"
+	mainPage            = `
+	<html>
+		<head>
+			<title>Document Search</title>
+		</head>
+		<body>
+			Initialize and clear table:
+			<form action="/reset" method="post">
+				<div><input type="submit" value="Init"></div>
+			</form>
+
+			Search for documents:
+			<form action="/search" method="post">
+				<div><input type="text" name="q" size=80></div>
+				<div><input type="submit" value="Search"></div>
+			</form>
+
+			Add a document:
+			<form action="/add" method="post">
+				Document name:
+				<div><textarea name="name" rows="1" cols="80"></textarea></div>
+				Document text:
+				<div><textarea name="content" rows="20" cols="80"></textarea></div>
+				<div><input type="submit" value="Submit"></div>
+			</form>
+
+			Copy data from another table:
+			<form action="/copy" method="post">
+				Source table name:
+				<div><input type="text" name="name" size=80></div>
+				<div><input type="submit" value="Copy"></div>
+			</form>
+		</body>
+	</html>
+	`
+)
+
+func main() {
+	var (
+		project   = flag.String("project", "", "The name of the project.")
+		instance  = flag.String("instance", "", "The name of the Cloud Bigtable instance.")
+		tableName = flag.String("table", "docindex", "The name of the table containing the documents and index.")
+		port      = flag.Int("port", 8080, "TCP port for server.")
+	)
+	flag.Parse()
+
+	// Make an admin client.
+	adminClient, err := bigtable.NewAdminClient(context.Background(), *project, *instance)
+	if err != nil {
+		log.Fatal("Bigtable NewAdminClient:", err)
+	}
+
+	// Make a regular client.
+	client, err := bigtable.NewClient(context.Background(), *project, *instance)
+	if err != nil {
+		log.Fatal("Bigtable NewClient:", err)
+	}
+
+	// Open the table.
+	table := client.Open(*tableName)
+
+	// Set up HTML handlers, and start the web server.
+	http.HandleFunc("/search", func(w http.ResponseWriter, r *http.Request) { handleSearch(w, r, table) })
+	http.HandleFunc("/content", func(w http.ResponseWriter, r *http.Request) { handleContent(w, r, table) })
+	http.HandleFunc("/add", func(w http.ResponseWriter, r *http.Request) { handleAddDoc(w, r, table) })
+	http.HandleFunc("/reset", func(w http.ResponseWriter, r *http.Request) { handleReset(w, r, *tableName, adminClient) })
+	http.HandleFunc("/copy", func(w http.ResponseWriter, r *http.Request) { handleCopy(w, r, *tableName, client, adminClient) })
+	http.HandleFunc("/", handleMain)
+	log.Fatal(http.ListenAndServe(":"+strconv.Itoa(*port), nil))
+}
+
+// handleMain outputs the home page.
+func handleMain(w http.ResponseWriter, r *http.Request) {
+	io.WriteString(w, mainPage)
+}
+
+// tokenize splits a string into tokens.
+// This is very simple, it's not a good tokenization function.
+func tokenize(s string) []string {
+	wordMap := make(map[string]bool)
+	f := strings.FieldsFunc(s, func(r rune) bool { return !unicode.IsLetter(r) })
+	for _, word := range f {
+		word = strings.ToLower(word)
+		wordMap[word] = true
+	}
+	words := make([]string, 0, len(wordMap))
+	for word := range wordMap {
+		words = append(words, word)
+	}
+	return words
+}
+
+// handleContent fetches the content of a document from the Bigtable and returns it.
+func handleContent(w http.ResponseWriter, r *http.Request, table *bigtable.Table) {
+	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	name := r.FormValue("name")
+	if len(name) == 0 {
+		http.Error(w, "No document name supplied.", http.StatusBadRequest)
+		return
+	}
+
+	row, err := table.ReadRow(ctx, name)
+	if err != nil {
+		http.Error(w, "Error reading content: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	content := row[contentColumnFamily]
+	if len(content) == 0 {
+		http.Error(w, "Document not found.", http.StatusNotFound)
+		return
+	}
+	var buf bytes.Buffer
+	if err := contentTemplate.ExecuteTemplate(&buf, "", struct{ Title, Content string }{name, string(content[0].Value)}); err != nil {
+		http.Error(w, "Error executing HTML template: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	io.Copy(w, &buf)
+}
+
+// handleSearch responds to search queries, returning links and snippets for matching documents.
+func handleSearch(w http.ResponseWriter, r *http.Request, table *bigtable.Table) {
+	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	query := r.FormValue("q")
+	// Split the query into words.
+	words := tokenize(query)
+	if len(words) == 0 {
+		http.Error(w, "Empty query.", http.StatusBadRequest)
+		return
+	}
+
+	// readRows reads from many rows concurrently.
+	readRows := func(rows []string) ([]bigtable.Row, error) {
+		results := make([]bigtable.Row, len(rows))
+		errors := make([]error, len(rows))
+		var wg sync.WaitGroup
+		for i, row := range rows {
+			wg.Add(1)
+			go func(i int, row string) {
+				defer wg.Done()
+				results[i], errors[i] = table.ReadRow(ctx, row, bigtable.RowFilter(bigtable.LatestNFilter(1)))
+			}(i, row)
+		}
+		wg.Wait()
+		for _, err := range errors {
+			if err != nil {
+				return nil, err
+			}
+		}
+		return results, nil
+	}
+
+	// For each query word, get the list of documents containing it.
+	results, err := readRows(words)
+	if err != nil {
+		http.Error(w, "Error reading index: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Count how many of the query words each result contained.
+	hits := make(map[string]int)
+	for _, r := range results {
+		for _, r := range r[indexColumnFamily] {
+			hits[r.Column]++
+		}
+	}
+
+	// Build a slice of all the documents that matched every query word.
+	var matches []string
+	for doc, count := range hits {
+		if count == len(words) {
+			matches = append(matches, doc[len(indexColumnFamily+":"):])
+		}
+	}
+
+	// Fetch the content of those documents from the Bigtable.
+	content, err := readRows(matches)
+	if err != nil {
+		http.Error(w, "Error reading results: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	type result struct{ Title, Snippet string }
+	data := struct {
+		Query   string
+		Results []result
+	}{query, nil}
+
+	// Output links and snippets.
+	for i, doc := range matches {
+		var text string
+		c := content[i][contentColumnFamily]
+		if len(c) > 0 {
+			text = string(c[0].Value)
+		}
+		if len(text) > 100 {
+			text = text[:100] + "..."
+		}
+		data.Results = append(data.Results, result{doc, text})
+	}
+	var buf bytes.Buffer
+	if err := searchTemplate.ExecuteTemplate(&buf, "", data); err != nil {
+		http.Error(w, "Error executing HTML template: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	io.Copy(w, &buf)
+}
+
+// handleAddDoc adds a document to the index.
+func handleAddDoc(w http.ResponseWriter, r *http.Request, table *bigtable.Table) {
+	if r.Method != "POST" {
+		http.Error(w, "POST requests only", http.StatusMethodNotAllowed)
+		return
+	}
+
+	ctx, _ := context.WithTimeout(context.Background(), time.Minute)
+
+	name := r.FormValue("name")
+	if len(name) == 0 {
+		http.Error(w, "Empty document name!", http.StatusBadRequest)
+		return
+	}
+
+	content := r.FormValue("content")
+	if len(content) == 0 {
+		http.Error(w, "Empty document content!", http.StatusBadRequest)
+		return
+	}
+
+	var (
+		writeErr error          // Set if any write fails.
+		mu       sync.Mutex     // Protects writeErr
+		wg       sync.WaitGroup // Used to wait for all writes to finish.
+	)
+
+	// writeOneColumn writes one column in one row, updates err if there is an error,
+	// and signals wg that one operation has finished.
+	writeOneColumn := func(row, family, column, value string, ts bigtable.Timestamp) {
+		mut := bigtable.NewMutation()
+		mut.Set(family, column, ts, []byte(value))
+		err := table.Apply(ctx, row, mut)
+		if err != nil {
+			mu.Lock()
+			writeErr = err
+			mu.Unlock()
+		}
+	}
+
+	// Start a write to store the document content.
+	wg.Add(1)
+	go func() {
+		writeOneColumn(name, contentColumnFamily, "", content, bigtable.Now())
+		wg.Done()
+	}()
+
+	// Start writes to store the document name in the index for each word in the document.
+	words := tokenize(content)
+	for _, word := range words {
+		var (
+			row    = word
+			family = indexColumnFamily
+			column = name
+			value  = ""
+			ts     = bigtable.Now()
+		)
+		wg.Add(1)
+		go func() {
+			// TODO: should use a semaphore to limit the number of concurrent writes.
+			writeOneColumn(row, family, column, value, ts)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	if writeErr != nil {
+		http.Error(w, "Error writing to Bigtable: "+writeErr.Error(), http.StatusInternalServerError)
+		return
+	}
+	var buf bytes.Buffer
+	if err := addTemplate.ExecuteTemplate(&buf, "", struct{ Title string }{name}); err != nil {
+		http.Error(w, "Error executing HTML template: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	io.Copy(w, &buf)
+}
+
+// handleReset deletes the table if it exists, creates it again, and creates its column families.
+func handleReset(w http.ResponseWriter, r *http.Request, table string, adminClient *bigtable.AdminClient) {
+	if r.Method != "POST" {
+		http.Error(w, "POST requests only", http.StatusMethodNotAllowed)
+		return
+	}
+	ctx, _ := context.WithTimeout(context.Background(), 5*time.Minute)
+	adminClient.DeleteTable(ctx, table)
+	if err := adminClient.CreateTable(ctx, table); err != nil {
+		http.Error(w, "Error creating Bigtable: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	time.Sleep(20 * time.Second)
+	// Create two column families, and set the GC policy for each one to keep one version.
+	for _, family := range []string{indexColumnFamily, contentColumnFamily} {
+		if err := adminClient.CreateColumnFamily(ctx, table, family); err != nil {
+			http.Error(w, "Error creating column family: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if err := adminClient.SetGCPolicy(ctx, table, family, bigtable.MaxVersionsPolicy(1)); err != nil {
+			http.Error(w, "Error setting GC policy: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+	w.Write([]byte("<html><body>Done.</body></html>"))
+	return
+}
+
+// copyTable copies data from one table to another.
+func copyTable(src, dst string, client *bigtable.Client, adminClient *bigtable.AdminClient) error {
+	if src == "" || src == dst {
+		return nil
+	}
+	ctx, _ := context.WithTimeout(context.Background(), time.Minute)
+
+	// Open the source and destination tables.
+	srcTable := client.Open(src)
+	dstTable := client.Open(dst)
+
+	var (
+		writeErr error          // Set if any write fails.
+		mu       sync.Mutex     // Protects writeErr
+		wg       sync.WaitGroup // Used to wait for all writes to finish.
+	)
+	copyRowToTable := func(row bigtable.Row) bool {
+		mu.Lock()
+		failed := writeErr != nil
+		mu.Unlock()
+		if failed {
+			return false
+		}
+		mut := bigtable.NewMutation()
+		for family, items := range row {
+			for _, item := range items {
+				// Get the column name, excluding the column family name and ':' character.
+				columnWithoutFamily := item.Column[len(family)+1:]
+				mut.Set(family, columnWithoutFamily, bigtable.Now(), item.Value)
+			}
+		}
+		wg.Add(1)
+		go func() {
+			// TODO: should use a semaphore to limit the number of concurrent writes.
+			if err := dstTable.Apply(ctx, row.Key(), mut); err != nil {
+				mu.Lock()
+				writeErr = err
+				mu.Unlock()
+			}
+			wg.Done()
+		}()
+		return true
+	}
+
+	// Create a filter that only accepts the column families we're interested in.
+	filter := bigtable.FamilyFilter(indexColumnFamily + "|" + contentColumnFamily)
+	// Read every row from srcTable, and call copyRowToTable to copy it to our table.
+	err := srcTable.ReadRows(ctx, bigtable.InfiniteRange(""), copyRowToTable, bigtable.RowFilter(filter))
+	wg.Wait()
+	if err != nil {
+		return err
+	}
+	return writeErr
+}
+
+// handleCopy copies data from one table to another.
+func handleCopy(w http.ResponseWriter, r *http.Request, dst string, client *bigtable.Client, adminClient *bigtable.AdminClient) {
+	if r.Method != "POST" {
+		http.Error(w, "POST requests only", http.StatusMethodNotAllowed)
+		return
+	}
+	src := r.FormValue("name")
+	if src == "" {
+		http.Error(w, "No source table specified.", http.StatusBadRequest)
+		return
+	}
+	if err := copyTable(src, dst, client, adminClient); err != nil {
+		http.Error(w, "Failed to rebuild index: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	fmt.Fprint(w, "Copied table.\n")
+}

--- a/bigtable/search/search.go
+++ b/bigtable/search/search.go
@@ -1,18 +1,6 @@
-/*
-Copyright 2015 Google Inc. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2015 Google Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
 
 // Search is a sample web server that uses Cloud Bigtable as the storage layer
 // for a simple document-storage and full-text-search service.

--- a/bigtable/usercounter/README.md
+++ b/bigtable/usercounter/README.md
@@ -1,0 +1,29 @@
+# User Counter
+# (Cloud Bigtable on Managed VMs using Go)
+
+This app counts how often each user visits. The app uses Cloud Bigtable to store the visit counts for each user.
+
+## Prerequisites
+
+1. Set up Cloud Console.
+  1. Go to the [Cloud Console](https://cloud.google.com/console) and create or select your project.
+     You will need the project ID later.
+  1. Go to **Settings > Project Billing Settings** and enable billing.
+  1. Select **APIs & Auth > APIs**.
+  1. Enable the **Cloud Bigtable API** and the **Cloud Bigtable Admin API**.
+  (You may need to search for the API).
+1. Set up gcloud.
+  1. `gcloud components update`
+  1. `gcloud auth login`
+  1. `gcloud config set project PROJECT_ID`
+1. Download App Engine SDK for Go.
+  1. `go get -u google.golang.org/appengine/...`
+1. In main.go, change the `project` and `instance` constants.
+
+## Running locally
+
+1. From the sample project folder, `dev_appserver.py app.yaml`.
+
+## Deploying on Google App Engine flexible environment
+
+Follow the [deployment instructions](https://cloud.google.com/appengine/docs/flexible/go/testing-and-deploying-your-app).

--- a/bigtable/usercounter/app.yaml
+++ b/bigtable/usercounter/app.yaml
@@ -1,0 +1,11 @@
+runtime: go
+api_version: go1
+vm: true
+
+manual_scaling:
+  instances: 1
+
+handlers:
+# Serve only the web root.
+- url: /
+  script: _go_app

--- a/bigtable/usercounter/main.go
+++ b/bigtable/usercounter/main.go
@@ -1,0 +1,180 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+User counter is a program that tracks how often a user has visited the index page.
+
+This program demonstrates usage of the Cloud Bigtable API for App Engine flexible environment and Go.
+Instructions for running this program are in the README.md.
+*/
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"html/template"
+	"log"
+	"net/http"
+
+	"cloud.google.com/go/bigtable"
+	"golang.org/x/net/context"
+	"google.golang.org/appengine"
+	aelog "google.golang.org/appengine/log"
+	"google.golang.org/appengine/user"
+)
+
+// User-provided constants.
+const (
+	project  = "PROJECT_ID"
+	instance = "INSTANCE"
+)
+
+var (
+	tableName  = "user-visit-counter"
+	familyName = "emails"
+
+	// Client is initialized by main.
+	client *bigtable.Client
+)
+
+func main() {
+	ctx := context.Background()
+
+	// Set up admin client, tables, and column families.
+	// NewAdminClient uses Application Default Credentials to authenticate.
+	adminClient, err := bigtable.NewAdminClient(ctx, project, instance)
+	if err != nil {
+		log.Fatalf("Unable to create a table admin client. %v", err)
+	}
+	tables, err := adminClient.Tables(ctx)
+	if err != nil {
+		log.Fatalf("Unable to fetch table list. %v", err)
+	}
+	if !sliceContains(tables, tableName) {
+		if err := adminClient.CreateTable(ctx, tableName); err != nil {
+			log.Fatalf("Unable to create table: %v. %v", tableName, err)
+		}
+	}
+	tblInfo, err := adminClient.TableInfo(ctx, tableName)
+	if err != nil {
+		log.Fatalf("Unable to read info for table: %v. %v", tableName, err)
+	}
+	if !sliceContains(tblInfo.Families, familyName) {
+		if err := adminClient.CreateColumnFamily(ctx, tableName, familyName); err != nil {
+			log.Fatalf("Unable to create column family: %v. %v", familyName, err)
+		}
+	}
+	adminClient.Close()
+
+	// Set up Bigtable data operations client.
+	// NewClient uses Application Default Credentials to authenticate.
+	client, err = bigtable.NewClient(ctx, project, instance)
+	if err != nil {
+		log.Fatalf("Unable to create data operations client. %v", err)
+	}
+
+	http.Handle("/", appHandler(mainHandler))
+	appengine.Main() // Never returns.
+}
+
+// mainHandler tracks how many times each user has visited this page.
+func mainHandler(w http.ResponseWriter, r *http.Request) *appError {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return nil
+	}
+
+	ctx := appengine.NewContext(r)
+	u := user.Current(ctx)
+	if u == nil {
+		login, err := user.LoginURL(ctx, r.URL.String())
+		if err != nil {
+			return &appError{err, "Error finding login URL", http.StatusInternalServerError}
+		}
+		http.Redirect(w, r, login, http.StatusFound)
+		return nil
+	}
+	logoutURL, err := user.LogoutURL(ctx, "/")
+	if err != nil {
+		return &appError{err, "Error finding logout URL", http.StatusInternalServerError}
+	}
+
+	// Increment visit count for user.
+	tbl := client.Open(tableName)
+	rmw := bigtable.NewReadModifyWrite()
+	rmw.Increment(familyName, u.Email, 1)
+	row, err := tbl.ApplyReadModifyWrite(ctx, u.Email, rmw)
+	if err != nil {
+		return &appError{err, "Error applying ReadModifyWrite to row: " + u.Email, http.StatusInternalServerError}
+	}
+	data := struct {
+		Username, Logout string
+		Visits           uint64
+	}{
+		Username: u.Email,
+		// Retrieve the most recently edited column.
+		Visits: binary.BigEndian.Uint64(row[familyName][0].Value),
+		Logout: logoutURL,
+	}
+
+	// Display hello page.
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return &appError{err, "Error writing template", http.StatusInternalServerError}
+	}
+	buf.WriteTo(w)
+	return nil
+}
+
+var tmpl = template.Must(template.New("").Parse(`
+<html><body>
+
+<p>
+{{with .Username}} Hello {{.}}{{end}}
+{{with .Logout}}<a href="{{.}}">Sign out</a>{{end}}
+
+</p>
+
+<p>
+You have visited {{.Visits}}
+</p>
+
+</body></html>`))
+
+// sliceContains reports whether the provided string is present in the given slice of strings.
+func sliceContains(list []string, target string) bool {
+	for _, s := range list {
+		if s == target {
+			return true
+		}
+	}
+	return false
+}
+
+// More info about this method of error handling can be found at: http://blog.golang.org/error-handling-and-go
+type appHandler func(http.ResponseWriter, *http.Request) *appError
+
+type appError struct {
+	Error   error
+	Message string
+	Code    int
+}
+
+func (fn appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if e := fn(w, r); e != nil {
+		ctx := appengine.NewContext(r)
+		aelog.Errorf(ctx, "%v", e.Error)
+		http.Error(w, e.Message, e.Code)
+	}
+}

--- a/bigtable/usercounter/main.go
+++ b/bigtable/usercounter/main.go
@@ -1,16 +1,6 @@
-// Copyright 2015 Google Inc. All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2015 Google Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
 
 /*
 User counter is a program that tracks how often a user has visited the index page.


### PR DESCRIPTION
Move the bigtable examples to golang-samples as they are getting deleted from cloud.google.com/go. See https://code-review.googlesource.com/c/11656/.