### PR TITLE
"golang.org/x/net/context" is unnecessary

### DIFF
--- a/docs/appengine/taskqueue/push/taskqueue_push.go
+++ b/docs/appengine/taskqueue/push/taskqueue_push.go
@@ -8,9 +8,6 @@ package counter
 import (
 	"html/template"
 	"net/http"
-
-	"golang.org/x/net/context"
-
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
 	"google.golang.org/appengine/delay"


### PR DESCRIPTION
Got below errors when deploy the code:
```
ERROR: (gcloud.app.deploy) Error Response: [9] Deployment contains files that cannot be compiled: Compile failed:
2017/05/17 17:58:59 go-app-builder: build timing: 15×compile (5.528s total), 0×link (0s total)
2017/05/17 17:58:59 go-app-builder: failed running compile: exit status 2

hello.go:7: imported and not used: "golang.org/x/net/context"
```
Remove `golang.org/x/net/context` from the import.