### PR TITLE
pubsub: deflake tests

### DIFF
--- a/pubsub/subscriptions/main_test.go
+++ b/pubsub/subscriptions/main_test.go
@@ -17,15 +17,12 @@ import (
 )
 
 var topic *pubsub.Topic
-
-const (
-	subID   = "golang-samples-subscription"
-	topicID = "golang-samples-topic"
-)
+var subID string
 
 var once sync.Once // guards cleanup related operations in setup.
 
 func setup(t *testing.T) *pubsub.Client {
+
 	ctx := context.Background()
 	tc := testutil.SystemTest(t)
 
@@ -33,6 +30,9 @@ func setup(t *testing.T) *pubsub.Client {
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
+
+	subID = tc.ProjectID + "-test-sub"
+	topicID := tc.ProjectID + "-test-sub-topic"
 
 	// Cleanup resources from the previous failed tests.
 	once.Do(func() {

--- a/pubsub/topics/main_test.go
+++ b/pubsub/topics/main_test.go
@@ -15,11 +15,13 @@ import (
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 )
 
-const topicID = "golang-samples-topic-example"
+var topicID string
 
 func setup(t *testing.T) *pubsub.Client {
 	ctx := context.Background()
 	tc := testutil.SystemTest(t)
+
+	topicID = tc.ProjectID + "-test-topic"
 
 	client, err := pubsub.NewClient(ctx, tc.ProjectID)
 	if err != nil {


### PR DESCRIPTION
Add the Project ID as a prefix to ensure tests can run in parallel.

Fixes #219.