### PR TITLE
the url pattern is not working

### DIFF
--- a/docs/appengine/taskqueue/app.yaml
+++ b/docs/appengine/taskqueue/app.yaml
@@ -5,5 +5,7 @@ api_version: go1
 handlers:
 - url: /.*
   script: _go_app
+- url: /worker/.*
+  script: _go_app
   login: admin
 // [END securing_urls]

--- a/docs/appengine/taskqueue/app.yaml
+++ b/docs/appengine/taskqueue/app.yaml
@@ -3,7 +3,7 @@ runtime: go
 api_version: go1
 
 handlers:
-- url: /tasks/process
+- url: /.*
   script: _go_app
   login: admin
 // [END securing_urls]


### PR DESCRIPTION
The url in the handlers, `/tasks/process`, does not work for taskqueue_push.go, where we use `/` and `/worker`.