### PR TITLE
updating Mailjet code samples for Send API v3.1

### DIFF
--- a/appengine_flexible/mailjet/mailjet.go
+++ b/appengine_flexible/mailjet/mailjet.go
@@ -49,25 +49,31 @@ func sendEmail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	m := &mailjet.InfoSendMail{
-		FromEmail: fromEmail,
-		FromName:  "App Engine Mailjet sample",
-		Subject:   "Your email flight plan!",
-		TextPart:  "Dear passenger, welcome to Mailjet! May the delivery force be with you!",
-		HTMLPart:  "<h3>Dear passenger, welcome to Mailjet!</h3><br/>May the delivery force be with you!",
-		Recipients: []mailjet.Recipient{
-			{
-				Email: to,
+	messagesInfo := []mailjet.InfoMessagesV31{
+		{
+			From: &mailjet.RecipientV31{
+				Email: fromEmail,
+				Name:  "Mailjet Pilot",
 			},
+			To: &mailjet.RecipientsV31{
+				mailjet.RecipientV31{
+					Email: to,
+					Name:  "passenger 1",
+				},
+			},
+			Subject:  "Your email flight plan!",
+			TextPart: "Dear passenger, welcome to Mailjet! May the delivery force be with you!",
+			HTMLPart: "<h3>Dear passenger, welcome to Mailjet!</h3><br />May the delivery force be with you!",
 		},
 	}
 
-	resp, err := mailjetClient.SendMail(m)
+	messages := mailjet.MessagesV31{Info: messagesInfo}
+	resp, err := mailjetClient.SendMailV31(&messages)
 	if err != nil {
 		msg := fmt.Sprintf("Could not send mail: %v", err)
 		http.Error(w, msg, 500)
 		return
 	}
 
-	fmt.Fprintf(w, "%d email(s) sent!", len(resp.Sent))
+	fmt.Fprintf(w, "%d email(s) sent!", len(resp.ResultsV31))
 }

--- a/docs/appengine/mail/mailjet/mailjet.go
+++ b/docs/appengine/mail/mailjet/mailjet.go
@@ -54,25 +54,31 @@ func sendEmail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	m := &mailjet.InfoSendMail{
-		FromEmail: fromEmail,
-		FromName:  "App Engine Mailjet sample",
-		Subject:   "Your email flight plan!",
-		TextPart:  "Dear passenger, welcome to Mailjet! May the delivery force be with you!",
-		HTMLPart:  "<h3>Dear passenger, welcome to Mailjet!</h3><br/>May the delivery force be with you!",
-		Recipients: []mailjet.Recipient{
-			{
-				Email: to,
+	messagesInfo := []mailjet.InfoMessagesV31{
+		{
+			From: &mailjet.RecipientV31{
+				Email: fromEmail,
+				Name:  "Mailjet Pilot",
 			},
+			To: &mailjet.RecipientsV31{
+				mailjet.RecipientV31{
+					Email: to,
+					Name:  "passenger 1",
+				},
+			},
+			Subject:  "Your email flight plan!",
+			TextPart: "Dear passenger, welcome to Mailjet! May the delivery force be with you!",
+			HTMLPart: "<h3>Dear passenger, welcome to Mailjet!</h3><br />May the delivery force be with you!",
 		},
 	}
 
-	resp, err := mailjetClient.SendMail(m)
+	messages := mailjet.MessagesV31{Info: messagesInfo}
+	resp, err := mailjetClient.SendMailV31(&messages)
 	if err != nil {
 		msg := fmt.Sprintf("Could not send mail: %v", err)
 		http.Error(w, msg, 500)
 		return
 	}
 
-	fmt.Fprintf(w, "%d email(s) sent!", len(resp.Sent))
+	fmt.Fprintf(w, "%d email(s) sent!", len(resp.ResultsV31))
 }


### PR DESCRIPTION
Mailjet Send API v3.1 is being released, so updating the code samples to match the new Send API v3.1 configuration. Reference can be found [here](https://dev.mailjet.com/beta/).
