### PR TITLE
storage: add gcsupload, an upload sample + tests

### DIFF
--- a/storage/gcsupload/README.md
+++ b/storage/gcsupload/README.md
@@ -1,0 +1,28 @@
+# gcsupload
+
+This is a simple CLI that allows you to upload a file to your Google Cloud Storage bucket.
+
+
+## Authentication
+
+Please visit https://cloud.google.com/docs/authentication/getting-started
+
+
+## Installing it
+
+```shell
+go get -u github.com/GoogleCloudPlatform/golang-samples/storage/gcsupload
+```
+
+
+## Using it
+
+```shell
+gcsupload -project orijtech-161805 -source ~/Desktop/birthdayPic.jpg -bucket orijtech-gcs-test
+```
+which will give you a result like this
+```shell
+URL: https://storage.googleapis.com/orijtech-gcs-test/birthdayPic.jpg
+Size: 865096
+MD5: 5b6c7b4aed837e8ed0f9950564a10b32
+```

--- a/storage/gcsupload/gcsupload.go
+++ b/storage/gcsupload/gcsupload.go
@@ -1,0 +1,142 @@
+// Copyright 2017 Google Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+// gcsupload is a CLI to upload a file to Google Cloud Storage.
+// Invoke -h to see its flags:
+// gcsupload -h
+//  Usage of gcsupload:
+//    -bucket string
+//	    the bucket to upload content to
+//    -name string
+//	    the name of the file to be stored on GCS
+//    -project string
+//	    the ID of the GCP project to use
+//    -public
+//	    whether the item should be available publicly (default true)
+//    -source string
+//	    the path to the source
+//
+// For example:
+//  gcsupload --project gcs-samples --source ~/Desktop/birthdayPic.jpg --bucket gcs-cli-test
+//  URL: https://storage.googleapis.com/gcs-cli-test/birthdayPic.jpg
+//  Size: 865096
+//  MD5: 5b6c7b4aed837e8ed0f9950564a10b32
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+
+	"cloud.google.com/go/storage"
+
+	"golang.org/x/net/context"
+)
+
+func main() {
+	// Prevent log from printing out time information
+	log.SetFlags(0)
+
+	var projectID, bucket, source, name string
+	var public bool
+
+	flag.StringVar(&bucket, "bucket", "", "the bucket to upload content to")
+	flag.StringVar(&projectID, "project", "", "the ID of the GCP project to use")
+	flag.StringVar(&source, "source", "", "the path to the source")
+	flag.StringVar(&name, "name", "", "the name of the file to be stored on GCS")
+	flag.BoolVar(&public, "public", true, "whether the item should be available publicly")
+	flag.Parse()
+
+	// If they haven't set the bucket or projectID nor specified
+	// in the environment, then fail if missing.
+	bucket = mustGetEnv("GOLANG_SAMPLES_BUCKET", bucket)
+	projectID = mustGetEnv("GOLANG_SAMPLES_PROJECT_ID", projectID)
+
+	var r io.Reader
+	if source == "" {
+		r = os.Stdin
+		log.Printf("Reading from stdin...")
+	} else {
+		f, err := os.Open(source)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer f.Close()
+		r = f
+	}
+
+	if name == "" {
+		if source != "" {
+			name = filepath.Base(source)
+		} else {
+			name = "test-sample"
+		}
+	}
+
+	ctx := context.Background()
+	_, objAttrs, err := upload(ctx, r, projectID, bucket, name, true)
+	if err != nil {
+		switch err {
+		case storage.ErrBucketNotExist:
+			log.Fatal("Please create the bucket first e.g. with `gsutil mb`")
+		default:
+			log.Fatal(err)
+		}
+	}
+
+	log.Printf("URL: %s", objectURL(objAttrs))
+	log.Printf("Size: %d", objAttrs.Size)
+	log.Printf("MD5: %x", objAttrs.MD5)
+	log.Printf("objAttrs: %+v", objAttrs)
+}
+
+func objectURL(objAttrs *storage.ObjectAttrs) string {
+	return fmt.Sprintf("https://storage.googleapis.com/%s/%s", objAttrs.Bucket, objAttrs.Name)
+}
+
+func upload(ctx context.Context, r io.Reader, projectID, bucket, name string, public bool) (*storage.ObjectHandle, *storage.ObjectAttrs, error) {
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer client.Close()
+
+	bh := client.Bucket(bucket)
+	// Next check if the bucket exists
+	if _, err = bh.Attrs(ctx); err != nil {
+		return nil, nil, err
+	}
+
+	obj := bh.Object(name)
+	w := obj.NewWriter(ctx)
+	if _, err := io.Copy(w, r); err != nil {
+		return nil, nil, err
+	}
+	if err := w.Close(); err != nil {
+		return nil, nil, err
+	}
+
+	if public {
+		if err := obj.ACL().Set(ctx, storage.AllUsers, storage.RoleReader); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	attrs, err := obj.Attrs(ctx)
+	return obj, attrs, err
+}
+
+func mustGetEnv(envKey, defaultValue string) string {
+	val := os.Getenv(envKey)
+	if val == "" {
+		val = defaultValue
+	}
+	if val == "" {
+		log.Fatalf("%q should be set", envKey)
+	}
+	return val
+}

--- a/storage/gcsupload/gcsupload_test.go
+++ b/storage/gcsupload/gcsupload_test.go
@@ -1,0 +1,95 @@
+// Copyright 2017 Google Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bytes"
+	"crypto/md5"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/context"
+	"google.golang.org/api/iterator"
+
+	"cloud.google.com/go/storage"
+
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+)
+
+func TestUpload(t *testing.T) {
+	tc := testutil.SystemTest(t)
+
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		t.Fatalf("Creating client: %v", err)
+	}
+	projectID := tc.ProjectID
+	bucket := projectID + "-gcsupload"
+
+	cleanBucket(t, ctx, client, projectID, bucket)
+	defer deleteBucketIfExists(t, ctx, client, bucket)
+
+	input := strings.Repeat("GCS test\n", 30)
+	r := strings.NewReader(input)
+
+	name := "atest.txt"
+	obj, objAttrs, err := upload(ctx, r, projectID, bucket, name, true)
+	if err != nil {
+		t.Fatalf("expected to successfully upload: %v", err)
+	}
+	if objAttrs == nil {
+		t.Fatal("expected back a non-nil object")
+	}
+	defer obj.Delete(ctx)
+
+	if g, w := objAttrs.Name, name; g != w {
+		t.Errorf("name: got=%q want=%q", g, w)
+	}
+	if g, w := objAttrs.Size, int64(len(input)); g != w {
+		t.Errorf("size: got=%d want=%d", g, w)
+	}
+	h := md5.New()
+	h.Write([]byte(input))
+	if g, w := objAttrs.MD5, h.Sum(nil); !bytes.Equal(g, w) {
+		t.Errorf("md5: got=%x want=%x", g, w)
+	}
+}
+
+func cleanBucket(t *testing.T, ctx context.Context, client *storage.Client, projectID, bucket string) {
+	deleteBucketIfExists(t, ctx, client, bucket)
+
+	b := client.Bucket(bucket)
+	// Now create it
+	if err := b.Create(ctx, projectID, nil); err != nil {
+		t.Fatalf("Bucket.Create(%q): %v", bucket, err)
+	}
+}
+
+func deleteBucketIfExists(t *testing.T, ctx context.Context, client *storage.Client, bucket string) {
+	b := client.Bucket(bucket)
+	if _, err := b.Attrs(ctx); err != nil {
+		return
+	}
+
+	// Delete all the elements in the already existent bucket
+	it := b.Objects(ctx, nil)
+	for {
+		attrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Bucket.Objects(%q): %v", bucket, err)
+		}
+		if err := b.Object(attrs.Name).Delete(ctx); err != nil {
+			t.Fatalf("Bucket(%q).Object(%q).Delete: %v", bucket, attrs.Name, err)
+		}
+	}
+	// Then delete the bucket itself
+	if err := b.Delete(ctx); err != nil {
+		t.Fatalf("Bucket.Delete(%q): %v", bucket, err)
+	}
+}


### PR DESCRIPTION
This sample is a snippet of code with which you can create a CLI
that allows you to upload a file to your Google Cloud Storage bucket.

* Using it
```shell
upload -project-id orijtech-161805 -source ~/Desktop/birthdayPic.jpg
-bucket orijtech-gcs-test
```
which will give you a result like this
```shell
ObjectURL:
https://storage.googleapis.com/orijtech-gcs-test/birthdayPic.jpg
Size: 865096
MD5: W2x7Su2Dfo7Q+ZUFZKELMg==
```