### PR TITLE
endpoints/getting-started-grpc/client: fix for grpc breaking metadata change

### DIFF
--- a/endpoints/getting-started-grpc/client/main.go
+++ b/endpoints/getting-started-grpc/client/main.go
@@ -62,7 +62,7 @@ func main() {
 	c := pb.NewGreeterClient(conn)
 
 	ctx := context.Background()
-	ctx = metadata.NewContext(ctx, metadata.Pairs("x-api-key", *key))
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("x-api-key", *key))
 
 	// Contact the server and print out its response.
 	name := defaultName


### PR DESCRIPTION
See https://github.com/grpc/grpc-go/commit/596a6acc87c73c3bc398a60ef0089976491ca060
And build failures: https://travis-ci.org/GoogleCloudPlatform/golang-samples