### PR TITLE
vision: fix broken demos

### DIFF
--- a/vision/detect/detect.go
+++ b/vision/detect/detect.go
@@ -194,8 +194,12 @@ func detectDocumentText(w io.Writer, file string) error {
 		return err
 	}
 
-	fmt.Fprintln(w, "Text:")
-	fmt.Fprintf(w, "%q\n", annotation.Text)
+	if annotation == nil {
+		fmt.Fprintln(w, "No text found.")
+	} else {
+		fmt.Fprintln(w, "Text:")
+		fmt.Fprintf(w, "%q\n", annotation.Text)
+	}
 
 	return nil
 }

--- a/vision/vision_quickstart/main.go
+++ b/vision/vision_quickstart/main.go
@@ -26,7 +26,7 @@ func main() {
 	}
 
 	// Sets the name of the image file to annotate.
-	filename := "vision/testdata/cat.jpg"
+	filename := "../testdata/cat.jpg"
 
 	file, err := os.Open(filename)
 	if err != nil {


### PR DESCRIPTION
The path to the `cat.jpg` file is broken in the vision_quickstart demo. This pull request fixes it.