### PR TITLE
only test trace samples on go1.7+

### DIFF
--- a/trace/trace_quickstart/main.go
+++ b/trace/trace_quickstart/main.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+// +build go1.7
+
 // [START trace_quickstart]
 
 // Sample trace_quickstart creates traces incoming and outgoing requests.


### PR DESCRIPTION
1.6 travis failure:

```
# github.com/GoogleCloudPlatform/golang-samples/trace/trace_quickstart
trace/trace_quickstart/main.go:32: undefined: "cloud.google.com/go/trace".Transport
trace/trace_quickstart/main.go:40: req.WithContext undefined (type *"net/http".Request has no field or method WithContext)
trace/trace_quickstart/main.go:40: r.Context undefined (type *"net/http".Request has no field or method Context)
trace/trace_quickstart/main.go:47: traceClient.HTTPHandler undefined (type *"cloud.google.com/go/trace".Client has no field or method HTTPHandler)
```