### PR TITLE
Add WithBlock option to NewClient.

### DIFF
--- a/pubsub/topics/main.go
+++ b/pubsub/topics/main.go
@@ -18,6 +18,8 @@ import (
 	"cloud.google.com/go/iam"
 	"cloud.google.com/go/pubsub"
 	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
 	// [END imports]
 )
 
@@ -29,7 +31,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "GOOGLE_CLOUD_PROJECT environment variable must be set.\n")
 		os.Exit(1)
 	}
-	client, err := pubsub.NewClient(ctx, proj)
+	client, err := pubsub.NewClient(ctx, proj, option.WithGRPCDialOption(grpc.WithBlock()))
 	if err != nil {
 		log.Fatalf("Could not create pubsub Client: %v", err)
 	}


### PR DESCRIPTION
Add WithBlock option to NewClient to block.
Without this, calling testPermissions immediately after NewClient can fail with the following error.

2017/07/31 17:20:15 testPermissions failed: rpc error: code = Unavailable desc = there is no address available