### PR TITLE
speech: add GCS samples; fail hard on error in streaming sample

### DIFF
--- a/speech/caption/caption_test.go
+++ b/speech/caption/caption_test.go
@@ -29,3 +29,23 @@ func TestRecognize(t *testing.T) {
 		t.Errorf("Transcript: got %q; want %q", got, want)
 	}
 }
+
+func TestRecognizeGCS(t *testing.T) {
+	testutil.SystemTest(t)
+
+	resp, err := recognizeGCS("gs://python-docs-samples-tests/speech/audio.raw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Results) == 0 {
+		t.Fatal("got no results; want at least one")
+	}
+
+	result := resp.Results[0]
+	if len(result.Alternatives) < 1 {
+		t.Fatal("got no alternatives; want at least one")
+	}
+	if got, want := result.Alternatives[0].Transcript, "how old is the Brooklyn Bridge"; got != want {
+		t.Errorf("Transcript: got %q; want %q", got, want)
+	}
+}

--- a/speech/captionasync/captionasync_test.go
+++ b/speech/captionasync/captionasync_test.go
@@ -44,3 +44,35 @@ func TestRecognize(t *testing.T) {
 		t.Errorf("Transcript: got %q; want %q", got, want)
 	}
 }
+
+func TestRecognizeGCS(t *testing.T) {
+	testutil.SystemTest(t)
+
+	ctx := context.Background()
+	client, err := speech.NewClient(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	opName, err := sendGCS(client, "gs://python-docs-samples-tests/speech/audio.raw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opName == "" {
+		t.Fatal("got no op name; want one")
+	}
+	resp, err := wait(client, opName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Results) == 0 {
+		t.Fatal("got no results; want at least one")
+	}
+	result := resp.Results[0]
+	if len(result.Alternatives) < 1 {
+		t.Fatal("got no alternatives; want at least one")
+	}
+	if got, want := result.Alternatives[0].Transcript, "how old is the Brooklyn Bridge"; got != want {
+		t.Errorf("Transcript: got %q; want %q", got, want)
+	}
+}

--- a/speech/livecaption/livecaption.go
+++ b/speech/livecaption/livecaption.go
@@ -66,7 +66,7 @@ func main() {
 			if err == io.EOF {
 				// Nothing else to pipe, close the stream.
 				if err := stream.CloseSend(); err != nil {
-					log.Printf("Could not close stream: %v", err)
+					log.Fatalf("Could not close stream: %v", err)
 				}
 				return
 			}


### PR DESCRIPTION
For caption and captionasync, add samples using GCS URIs.
For livecaption, if the stream cannot be closed, exit the program.