### PR TITLE
speech/captionasync: revert use GCS URI, inline audio is not allowed

### DIFF
--- a/speech/captionasync/captionasync.go
+++ b/speech/captionasync/captionasync.go
@@ -9,6 +9,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"time"
@@ -22,9 +23,9 @@ import (
 	longrunningpb "google.golang.org/genproto/googleapis/longrunning"
 )
 
-const usage = `Usage: captionasync gs://<path-to-audiofile>
+const usage = `Usage: captionasync <audiofile>
 
-Audio file must be a 16-bit signed little-endian encoded
+Audio file is required to be 16-bit signed little-endian encoded
 with a sample rate of 16000.
 `
 
@@ -58,8 +59,12 @@ func main() {
 	}
 }
 
-func send(client *speech.Client, gcsURI string) (string, error) {
+func send(client *speech.Client, filename string) (string, error) {
 	ctx := context.Background()
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return "", err
+	}
 
 	// Send the contents of the audio file with the encoding and
 	// and sample rate information to be transcripted.
@@ -70,7 +75,7 @@ func send(client *speech.Client, gcsURI string) (string, error) {
 			LanguageCode:    "en-US",
 		},
 		Audio: &speechpb.RecognitionAudio{
-			AudioSource: &speechpb.RecognitionAudio_Uri{Uri: gcsURI},
+			AudioSource: &speechpb.RecognitionAudio_Content{Content: data},
 		},
 	}
 

--- a/speech/captionasync/captionasync_test.go
+++ b/speech/captionasync/captionasync_test.go
@@ -22,7 +22,7 @@ func TestRecognize(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	opName, err := send(client, "gs://python-docs-samples-tests/speech/audio.raw")
+	opName, err := send(client, "./quit.raw")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +40,7 @@ func TestRecognize(t *testing.T) {
 	if len(result.Alternatives) < 1 {
 		t.Fatal("got no alternatives; want at least one")
 	}
-	if got, want := result.Alternatives[0].Transcript, "how old is the Brooklyn Bridge"; got != want {
+	if got, want := result.Alternatives[0].Transcript, "quit"; got != want {
 		t.Errorf("Transcript: got %q; want %q", got, want)
 	}
 }


### PR DESCRIPTION
Reverts GoogleCloudPlatform/golang-samples#232