### PR TITLE
speech/captionasync: enable WordTimeOffsets

### DIFF
--- a/speech/captionasync/captionasync.go
+++ b/speech/captionasync/captionasync.go
@@ -71,8 +71,8 @@ func main() {
 				fmt.Printf(
 					"Word: \"%v\" (startTime=%3f, endTime=%3f)\n",
 					w.Word,
-					float64(w.StartTime.Seconds) + float64(w.StartTime.Nanos) * 1e-9,
-					float64(w.EndTime.Seconds) + float64(w.EndTime.Nanos) * 1e-9,
+					float64(w.StartTime.Seconds)+float64(w.StartTime.Nanos)*1e-9,
+					float64(w.EndTime.Seconds)+float64(w.EndTime.Nanos)*1e-9,
 				)
 			}
 		}
@@ -147,9 +147,9 @@ func sendGCS(client *speech.Client, gcsURI string) (string, error) {
 	// and sample rate information to be transcripted.
 	req := &speechpb.LongRunningRecognizeRequest{
 		Config: &speechpb.RecognitionConfig{
-			Encoding:        speechpb.RecognitionConfig_LINEAR16,
-			SampleRateHertz: 16000,
-			LanguageCode:    "en-US",
+			Encoding:              speechpb.RecognitionConfig_LINEAR16,
+			SampleRateHertz:       16000,
+			LanguageCode:          "en-US",
 			EnableWordTimeOffsets: true,
 		},
 		Audio: &speechpb.RecognitionAudio{

--- a/speech/captionasync/captionasync.go
+++ b/speech/captionasync/captionasync.go
@@ -67,6 +67,14 @@ func main() {
 	for _, result := range resp.Results {
 		for _, alt := range result.Alternatives {
 			fmt.Printf("\"%v\" (confidence=%3f)\n", alt.Transcript, alt.Confidence)
+			for _, w := range alt.Words {
+				fmt.Printf(
+					"Word: \"%v\" (startTime=%3f, endTime=%3f)\n",
+					w.Word,
+					float64(w.StartTime.Seconds) + float64(w.StartTime.Nanos) * 1e-9,
+					float64(w.EndTime.Seconds) + float64(w.EndTime.Nanos) * 1e-9,
+				)
+			}
 		}
 	}
 }
@@ -142,6 +150,7 @@ func sendGCS(client *speech.Client, gcsURI string) (string, error) {
 			Encoding:        speechpb.RecognitionConfig_LINEAR16,
 			SampleRateHertz: 16000,
 			LanguageCode:    "en-US",
+			EnableWordTimeOffsets: true,
 		},
 		Audio: &speechpb.RecognitionAudio{
 			AudioSource: &speechpb.RecognitionAudio_Uri{Uri: gcsURI},

--- a/speech/captionasync/captionasync_test.go
+++ b/speech/captionasync/captionasync_test.go
@@ -76,3 +76,41 @@ func TestRecognizeGCS(t *testing.T) {
 		t.Errorf("Transcript: got %q; want %q", got, want)
 	}
 }
+
+func TestRecognizeGCSWordTimeOffsets(t *testing.T) {
+	testutil.SystemTest(t)
+
+	ctx := context.Background()
+	client, err := speech.NewClient(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	opName, err := sendGCS(client, "gs://python-docs-samples-tests/speech/audio.raw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opName == "" {
+		t.Fatal("got no op name; want one")
+	}
+	resp, err := wait(client, opName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Results) == 0 {
+		t.Fatal("got no results; want at least one")
+	}
+	result := resp.Results[0]
+	if len(result.Alternatives) < 1 {
+		t.Fatal("got no alternatives; want at least one")
+	}
+	if got, want := result.Alternatives[0].Words[5].Word, "Bridge"; got != want {
+		t.Errorf("Transcript: got %q; want %q", got, want)
+	}
+	if got := result.Alternatives[0].Words[5].StartTime.Seconds; got <= 0 {
+		t.Errorf("Word start time: got %f, want positive", got)
+	}
+	if got := result.Alternatives[0].Words[5].EndTime.Seconds; got <= 0 {
+		t.Errorf("Word end time: got %f, want positive", got)
+	}
+}


### PR DESCRIPTION
speech/captionasync: enable WordTimeOffsets

This updates the captionasync example to show how the RecognitionConfig
can be updated to that the API response includes word-level time offsets.