### PR TITLE
Replaced all env variables GCLOUD_PROJECT with GOOGLE_CLOUD_PROJECT

### DIFF
--- a/appengine_flexible/pubsub/app.yaml
+++ b/appengine_flexible/pubsub/app.yaml
@@ -6,6 +6,6 @@ automatic_scaling:
 
 #[START env_variables]
 env_variables:
-  GCLOUD_PROJECT: your-project-id
+  GOOGLE_CLOUD_PROJECT: your-project-id
   PUBSUB_TOPIC: your-topic
 #[END env_variables]

--- a/appengine_flexible/pubsub/pubsub.go
+++ b/appengine_flexible/pubsub/pubsub.go
@@ -34,7 +34,7 @@ const maxMessages = 10
 func main() {
 	ctx := context.Background()
 
-	client, err := pubsub.NewClient(ctx, mustGetenv("GCLOUD_PROJECT"))
+	client, err := pubsub.NewClient(ctx, mustGetenv("GOOGLE_CLOUD_PROJECT"))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/bigquery/simpleapp/simpleapp.go
+++ b/bigquery/simpleapp/simpleapp.go
@@ -18,9 +18,9 @@ import (
 )
 
 func main() {
-	proj := os.Getenv("GCLOUD_PROJECT")
+	proj := os.Getenv("GOOGLE_CLOUD_PROJECT")
 	if proj == "" {
-		fmt.Println("GCLOUD_PROJECT environment variable must be set.")
+		fmt.Println("GOOGLE_CLOUD_PROJECT environment variable must be set.")
 		os.Exit(1)
 	}
 

--- a/bigquery/syncquery/syncquery.go
+++ b/bigquery/syncquery/syncquery.go
@@ -21,9 +21,9 @@ func main() {
 		fmt.Println("usage: ", os.Args[0], "'query text'")
 		os.Exit(1)
 	}
-	proj := os.Getenv("GCLOUD_PROJECT")
+	proj := os.Getenv("GOOGLE_CLOUD_PROJECT")
 	if proj == "" {
-		fmt.Println("GCLOUD_PROJECT environment variable must be set.")
+		fmt.Println("GOOGLE_CLOUD_PROJECT environment variable must be set.")
 		os.Exit(1)
 	}
 

--- a/endpoints/getting-started-grpc/README.md
+++ b/endpoints/getting-started-grpc/README.md
@@ -73,8 +73,8 @@ gcloud container builds submit --tag gcr.io/YOUR_PROJECT_ID/go-grpc-hello:1.0 .
 1. Set some environment variables (you'll need to manually set the service config ID):
 
     ```bash
-    GCLOUD_PROJECT=$(curl -s "http://metadata.google.internal/computeMetadata/v1/project/project-id" -H "Metadata-Flavor: Google")
-    SERVICE_NAME=hellogrpc.endpoints.${GCLOUD_PROJECT}.cloud.goog
+    GOOGLE_CLOUD_PROJECT=$(curl -s "http://metadata.google.internal/computeMetadata/v1/project/project-id" -H "Metadata-Flavor: Google")
+    SERVICE_NAME=hellogrpc.endpoints.${GOOGLE_CLOUD_PROJECT}.cloud.goog
     SERVICE_CONFIG_ID=<Your Config ID>
     ```
 
@@ -87,7 +87,7 @@ gcloud container builds submit --tag gcr.io/YOUR_PROJECT_ID/go-grpc-hello:1.0 .
 1. Run your gRPC server's container:
 
     ```bash
-    docker run -d --name=grpc-hello gcr.io/${GCLOUD_PROJECT}/go-grpc-hello:1.0
+    docker run -d --name=grpc-hello gcr.io/${GOOGLE_CLOUD_PROJECT}/go-grpc-hello:1.0
     ```
 
 1. Run Endpoints proxy:


### PR DESCRIPTION
In order to provide more consistent examples, I have removed all instances of 'GCLOUD_PROJECT' and replaced them with 'GOOGLE_CLOUD_PROJECT'. 