### PR TITLE
internal/e2e: prepare the body for POST request before http.Do

### DIFF
--- a/internal/e2e/flexible_test.go
+++ b/internal/e2e/flexible_test.go
@@ -95,10 +95,6 @@ func TestStorage(t *testing.T) {
 
 	url, _ := storage.URL("/upload")
 	var body bytes.Buffer
-	req, err := http.NewRequest("POST", url, &body)
-	if err != nil {
-		t.Fatalf("NewRequest: %v", err)
-	}
 	const filename = "flexible-storage-e2e"
 	w := multipart.NewWriter(&body)
 	fw, err := w.CreateFormFile("file", filename)
@@ -107,6 +103,11 @@ func TestStorage(t *testing.T) {
 	}
 	fw.Write([]byte("hello"))
 	w.Close()
+
+	req, err := http.NewRequest("POST", url, &body)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
 	req.Header.Set("Content-Type", w.FormDataContentType())
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
As of Go 1.8, NewRequest reads from the body. Instead of writing to the
body's buffer after the call to NewRequest, call NewRequest after
first preparing the multipart body.

FORCE_E2E=true