### PR TITLE
Update comments on Cloud Storage Go sample

### DIFF
--- a/storage/objects/main.go
+++ b/storage/objects/main.go
@@ -129,11 +129,11 @@ func listByPrefix(client *storage.Client, bucket, prefix, delim string) error {
 	//   /a/1.txt
 	//   /a/b/2.txt
 	//
-	// If you just specify prefix="/a", you'll get back:
+	// If you just specify prefix="a/", you'll get back:
 	//   /a/1.txt
 	//   /a/b/2.txt
 	//
-	// However, if you specify prefix="/a"" and delim="/", you'll get back:
+	// However, if you specify prefix="a/" and delim="/", you'll get back:
 	//   /a/1.txt
 	it := client.Bucket(bucket).Objects(ctx, &storage.Query{
 		Prefix:    prefix,


### PR DESCRIPTION
The prefix instructions for queries are incorrect in the Google Cloud Storage sample according to my testing. The `/` belongs at the end of the prefix to look up files in a directory, not at the beginning.