### PR TITLE
vision: switch to the generated surface

### DIFF
--- a/vision/detect/detect.go
+++ b/vision/detect/detect.go
@@ -14,14 +14,14 @@ import (
 	"io"
 	"os"
 
-	vs "cloud.google.com/go/vision/apiv1"
+	vision "cloud.google.com/go/vision/apiv1"
 	"golang.org/x/net/context"
 )
 
 func init() {
 	// Refer to these functions so that goimports is happy before boilerplate is inserted.
 	_ = context.Background()
-	_ = vs.ImageAnnotatorClient{}
+	_ = vision.ImageAnnotatorClient{}
 	_ = os.Open
 }
 
@@ -29,7 +29,7 @@ func init() {
 func detectFaces(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vs.NewImageAnnotatorClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -40,7 +40,7 @@ func detectFaces(w io.Writer, file string) error {
 	}
 	defer f.Close()
 
-	image, err := vs.NewImageFromReader(f)
+	image, err := vision.NewImageFromReader(f)
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func detectFaces(w io.Writer, file string) error {
 func detectLabels(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vs.NewImageAnnotatorClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -77,7 +77,7 @@ func detectLabels(w io.Writer, file string) error {
 	}
 	defer f.Close()
 
-	image, err := vs.NewImageFromReader(f)
+	image, err := vision.NewImageFromReader(f)
 	if err != nil {
 		return err
 	}
@@ -102,7 +102,7 @@ func detectLabels(w io.Writer, file string) error {
 func detectLandmarks(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vs.NewImageAnnotatorClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -113,7 +113,7 @@ func detectLandmarks(w io.Writer, file string) error {
 	}
 	defer f.Close()
 
-	image, err := vs.NewImageFromReader(f)
+	image, err := vision.NewImageFromReader(f)
 	if err != nil {
 		return err
 	}
@@ -138,7 +138,7 @@ func detectLandmarks(w io.Writer, file string) error {
 func detectText(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vs.NewImageAnnotatorClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -149,7 +149,7 @@ func detectText(w io.Writer, file string) error {
 	}
 	defer f.Close()
 
-	image, err := vs.NewImageFromReader(f)
+	image, err := vision.NewImageFromReader(f)
 	if err != nil {
 		return err
 	}
@@ -174,7 +174,7 @@ func detectText(w io.Writer, file string) error {
 func detectDocumentText(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vs.NewImageAnnotatorClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -185,7 +185,7 @@ func detectDocumentText(w io.Writer, file string) error {
 	}
 	defer f.Close()
 
-	image, err := vs.NewImageFromReader(f)
+	image, err := vision.NewImageFromReader(f)
 	if err != nil {
 		return err
 	}
@@ -204,7 +204,7 @@ func detectDocumentText(w io.Writer, file string) error {
 func detectProperties(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vs.NewImageAnnotatorClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -215,7 +215,7 @@ func detectProperties(w io.Writer, file string) error {
 	}
 	defer f.Close()
 
-	image, err := vs.NewImageFromReader(f)
+	image, err := vision.NewImageFromReader(f)
 	if err != nil {
 		return err
 	}
@@ -240,7 +240,7 @@ func detectProperties(w io.Writer, file string) error {
 func detectCropHints(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vs.NewImageAnnotatorClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -251,7 +251,7 @@ func detectCropHints(w io.Writer, file string) error {
 	}
 	defer f.Close()
 
-	image, err := vs.NewImageFromReader(f)
+	image, err := vision.NewImageFromReader(f)
 	if err != nil {
 		return err
 	}
@@ -274,7 +274,7 @@ func detectCropHints(w io.Writer, file string) error {
 func detectSafeSearch(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vs.NewImageAnnotatorClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -285,7 +285,7 @@ func detectSafeSearch(w io.Writer, file string) error {
 	}
 	defer f.Close()
 
-	image, err := vs.NewImageFromReader(f)
+	image, err := vision.NewImageFromReader(f)
 	if err != nil {
 		return err
 	}
@@ -307,7 +307,7 @@ func detectSafeSearch(w io.Writer, file string) error {
 func detectWeb(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vs.NewImageAnnotatorClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -318,7 +318,7 @@ func detectWeb(w io.Writer, file string) error {
 	}
 	defer f.Close()
 
-	image, err := vs.NewImageFromReader(f)
+	image, err := vision.NewImageFromReader(f)
 	if err != nil {
 		return err
 	}
@@ -354,7 +354,7 @@ func detectWeb(w io.Writer, file string) error {
 func detectLogos(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vs.NewImageAnnotatorClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -365,7 +365,7 @@ func detectLogos(w io.Writer, file string) error {
 	}
 	defer f.Close()
 
-	image, err := vs.NewImageFromReader(f)
+	image, err := vision.NewImageFromReader(f)
 	if err != nil {
 		return err
 	}
@@ -389,7 +389,7 @@ func detectLogos(w io.Writer, file string) error {
 func init() {
 	// Refer to these functions so that goimports is happy before boilerplate is inserted.
 	_ = context.Background()
-	_ = vs.ImageAnnotatorClient{}
+	_ = vision.ImageAnnotatorClient{}
 	_ = os.Open
 }
 
@@ -397,12 +397,12 @@ func init() {
 func detectFacesURI(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vs.NewImageAnnotatorClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	image := vs.NewImageFromURI(file)
+	image := vision.NewImageFromURI(file)
 	annotations, err := client.DetectFaces(ctx, image, nil, 10)
 	if err != nil {
 		return err
@@ -425,12 +425,12 @@ func detectFacesURI(w io.Writer, file string) error {
 func detectLabelsURI(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vs.NewImageAnnotatorClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	image := vs.NewImageFromURI(file)
+	image := vision.NewImageFromURI(file)
 	annotations, err := client.DetectLabels(ctx, image, nil, 10)
 	if err != nil {
 		return err
@@ -452,12 +452,12 @@ func detectLabelsURI(w io.Writer, file string) error {
 func detectLandmarksURI(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vs.NewImageAnnotatorClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	image := vs.NewImageFromURI(file)
+	image := vision.NewImageFromURI(file)
 	annotations, err := client.DetectLandmarks(ctx, image, nil, 10)
 	if err != nil {
 		return err
@@ -479,12 +479,12 @@ func detectLandmarksURI(w io.Writer, file string) error {
 func detectTextURI(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vs.NewImageAnnotatorClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	image := vs.NewImageFromURI(file)
+	image := vision.NewImageFromURI(file)
 	annotations, err := client.DetectTexts(ctx, image, nil, 10)
 	if err != nil {
 		return err
@@ -506,12 +506,12 @@ func detectTextURI(w io.Writer, file string) error {
 func detectDocumentTextURI(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vs.NewImageAnnotatorClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	image := vs.NewImageFromURI(file)
+	image := vision.NewImageFromURI(file)
 	annotation, err := client.DetectDocumentText(ctx, image, nil)
 	if err != nil {
 		return err
@@ -527,12 +527,12 @@ func detectDocumentTextURI(w io.Writer, file string) error {
 func detectPropertiesURI(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vs.NewImageAnnotatorClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	image := vs.NewImageFromURI(file)
+	image := vision.NewImageFromURI(file)
 	props, err := client.DetectImageProperties(ctx, image, nil)
 	if err != nil {
 		return err
@@ -554,12 +554,12 @@ func detectPropertiesURI(w io.Writer, file string) error {
 func detectCropHintsURI(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vs.NewImageAnnotatorClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	image := vs.NewImageFromURI(file)
+	image := vision.NewImageFromURI(file)
 	res, err := client.CropHints(ctx, image, nil)
 	if err != nil {
 		return err
@@ -579,12 +579,12 @@ func detectCropHintsURI(w io.Writer, file string) error {
 func detectSafeSearchURI(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vs.NewImageAnnotatorClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	image := vs.NewImageFromURI(file)
+	image := vision.NewImageFromURI(file)
 	props, err := client.DetectSafeSearch(ctx, image, nil)
 	if err != nil {
 		return err
@@ -603,12 +603,12 @@ func detectSafeSearchURI(w io.Writer, file string) error {
 func detectWebURI(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vs.NewImageAnnotatorClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	image := vs.NewImageFromURI(file)
+	image := vision.NewImageFromURI(file)
 	web, err := client.DetectWeb(ctx, image, nil)
 	if err != nil {
 		return err
@@ -641,12 +641,12 @@ func detectWebURI(w io.Writer, file string) error {
 func detectLogosURI(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vs.NewImageAnnotatorClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	image := vs.NewImageFromURI(file)
+	image := vision.NewImageFromURI(file)
 	annotations, err := client.DetectLogos(ctx, image, nil, 10)
 	if err != nil {
 		return err

--- a/vision/detect/detect.go
+++ b/vision/detect/detect.go
@@ -16,7 +16,6 @@ import (
 
 	vs "cloud.google.com/go/vision/apiv1"
 	"golang.org/x/net/context"
-	pb "google.golang.org/genproto/googleapis/cloud/vision/v1"
 )
 
 func init() {
@@ -24,7 +23,6 @@ func init() {
 	_ = context.Background()
 	_ = vs.ImageAnnotatorClient{}
 	_ = os.Open
-	_ = pb.AnnotateImageRequest{}
 }
 
 // detectFaces gets faces from the Vision API for an image at the given file path.
@@ -393,7 +391,6 @@ func init() {
 	_ = context.Background()
 	_ = vs.ImageAnnotatorClient{}
 	_ = os.Open
-	_ = pb.AnnotateImageRequest{}
 }
 
 // detectFaces gets faces from the Vision API for an image at the given file path.

--- a/vision/detect/detect.go
+++ b/vision/detect/detect.go
@@ -221,7 +221,7 @@ func detectProperties(w io.Writer, file string) error {
 	if err != nil {
 		return err
 	}
-	props, err := client.DetectImageProperties(ctx, image, nil, nil)
+	props, err := client.DetectImageProperties(ctx, image, nil)
 	if err != nil {
 		return err
 	}
@@ -264,7 +264,9 @@ func detectCropHints(w io.Writer, file string) error {
 
 	fmt.Fprintln(w, "Crop hints:")
 	for _, hint := range res.CropHints {
-		fmt.Fprintf(w, "%v\n", hint.BoundingPoly)
+		for _, v := range hint.BoundingPoly.Vertices {
+			fmt.Fprintf(w, "(%d,%d)\n", v.X, v.Y)
+		}
 	}
 
 	return nil
@@ -534,7 +536,7 @@ func detectPropertiesURI(w io.Writer, file string) error {
 	}
 
 	image := vision.NewImageFromURI(file)
-	props, err := client.DetectImageProperties(ctx, image, nil, nil)
+	props, err := client.DetectImageProperties(ctx, image, nil)
 	if err != nil {
 		return err
 	}
@@ -568,7 +570,9 @@ func detectCropHintsURI(w io.Writer, file string) error {
 
 	fmt.Fprintln(w, "Crop hints:")
 	for _, hint := range res.CropHints {
-		fmt.Fprintf(w, "%v\n", hint.BoundingPoly)
+		for _, v := range hint.BoundingPoly.Vertices {
+			fmt.Fprintf(w, "(%d,%d)\n", v.X, v.Y)
+		}
 	}
 
 	return nil

--- a/vision/detect/detect.go
+++ b/vision/detect/detect.go
@@ -14,7 +14,7 @@ import (
 	"io"
 	"os"
 
-	"cloud.google.com/go/vision/apiv1"
+	vs "cloud.google.com/go/vision/apiv1"
 	"golang.org/x/net/context"
 	pb "google.golang.org/genproto/googleapis/cloud/vision/v1"
 )
@@ -22,7 +22,7 @@ import (
 func init() {
 	// Refer to these functions so that goimports is happy before boilerplate is inserted.
 	_ = context.Background()
-	_ = vision.ImageAnnotatorClient{}
+	_ = vs.ImageAnnotatorClient{}
 	_ = os.Open
 	_ = pb.AnnotateImageRequest{}
 }
@@ -31,7 +31,7 @@ func init() {
 func detectFaces(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vision.NewImageAnnotatorClient(ctx)
+	client, err := vs.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -42,7 +42,7 @@ func detectFaces(w io.Writer, file string) error {
 	}
 	defer f.Close()
 
-	image, err := vision.NewImageFromReader(f)
+	image, err := vs.NewImageFromReader(f)
 	if err != nil {
 		return err
 	}
@@ -68,7 +68,7 @@ func detectFaces(w io.Writer, file string) error {
 func detectLabels(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vision.NewImageAnnotatorClient(ctx)
+	client, err := vs.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func detectLabels(w io.Writer, file string) error {
 	}
 	defer f.Close()
 
-	image, err := vision.NewImageFromReader(f)
+	image, err := vs.NewImageFromReader(f)
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func detectLabels(w io.Writer, file string) error {
 func detectLandmarks(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vision.NewImageAnnotatorClient(ctx)
+	client, err := vs.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,7 @@ func detectLandmarks(w io.Writer, file string) error {
 	}
 	defer f.Close()
 
-	image, err := vision.NewImageFromReader(f)
+	image, err := vs.NewImageFromReader(f)
 	if err != nil {
 		return err
 	}
@@ -140,7 +140,7 @@ func detectLandmarks(w io.Writer, file string) error {
 func detectText(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vision.NewImageAnnotatorClient(ctx)
+	client, err := vs.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -151,7 +151,7 @@ func detectText(w io.Writer, file string) error {
 	}
 	defer f.Close()
 
-	image, err := vision.NewImageFromReader(f)
+	image, err := vs.NewImageFromReader(f)
 	if err != nil {
 		return err
 	}
@@ -176,7 +176,7 @@ func detectText(w io.Writer, file string) error {
 func detectDocumentText(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vision.NewImageAnnotatorClient(ctx)
+	client, err := vs.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -187,7 +187,7 @@ func detectDocumentText(w io.Writer, file string) error {
 	}
 	defer f.Close()
 
-	image, err := vision.NewImageFromReader(f)
+	image, err := vs.NewImageFromReader(f)
 	if err != nil {
 		return err
 	}
@@ -206,7 +206,7 @@ func detectDocumentText(w io.Writer, file string) error {
 func detectProperties(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vision.NewImageAnnotatorClient(ctx)
+	client, err := vs.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -217,7 +217,7 @@ func detectProperties(w io.Writer, file string) error {
 	}
 	defer f.Close()
 
-	image, err := vision.NewImageFromReader(f)
+	image, err := vs.NewImageFromReader(f)
 	if err != nil {
 		return err
 	}
@@ -242,7 +242,7 @@ func detectProperties(w io.Writer, file string) error {
 func detectCropHints(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vision.NewImageAnnotatorClient(ctx)
+	client, err := vs.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -253,7 +253,7 @@ func detectCropHints(w io.Writer, file string) error {
 	}
 	defer f.Close()
 
-	image, err := vision.NewImageFromReader(f)
+	image, err := vs.NewImageFromReader(f)
 	if err != nil {
 		return err
 	}
@@ -276,7 +276,7 @@ func detectCropHints(w io.Writer, file string) error {
 func detectSafeSearch(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vision.NewImageAnnotatorClient(ctx)
+	client, err := vs.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -287,7 +287,7 @@ func detectSafeSearch(w io.Writer, file string) error {
 	}
 	defer f.Close()
 
-	image, err := vision.NewImageFromReader(f)
+	image, err := vs.NewImageFromReader(f)
 	if err != nil {
 		return err
 	}
@@ -309,7 +309,7 @@ func detectSafeSearch(w io.Writer, file string) error {
 func detectWeb(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vision.NewImageAnnotatorClient(ctx)
+	client, err := vs.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -320,7 +320,7 @@ func detectWeb(w io.Writer, file string) error {
 	}
 	defer f.Close()
 
-	image, err := vision.NewImageFromReader(f)
+	image, err := vs.NewImageFromReader(f)
 	if err != nil {
 		return err
 	}
@@ -356,7 +356,7 @@ func detectWeb(w io.Writer, file string) error {
 func detectLogos(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vision.NewImageAnnotatorClient(ctx)
+	client, err := vs.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -367,7 +367,7 @@ func detectLogos(w io.Writer, file string) error {
 	}
 	defer f.Close()
 
-	image, err := vision.NewImageFromReader(f)
+	image, err := vs.NewImageFromReader(f)
 	if err != nil {
 		return err
 	}
@@ -391,7 +391,7 @@ func detectLogos(w io.Writer, file string) error {
 func init() {
 	// Refer to these functions so that goimports is happy before boilerplate is inserted.
 	_ = context.Background()
-	_ = vision.ImageAnnotatorClient{}
+	_ = vs.ImageAnnotatorClient{}
 	_ = os.Open
 	_ = pb.AnnotateImageRequest{}
 }
@@ -400,12 +400,12 @@ func init() {
 func detectFacesURI(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vision.NewImageAnnotatorClient(ctx)
+	client, err := vs.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	image := vision.NewImageFromURI(file)
+	image := vs.NewImageFromURI(file)
 	annotations, err := client.DetectFaces(ctx, image, nil, 10)
 	if err != nil {
 		return err
@@ -428,12 +428,12 @@ func detectFacesURI(w io.Writer, file string) error {
 func detectLabelsURI(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vision.NewImageAnnotatorClient(ctx)
+	client, err := vs.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	image := vision.NewImageFromURI(file)
+	image := vs.NewImageFromURI(file)
 	annotations, err := client.DetectLabels(ctx, image, nil, 10)
 	if err != nil {
 		return err
@@ -455,12 +455,12 @@ func detectLabelsURI(w io.Writer, file string) error {
 func detectLandmarksURI(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vision.NewImageAnnotatorClient(ctx)
+	client, err := vs.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	image := vision.NewImageFromURI(file)
+	image := vs.NewImageFromURI(file)
 	annotations, err := client.DetectLandmarks(ctx, image, nil, 10)
 	if err != nil {
 		return err
@@ -482,12 +482,12 @@ func detectLandmarksURI(w io.Writer, file string) error {
 func detectTextURI(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vision.NewImageAnnotatorClient(ctx)
+	client, err := vs.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	image := vision.NewImageFromURI(file)
+	image := vs.NewImageFromURI(file)
 	annotations, err := client.DetectTexts(ctx, image, nil, 10)
 	if err != nil {
 		return err
@@ -509,12 +509,12 @@ func detectTextURI(w io.Writer, file string) error {
 func detectDocumentTextURI(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vision.NewImageAnnotatorClient(ctx)
+	client, err := vs.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	image := vision.NewImageFromURI(file)
+	image := vs.NewImageFromURI(file)
 	annotation, err := client.DetectDocumentText(ctx, image, nil)
 	if err != nil {
 		return err
@@ -530,12 +530,12 @@ func detectDocumentTextURI(w io.Writer, file string) error {
 func detectPropertiesURI(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vision.NewImageAnnotatorClient(ctx)
+	client, err := vs.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	image := vision.NewImageFromURI(file)
+	image := vs.NewImageFromURI(file)
 	props, err := client.DetectImageProperties(ctx, image, nil)
 	if err != nil {
 		return err
@@ -557,12 +557,12 @@ func detectPropertiesURI(w io.Writer, file string) error {
 func detectCropHintsURI(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vision.NewImageAnnotatorClient(ctx)
+	client, err := vs.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	image := vision.NewImageFromURI(file)
+	image := vs.NewImageFromURI(file)
 	res, err := client.CropHints(ctx, image, nil)
 	if err != nil {
 		return err
@@ -582,12 +582,12 @@ func detectCropHintsURI(w io.Writer, file string) error {
 func detectSafeSearchURI(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vision.NewImageAnnotatorClient(ctx)
+	client, err := vs.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	image := vision.NewImageFromURI(file)
+	image := vs.NewImageFromURI(file)
 	props, err := client.DetectSafeSearch(ctx, image, nil)
 	if err != nil {
 		return err
@@ -606,12 +606,12 @@ func detectSafeSearchURI(w io.Writer, file string) error {
 func detectWebURI(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vision.NewImageAnnotatorClient(ctx)
+	client, err := vs.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	image := vision.NewImageFromURI(file)
+	image := vs.NewImageFromURI(file)
 	web, err := client.DetectWeb(ctx, image, nil)
 	if err != nil {
 		return err
@@ -644,12 +644,12 @@ func detectWebURI(w io.Writer, file string) error {
 func detectLogosURI(w io.Writer, file string) error {
 	ctx := context.Background()
 
-	client, err := vision.NewImageAnnotatorClient(ctx)
+	client, err := vs.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	image := vision.NewImageFromURI(file)
+	image := vs.NewImageFromURI(file)
 	annotations, err := client.DetectLogos(ctx, image, nil, 10)
 	if err != nil {
 		return err

--- a/vision/detect/generated/gen.go
+++ b/vision/detect/generated/gen.go
@@ -48,11 +48,11 @@ func main() {
 	}
 }
 
-const boilerplateSentinel = "\tvar client *vision.Client // Boilerplate is inserted by gen.go\n"
+const boilerplateSentinel = "\tvar client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go\n"
 
 const boilerplate = `	ctx := context.Background()
 
-	client, err := vision.NewClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -70,7 +70,7 @@ const boilerplate = `	ctx := context.Background()
 `
 const gcsBoilerplate = `	ctx := context.Background()
 
-	client, err := vision.NewClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/vision/detect/generated/gen.go
+++ b/vision/detect/generated/gen.go
@@ -48,11 +48,11 @@ func main() {
 	}
 }
 
-const boilerplateSentinel = "\tvar client *vs.ImageAnnotatorClient // Boilerplate is inserted by gen.go\n"
+const boilerplateSentinel = "\tvar client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go\n"
 
 const boilerplate = `	ctx := context.Background()
 
-	client, err := vs.NewImageAnnotatorClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -63,19 +63,19 @@ const boilerplate = `	ctx := context.Background()
 	}
 	defer f.Close()
 
-	image, err := vs.NewImageFromReader(f)
+	image, err := vision.NewImageFromReader(f)
 	if err != nil {
 		return err
 	}
 `
 const gcsBoilerplate = `	ctx := context.Background()
 
-	client, err := vs.NewImageAnnotatorClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	image := vs.NewImageFromURI(file)
+	image := vision.NewImageFromURI(file)
 `
 
 const header = `// Copyright 2017 Google Inc. All rights reserved.

--- a/vision/detect/generated/gen.go
+++ b/vision/detect/generated/gen.go
@@ -48,11 +48,11 @@ func main() {
 	}
 }
 
-const boilerplateSentinel = "\tvar client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go\n"
+const boilerplateSentinel = "\tvar client *vs.ImageAnnotatorClient // Boilerplate is inserted by gen.go\n"
 
 const boilerplate = `	ctx := context.Background()
 
-	client, err := vision.NewImageAnnotatorClient(ctx)
+	client, err := vs.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -63,19 +63,19 @@ const boilerplate = `	ctx := context.Background()
 	}
 	defer f.Close()
 
-	image, err := vision.NewImageFromReader(f)
+	image, err := vs.NewImageFromReader(f)
 	if err != nil {
 		return err
 	}
 `
 const gcsBoilerplate = `	ctx := context.Background()
 
-	client, err := vision.NewImageAnnotatorClient(ctx)
+	client, err := vs.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	image := vision.NewImageFromURI(file)
+	image := vs.NewImageFromURI(file)
 `
 
 const header = `// Copyright 2017 Google Inc. All rights reserved.

--- a/vision/detect/generated/sample-template.go
+++ b/vision/detect/generated/sample-template.go
@@ -10,7 +10,6 @@
 //   go generate
 // Boilerplate client code is inserted in the sections marked
 // `	var client *vision.Client // Boilerplate is inserted by gen.go`
-
 package main
 
 import (
@@ -18,44 +17,44 @@ import (
 	"io"
 	"os"
 
-	"cloud.google.com/go/vision"
+	"cloud.google.com/go/vision/apiv1"
 	"golang.org/x/net/context"
+	pb "google.golang.org/genproto/googleapis/cloud/vision/v1"
 )
 
 func init() {
 	// Refer to these functions so that goimports is happy before boilerplate is inserted.
 	_ = context.Background()
-	_ = vision.NewClient
+	_ = vision.ImageAnnotatorClient{}
 	_ = os.Open
+	_ = pb.AnnotateImageRequest{}
 }
 
 // detectFaces gets faces from the Vision API for an image at the given file path.
 func detectFaces(w io.Writer, file string) error {
-	var client *vision.Client // Boilerplate is inserted by gen.go
-	annotations, err := client.DetectFaces(ctx, image, 10)
+	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	annotations, err := client.DetectFaces(ctx, image, nil, 10)
 	if err != nil {
 		return err
 	}
-
 	if len(annotations) == 0 {
 		fmt.Fprintln(w, "No faces found.")
 	} else {
 		fmt.Fprintln(w, "Faces:")
 		for i, annotation := range annotations {
 			fmt.Fprintln(w, "  Face", i)
-			fmt.Fprintln(w, "    Anger:", annotation.Likelihoods.Anger)
-			fmt.Fprintln(w, "    Joy:", annotation.Likelihoods.Joy)
-			fmt.Fprintln(w, "    Surprise:", annotation.Likelihoods.Surprise)
+			fmt.Fprintln(w, "    Anger:", annotation.AngerLikelihood)
+			fmt.Fprintln(w, "    Joy:", annotation.JoyLikelihood)
+			fmt.Fprintln(w, "    Surprise:", annotation.SurpriseLikelihood)
 		}
 	}
-
 	return nil
 }
 
 // detectLabels gets labels from the Vision API for an image at the given file path.
 func detectLabels(w io.Writer, file string) error {
-	var client *vision.Client // Boilerplate is inserted by gen.go
-	annotations, err := client.DetectLabels(ctx, image, 10)
+	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	annotations, err := client.DetectLabels(ctx, image, nil, 10)
 	if err != nil {
 		return err
 	}
@@ -74,8 +73,8 @@ func detectLabels(w io.Writer, file string) error {
 
 // detectLandmarks gets landmarks from the Vision API for an image at the given file path.
 func detectLandmarks(w io.Writer, file string) error {
-	var client *vision.Client // Boilerplate is inserted by gen.go
-	annotations, err := client.DetectLandmarks(ctx, image, 10)
+	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	annotations, err := client.DetectLandmarks(ctx, image, nil, 10)
 	if err != nil {
 		return err
 	}
@@ -94,8 +93,8 @@ func detectLandmarks(w io.Writer, file string) error {
 
 // detectText gets text from the Vision API for an image at the given file path.
 func detectText(w io.Writer, file string) error {
-	var client *vision.Client // Boilerplate is inserted by gen.go
-	annotations, err := client.DetectTexts(ctx, image, 10)
+	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	annotations, err := client.DetectTexts(ctx, image, nil, 10)
 	if err != nil {
 		return err
 	}
@@ -114,8 +113,8 @@ func detectText(w io.Writer, file string) error {
 
 // detectDocumentText gets the full document text from the Vision API for an image at the given file path.
 func detectDocumentText(w io.Writer, file string) error {
-	var client *vision.Client // Boilerplate is inserted by gen.go
-	annotation, err := client.DetectDocumentText(ctx, image)
+	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	annotation, err := client.DetectDocumentText(ctx, image, nil)
 	if err != nil {
 		return err
 	}
@@ -128,16 +127,19 @@ func detectDocumentText(w io.Writer, file string) error {
 
 // detectProperties gets image properties from the Vision API for an image at the given file path.
 func detectProperties(w io.Writer, file string) error {
-	var client *vision.Client // Boilerplate is inserted by gen.go
-	props, err := client.DetectImageProps(ctx, image)
+	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	props, err := client.DetectImageProperties(ctx, image, nil, nil)
 	if err != nil {
 		return err
 	}
 
 	fmt.Fprintln(w, "Dominant colors:")
-	for _, quantized := range props.DominantColors {
+	for _, quantized := range props.DominantColors.Colors {
 		color := quantized.Color
-		fmt.Fprintf(w, "%2.1f%% - #%02x%02x%02x\n", quantized.PixelFraction*100, color.R&0xff, color.G&0xff, color.B&0xff)
+		r := int(color.Red) & 0xff
+		g := int(color.Green) & 0xff
+		b := int(color.Blue) & 0xff
+		fmt.Fprintf(w, "%2.1f%% - #%02x%02x%02x\n", quantized.PixelFraction*100, r, g, b)
 	}
 
 	return nil
@@ -145,14 +147,14 @@ func detectProperties(w io.Writer, file string) error {
 
 // detectCropHints gets suggested croppings the Vision API for an image at the given file path.
 func detectCropHints(w io.Writer, file string) error {
-	var client *vision.Client // Boilerplate is inserted by gen.go
-	hints, err := client.CropHints(ctx, image, nil)
+	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	res, err := client.CropHints(ctx, image, nil)
 	if err != nil {
 		return err
 	}
 
 	fmt.Fprintln(w, "Crop hints:")
-	for _, hint := range hints {
+	for _, hint := range res.CropHints {
 		fmt.Fprintf(w, "%v\n", hint.BoundingPoly)
 	}
 
@@ -161,8 +163,8 @@ func detectCropHints(w io.Writer, file string) error {
 
 // detectSafeSearch gets image properties from the Vision API for an image at the given file path.
 func detectSafeSearch(w io.Writer, file string) error {
-	var client *vision.Client // Boilerplate is inserted by gen.go
-	props, err := client.DetectSafeSearch(ctx, image)
+	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	props, err := client.DetectSafeSearch(ctx, image, nil)
 	if err != nil {
 		return err
 	}
@@ -178,8 +180,8 @@ func detectSafeSearch(w io.Writer, file string) error {
 
 // detectWeb gets image properties from the Vision API for an image at the given file path.
 func detectWeb(w io.Writer, file string) error {
-	var client *vision.Client // Boilerplate is inserted by gen.go
-	web, err := client.DetectWeb(ctx, image)
+	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	web, err := client.DetectWeb(ctx, image, nil)
 	if err != nil {
 		return err
 	}
@@ -188,19 +190,19 @@ func detectWeb(w io.Writer, file string) error {
 	if len(web.FullMatchingImages) != 0 {
 		fmt.Fprintln(w, "\tFull image matches:")
 		for _, full := range web.FullMatchingImages {
-			fmt.Fprintf(w, "\t\t%s\n", full.URL)
+			fmt.Fprintf(w, "\t\t%s\n", full.Url)
 		}
 	}
 	if len(web.PagesWithMatchingImages) != 0 {
 		fmt.Fprintln(w, "\tPages with this image:")
 		for _, page := range web.PagesWithMatchingImages {
-			fmt.Fprintf(w, "\t\t%s\n", page.URL)
+			fmt.Fprintf(w, "\t\t%s\n", page.Url)
 		}
 	}
 	if len(web.WebEntities) != 0 {
 		fmt.Fprintln(w, "\tEntities:")
 		for _, entity := range web.WebEntities {
-			fmt.Fprintf(w, "\t\t%-12s %s\n", entity.ID, entity.Description)
+			fmt.Fprintf(w, "\t\t%-12s %s\n", entity.EntityId, entity.Description)
 		}
 	}
 
@@ -209,8 +211,8 @@ func detectWeb(w io.Writer, file string) error {
 
 // detectLogos gets logos from the Vision API for an image at the given file path.
 func detectLogos(w io.Writer, file string) error {
-	var client *vision.Client // Boilerplate is inserted by gen.go
-	annotations, err := client.DetectLogos(ctx, image, 10)
+	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	annotations, err := client.DetectLogos(ctx, image, nil, 10)
 	if err != nil {
 		return err
 	}

--- a/vision/detect/generated/sample-template.go
+++ b/vision/detect/generated/sample-template.go
@@ -17,20 +17,20 @@ import (
 	"io"
 	"os"
 
-	vs "cloud.google.com/go/vision/apiv1"
+	vision "cloud.google.com/go/vision/apiv1"
 	"golang.org/x/net/context"
 )
 
 func init() {
 	// Refer to these functions so that goimports is happy before boilerplate is inserted.
 	_ = context.Background()
-	_ = vs.ImageAnnotatorClient{}
+	_ = vision.ImageAnnotatorClient{}
 	_ = os.Open
 }
 
 // detectFaces gets faces from the Vision API for an image at the given file path.
 func detectFaces(w io.Writer, file string) error {
-	var client *vs.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
 	annotations, err := client.DetectFaces(ctx, image, nil, 10)
 	if err != nil {
 		return err
@@ -51,7 +51,7 @@ func detectFaces(w io.Writer, file string) error {
 
 // detectLabels gets labels from the Vision API for an image at the given file path.
 func detectLabels(w io.Writer, file string) error {
-	var client *vs.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
 	annotations, err := client.DetectLabels(ctx, image, nil, 10)
 	if err != nil {
 		return err
@@ -71,7 +71,7 @@ func detectLabels(w io.Writer, file string) error {
 
 // detectLandmarks gets landmarks from the Vision API for an image at the given file path.
 func detectLandmarks(w io.Writer, file string) error {
-	var client *vs.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
 	annotations, err := client.DetectLandmarks(ctx, image, nil, 10)
 	if err != nil {
 		return err
@@ -91,7 +91,7 @@ func detectLandmarks(w io.Writer, file string) error {
 
 // detectText gets text from the Vision API for an image at the given file path.
 func detectText(w io.Writer, file string) error {
-	var client *vs.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
 	annotations, err := client.DetectTexts(ctx, image, nil, 10)
 	if err != nil {
 		return err
@@ -111,7 +111,7 @@ func detectText(w io.Writer, file string) error {
 
 // detectDocumentText gets the full document text from the Vision API for an image at the given file path.
 func detectDocumentText(w io.Writer, file string) error {
-	var client *vs.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
 	annotation, err := client.DetectDocumentText(ctx, image, nil)
 	if err != nil {
 		return err
@@ -125,7 +125,7 @@ func detectDocumentText(w io.Writer, file string) error {
 
 // detectProperties gets image properties from the Vision API for an image at the given file path.
 func detectProperties(w io.Writer, file string) error {
-	var client *vs.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
 	props, err := client.DetectImageProperties(ctx, image, nil)
 	if err != nil {
 		return err
@@ -145,7 +145,7 @@ func detectProperties(w io.Writer, file string) error {
 
 // detectCropHints gets suggested croppings the Vision API for an image at the given file path.
 func detectCropHints(w io.Writer, file string) error {
-	var client *vs.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
 	res, err := client.CropHints(ctx, image, nil)
 	if err != nil {
 		return err
@@ -163,7 +163,7 @@ func detectCropHints(w io.Writer, file string) error {
 
 // detectSafeSearch gets image properties from the Vision API for an image at the given file path.
 func detectSafeSearch(w io.Writer, file string) error {
-	var client *vs.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
 	props, err := client.DetectSafeSearch(ctx, image, nil)
 	if err != nil {
 		return err
@@ -180,7 +180,7 @@ func detectSafeSearch(w io.Writer, file string) error {
 
 // detectWeb gets image properties from the Vision API for an image at the given file path.
 func detectWeb(w io.Writer, file string) error {
-	var client *vs.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
 	web, err := client.DetectWeb(ctx, image, nil)
 	if err != nil {
 		return err
@@ -211,7 +211,7 @@ func detectWeb(w io.Writer, file string) error {
 
 // detectLogos gets logos from the Vision API for an image at the given file path.
 func detectLogos(w io.Writer, file string) error {
-	var client *vs.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
 	annotations, err := client.DetectLogos(ctx, image, nil, 10)
 	if err != nil {
 		return err

--- a/vision/detect/generated/sample-template.go
+++ b/vision/detect/generated/sample-template.go
@@ -19,7 +19,6 @@ import (
 
 	vs "cloud.google.com/go/vision/apiv1"
 	"golang.org/x/net/context"
-	pb "google.golang.org/genproto/googleapis/cloud/vision/v1"
 )
 
 func init() {
@@ -27,7 +26,6 @@ func init() {
 	_ = context.Background()
 	_ = vs.ImageAnnotatorClient{}
 	_ = os.Open
-	_ = pb.AnnotateImageRequest{}
 }
 
 // detectFaces gets faces from the Vision API for an image at the given file path.

--- a/vision/detect/generated/sample-template.go
+++ b/vision/detect/generated/sample-template.go
@@ -17,7 +17,7 @@ import (
 	"io"
 	"os"
 
-	"cloud.google.com/go/vision/apiv1"
+	vs "cloud.google.com/go/vision/apiv1"
 	"golang.org/x/net/context"
 	pb "google.golang.org/genproto/googleapis/cloud/vision/v1"
 )
@@ -25,14 +25,14 @@ import (
 func init() {
 	// Refer to these functions so that goimports is happy before boilerplate is inserted.
 	_ = context.Background()
-	_ = vision.ImageAnnotatorClient{}
+	_ = vs.ImageAnnotatorClient{}
 	_ = os.Open
 	_ = pb.AnnotateImageRequest{}
 }
 
 // detectFaces gets faces from the Vision API for an image at the given file path.
 func detectFaces(w io.Writer, file string) error {
-	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	var client *vs.ImageAnnotatorClient // Boilerplate is inserted by gen.go
 	annotations, err := client.DetectFaces(ctx, image, nil, 10)
 	if err != nil {
 		return err
@@ -53,7 +53,7 @@ func detectFaces(w io.Writer, file string) error {
 
 // detectLabels gets labels from the Vision API for an image at the given file path.
 func detectLabels(w io.Writer, file string) error {
-	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	var client *vs.ImageAnnotatorClient // Boilerplate is inserted by gen.go
 	annotations, err := client.DetectLabels(ctx, image, nil, 10)
 	if err != nil {
 		return err
@@ -73,7 +73,7 @@ func detectLabels(w io.Writer, file string) error {
 
 // detectLandmarks gets landmarks from the Vision API for an image at the given file path.
 func detectLandmarks(w io.Writer, file string) error {
-	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	var client *vs.ImageAnnotatorClient // Boilerplate is inserted by gen.go
 	annotations, err := client.DetectLandmarks(ctx, image, nil, 10)
 	if err != nil {
 		return err
@@ -93,7 +93,7 @@ func detectLandmarks(w io.Writer, file string) error {
 
 // detectText gets text from the Vision API for an image at the given file path.
 func detectText(w io.Writer, file string) error {
-	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	var client *vs.ImageAnnotatorClient // Boilerplate is inserted by gen.go
 	annotations, err := client.DetectTexts(ctx, image, nil, 10)
 	if err != nil {
 		return err
@@ -113,7 +113,7 @@ func detectText(w io.Writer, file string) error {
 
 // detectDocumentText gets the full document text from the Vision API for an image at the given file path.
 func detectDocumentText(w io.Writer, file string) error {
-	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	var client *vs.ImageAnnotatorClient // Boilerplate is inserted by gen.go
 	annotation, err := client.DetectDocumentText(ctx, image, nil)
 	if err != nil {
 		return err
@@ -127,7 +127,7 @@ func detectDocumentText(w io.Writer, file string) error {
 
 // detectProperties gets image properties from the Vision API for an image at the given file path.
 func detectProperties(w io.Writer, file string) error {
-	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	var client *vs.ImageAnnotatorClient // Boilerplate is inserted by gen.go
 	props, err := client.DetectImageProperties(ctx, image, nil)
 	if err != nil {
 		return err
@@ -147,7 +147,7 @@ func detectProperties(w io.Writer, file string) error {
 
 // detectCropHints gets suggested croppings the Vision API for an image at the given file path.
 func detectCropHints(w io.Writer, file string) error {
-	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	var client *vs.ImageAnnotatorClient // Boilerplate is inserted by gen.go
 	res, err := client.CropHints(ctx, image, nil)
 	if err != nil {
 		return err
@@ -165,7 +165,7 @@ func detectCropHints(w io.Writer, file string) error {
 
 // detectSafeSearch gets image properties from the Vision API for an image at the given file path.
 func detectSafeSearch(w io.Writer, file string) error {
-	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	var client *vs.ImageAnnotatorClient // Boilerplate is inserted by gen.go
 	props, err := client.DetectSafeSearch(ctx, image, nil)
 	if err != nil {
 		return err
@@ -182,7 +182,7 @@ func detectSafeSearch(w io.Writer, file string) error {
 
 // detectWeb gets image properties from the Vision API for an image at the given file path.
 func detectWeb(w io.Writer, file string) error {
-	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	var client *vs.ImageAnnotatorClient // Boilerplate is inserted by gen.go
 	web, err := client.DetectWeb(ctx, image, nil)
 	if err != nil {
 		return err
@@ -213,7 +213,7 @@ func detectWeb(w io.Writer, file string) error {
 
 // detectLogos gets logos from the Vision API for an image at the given file path.
 func detectLogos(w io.Writer, file string) error {
-	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
+	var client *vs.ImageAnnotatorClient // Boilerplate is inserted by gen.go
 	annotations, err := client.DetectLogos(ctx, image, nil, 10)
 	if err != nil {
 		return err

--- a/vision/detect/generated/sample-template.go
+++ b/vision/detect/generated/sample-template.go
@@ -128,7 +128,7 @@ func detectDocumentText(w io.Writer, file string) error {
 // detectProperties gets image properties from the Vision API for an image at the given file path.
 func detectProperties(w io.Writer, file string) error {
 	var client *vision.ImageAnnotatorClient // Boilerplate is inserted by gen.go
-	props, err := client.DetectImageProperties(ctx, image, nil, nil)
+	props, err := client.DetectImageProperties(ctx, image, nil)
 	if err != nil {
 		return err
 	}
@@ -155,7 +155,9 @@ func detectCropHints(w io.Writer, file string) error {
 
 	fmt.Fprintln(w, "Crop hints:")
 	for _, hint := range res.CropHints {
-		fmt.Fprintf(w, "%v\n", hint.BoundingPoly)
+		for _, v := range hint.BoundingPoly.Vertices {
+			fmt.Fprintf(w, "(%d,%d)\n", v.X, v.Y)
+		}
 	}
 
 	return nil

--- a/vision/label/label.go
+++ b/vision/label/label.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 
 	// [START imports]
-	"cloud.google.com/go/vision"
+	"cloud.google.com/go/vision/apiv1"
 	"golang.org/x/net/context"
 	// [END imports]
 )
@@ -23,7 +23,7 @@ func findLabels(file string) ([]string, error) {
 	ctx := context.Background()
 
 	// Create the client.
-	client, err := vision.NewClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +41,7 @@ func findLabels(file string) ([]string, error) {
 	}
 
 	// Perform the request.
-	annotations, err := client.DetectLabels(ctx, image, 10)
+	annotations, err := client.DetectLabels(ctx, image, nil, 10)
 	if err != nil {
 		return nil, err
 	}

--- a/vision/label/label.go
+++ b/vision/label/label.go
@@ -12,7 +12,7 @@ import (
 	"path/filepath"
 
 	// [START imports]
-	"cloud.google.com/go/vision/apiv1"
+	vision "cloud.google.com/go/vision/apiv1"
 	"golang.org/x/net/context"
 	// [END imports]
 )

--- a/vision/vision_quickstart/main.go
+++ b/vision/vision_quickstart/main.go
@@ -12,7 +12,7 @@ import (
 	"os"
 
 	// Imports the Google Cloud Vision API client package.
-	"cloud.google.com/go/vision"
+	"cloud.google.com/go/vision/apiv1"
 	"golang.org/x/net/context"
 )
 
@@ -20,7 +20,7 @@ func main() {
 	ctx := context.Background()
 
 	// Creates a client.
-	client, err := vision.NewClient(ctx)
+	client, err := vision.NewImageAnnotatorClient(ctx)
 	if err != nil {
 		log.Fatalf("Failed to create client: %v", err)
 	}
@@ -38,7 +38,7 @@ func main() {
 		log.Fatalf("Failed to create image: %v", err)
 	}
 
-	labels, err := client.DetectLabels(ctx, image, 10)
+	labels, err := client.DetectLabels(ctx, image, nil, 10)
 	if err != nil {
 		log.Fatalf("Failed to detect labels: %v", err)
 	}

--- a/vision/vision_quickstart/main.go
+++ b/vision/vision_quickstart/main.go
@@ -12,7 +12,7 @@ import (
 	"os"
 
 	// Imports the Google Cloud Vision API client package.
-	"cloud.google.com/go/vision/apiv1"
+	vision "cloud.google.com/go/vision/apiv1"
 	"golang.org/x/net/context"
 )
 


### PR DESCRIPTION
Remove the dependency to cloud.google.com/go/vision and use
the new autogenated helpers.
