### PR TITLE
kms: fix casing of "plaintext" and "ciphertext" in variable names

### DIFF
--- a/kms/crypter/crypter.go
+++ b/kms/crypter/crypter.go
@@ -56,7 +56,7 @@ func main() {
 	}
 }
 
-func encrypt(projectID, keyRing, cryptoKey string, plainText []byte) ([]byte, error) {
+func encrypt(projectID, keyRing, cryptoKey string, plaintext []byte) ([]byte, error) {
 	ctx := context.Background()
 	client, err := google.DefaultClient(ctx, cloudkms.CloudPlatformScope)
 	if err != nil {
@@ -73,7 +73,7 @@ func encrypt(projectID, keyRing, cryptoKey string, plainText []byte) ([]byte, er
 
 	resp, err := cloudkmsService.Projects.Locations.KeyRings.CryptoKeys.
 		Encrypt(parentName, &cloudkms.EncryptRequest{
-			Plaintext: base64.StdEncoding.EncodeToString(plainText),
+			Plaintext: base64.StdEncoding.EncodeToString(plaintext),
 		}).Do()
 	if err != nil {
 		return nil, err
@@ -82,7 +82,7 @@ func encrypt(projectID, keyRing, cryptoKey string, plainText []byte) ([]byte, er
 	return base64.StdEncoding.DecodeString(resp.Ciphertext)
 }
 
-func decrypt(projectID, keyRing, cryptoKey string, cipherText []byte) ([]byte, error) {
+func decrypt(projectID, keyRing, cryptoKey string, ciphertext []byte) ([]byte, error) {
 	ctx := context.Background()
 	client, err := google.DefaultClient(ctx, cloudkms.CloudPlatformScope)
 	if err != nil {
@@ -99,7 +99,7 @@ func decrypt(projectID, keyRing, cryptoKey string, cipherText []byte) ([]byte, e
 
 	resp, err := cloudkmsService.Projects.Locations.KeyRings.CryptoKeys.
 		Decrypt(parentName, &cloudkms.DecryptRequest{
-			Ciphertext: base64.StdEncoding.EncodeToString(cipherText),
+			Ciphertext: base64.StdEncoding.EncodeToString(ciphertext),
 		}).Do()
 	if err != nil {
 		return nil, err

--- a/kms/crypter/crypter_test.go
+++ b/kms/crypter/crypter_test.go
@@ -21,18 +21,18 @@ func TestCrypter(t *testing.T) {
 		t.Skip("GOLANG_SAMPLES_KMS_KEYRING and GOLANG_SAMPLES_KMS_CRYPTOKEY must be set")
 	}
 
-	plainText := []byte("Hello KMS")
-	cipherText, err := encrypt(tc.ProjectID, keyRing, cryptoKey, plainText)
+	plaintext := []byte("Hello KMS")
+	ciphertext, err := encrypt(tc.ProjectID, keyRing, cryptoKey, plaintext)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if bytes.Equal(cipherText, plainText) {
+	if bytes.Equal(ciphertext, plaintext) {
 		t.Errorf("Ciphertext is the same as plaintext")
 	}
 
-	decryptedText, err := decrypt(tc.ProjectID, keyRing, cryptoKey, cipherText)
-	if !bytes.Equal(decryptedText, plainText) {
-		t.Errorf("decrypt: got %q; want %q", string(decryptedText), string(plainText))
+	decryptedText, err := decrypt(tc.ProjectID, keyRing, cryptoKey, ciphertext)
+	if !bytes.Equal(decryptedText, plaintext) {
+		t.Errorf("decrypt: got %q; want %q", string(decryptedText), string(plaintext))
 	}
 }


### PR DESCRIPTION
When dealing with encryption, "plaintext" and "ciphertext" are terms of art with
particular meaning. Plaintext is data used as input for encryption, whereas
ciphertext is the output of encryption. Plaintext need not be "plain text" -- it
could be an image, for example.

The example code for other languages are already cased/spelled correctly.