### PR TITLE
getting-started/bookshelf: use golang:alpine to build for GKE

### DIFF
--- a/getting-started/bookshelf/gke_deployment/Dockerfile
+++ b/getting-started/bookshelf/gke_deployment/Dockerfile
@@ -1,6 +1,18 @@
-# Dockerfile extending the generic Go image with application files for a
-# single application.
-FROM gcr.io/google_appengine/golang
+FROM golang:alpine
 
-COPY . /go/src/app
-RUN go-wrapper install -tags appenginevm
+RUN apk add --no-cache ca-certificates
+
+COPY . /go/src/bookshelf
+
+RUN set -ex \
+      && apk add --no-cache --virtual .build-deps \
+              git \
+      && go get -v bookshelf/... \
+      && apk del .build-deps
+
+RUN go build -o /app bookshelf/app
+RUN go build -o /pubsub_worker bookshelf/pubsub_worker
+
+WORKDIR /go/src/bookshelf/app
+
+CMD ["/app"]

--- a/getting-started/bookshelf/gke_deployment/Dockerfile
+++ b/getting-started/bookshelf/gke_deployment/Dockerfile
@@ -1,18 +1,20 @@
 FROM golang:alpine
 
+ARG pkg=github.com/GoogleCloudPlatform/golang-samples/getting-started/bookshelf
+
 RUN apk add --no-cache ca-certificates
 
-COPY . /go/src/bookshelf
+COPY . $GOPATH/src/$pkg
 
 RUN set -ex \
       && apk add --no-cache --virtual .build-deps \
               git \
-      && go get -v bookshelf/... \
+      && go get -v $pkg/... \
       && apk del .build-deps
 
-RUN go build -o /app bookshelf/app
-RUN go build -o /pubsub_worker bookshelf/pubsub_worker
+RUN go install $pkg/...
 
-WORKDIR /go/src/bookshelf/app
+# Needed for templates for the front-end app.
+WORKDIR $GOPATH/src/$pkg/app
 
-CMD ["/app"]
+CMD ["app"]

--- a/getting-started/bookshelf/gke_deployment/Dockerfile
+++ b/getting-started/bookshelf/gke_deployment/Dockerfile
@@ -17,4 +17,5 @@ RUN go install $pkg/...
 # Needed for templates for the front-end app.
 WORKDIR $GOPATH/src/$pkg/app
 
-CMD ["app"]
+# Users of the image should invoke either of the commands.
+CMD echo "Use the app or pubsub_worker commands."; exit 1

--- a/getting-started/bookshelf/gke_deployment/bookshelf-frontend.yaml
+++ b/getting-started/bookshelf/gke_deployment/bookshelf-frontend.yaml
@@ -37,6 +37,7 @@ spec:
       - name: bookshelf-app
         # TODO: Replace [YOUR_PROJECT_ID] with your project ID.
         image: gcr.io/[YOUR_PROJECT_ID]/bookshelf:latest
+        command: ["app"]
         # This setting makes nodes pull the docker image every time before
         # starting the pod. This is useful when debugging, but should be turned
         # off in production.

--- a/getting-started/bookshelf/gke_deployment/bookshelf-worker.yaml
+++ b/getting-started/bookshelf/gke_deployment/bookshelf-worker.yaml
@@ -37,7 +37,7 @@ spec:
       - name: bookshelf-worker
         # TODO: Replace [YOUR_PROJECT_ID] with your project ID.
         image: gcr.io/[YOUR_PROJECT_ID]/bookshelf:latest
-        command: ["/pubsub_worker"]
+        command: ["pubsub_worker"]
         # This setting makes nodes pull the docker image every time before
         # starting the pod. This is useful when debugging, but should be turned
         # off in production.

--- a/getting-started/bookshelf/gke_deployment/bookshelf-worker.yaml
+++ b/getting-started/bookshelf/gke_deployment/bookshelf-worker.yaml
@@ -36,7 +36,8 @@ spec:
       containers:
       - name: bookshelf-worker
         # TODO: Replace [YOUR_PROJECT_ID] with your project ID.
-        image: gcr.io/[YOUR_PROJECT_ID]/bookshelf-worker:latest
+        image: gcr.io/[YOUR_PROJECT_ID]/bookshelf:latest
+        command: ["/pubsub_worker"]
         # This setting makes nodes pull the docker image every time before
         # starting the pod. This is useful when debugging, but should be turned
         # off in production.


### PR DESCRIPTION
* use golang:alpine as base image
* consolidate both commands into one image
* "go get" from the Dockerfile (no need to use aedeploy)