### PR TITLE
e2e: only run on Go 1.7+

### DIFF
--- a/internal/e2e/flexible_test.go
+++ b/internal/e2e/flexible_test.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+// NOTE(cbro): x/time/rate requires standard library context.
+//+build go1.7
+
 // Package e2e contains end-to-end tests for Go programs running on Google Cloud Platform.
 // See README.md for details on running the tests.
 package e2e


### PR DESCRIPTION
x/time/rate requires the standard library context. We only run these
tests on Travis using Go 1.8.