### PR TITLE
speech/captionasync: change bad import of "proto" package

### DIFF
--- a/speech/captionasync/captionasync.go
+++ b/speech/captionasync/captionasync.go
@@ -14,7 +14,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 
 	"golang.org/x/net/context"
 


### PR DESCRIPTION
Wrong proto package was imported - github.com/gogo/proto over the
official github.com/golang/protobuf

Fixes #236.