### PR TITLE
replace the "repeat" to "range"

### DIFF
--- a/docs/appengine/taskqueue/push/taskqueue_push.go
+++ b/docs/appengine/taskqueue/push/taskqueue_push.go
@@ -70,7 +70,7 @@ func worker(w http.ResponseWriter, r *http.Request) {
 var handlerTemplate = template.Must(template.New("handler").Parse(handlerHTML))
 
 const handlerHTML = `
-{{repeat .}}
+{{range .}}
 <p>{{.Name}}: {{.Count}}</p>
 {{end}}
 <p>Start a new counter:</p>


### PR DESCRIPTION
I found repeat is not working in GAE now. I got the following 500 error in the logging:
```
panic: template: handler:2: function "repeat" not defined

goroutine 1 [running]:
panic(0x1889980, 0xc0105813c0)
	go/src/runtime/panic.go:481 +0x3e6
html/template.Must(0x0, 0x2b4c416f1028, 0xc0105813c0, 0x0)
	go/src/html/template/template.go:340 +0x4b
main43625.init()
	hello.go:62 +0xcd
main.init()
	_go_main.go:34 +0x59
```
"range" works normally. 