### PR TITLE
vision: fix detect.go generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,5 @@ Note: samples under `docs/appengine` are not shown because they mostly do not ru
 |[pubsub/topics](pubsub/topics)|Command topics is a tool to manage Google Cloud Pub/Sub topics by using the Pub/Sub API.|
 |[speech/caption](speech/caption)|Command caption reads an audio file and outputs the transcript for it.|
 |[storage/buckets](storage/buckets)|Sample buckets creates a bucket, lists buckets and deletes a bucket using the Google Storage API.|
+|[vision/detect](vision/detect)|Command detect uses the Vision API's capabilities to detect several types of content (label, text, location, etc) for the given image.|
 |[vision/label](vision/label)|Command label uses the Vision API's label detection capabilities to find a label based on an image's content.|

--- a/vision/README.md
+++ b/vision/README.md
@@ -10,3 +10,11 @@ See the [label detection](https://cloud.google.com/vision/docs/label-tutorial) t
 
 [Go Code](label)
 
+### Detect Content
+
+This example runs the Cloud Vision API content detection routines over a given image.
+
+The content is processed with the following models: faces, labels, landmarks, text, document text, logos, properties, crop hints, web and safe search.
+
+[Go Code](detect)
+

--- a/vision/detect/README.md
+++ b/vision/detect/README.md
@@ -33,5 +33,6 @@ go run detect.go main.go https://...
 Do not edit the `detect.go` file directly. In order to modify it edit the code at `vision/detect/generated/sample-template.go` and run `go generate` at the command line:
 
 ```bash
+cd vision/detect
 go generate
 ```

--- a/vision/detect/README.md
+++ b/vision/detect/README.md
@@ -27,3 +27,11 @@ go run detect.go main.go gs://...
 
 go run detect.go main.go https://...
 ```
+
+## Modifiying the source code
+
+Do not edit the `detect.go` file directly. In order to modify it edit the code at `vision/detect/generated/sample-template.go` and run `go generate` at the command line:
+
+```bash
+go generate
+```

--- a/vision/detect/detect.go
+++ b/vision/detect/detect.go
@@ -193,7 +193,7 @@ func detectDocumentText(w io.Writer, file string) error {
 	if err != nil {
 		return err
 	}
-
+	
 	if annotation == nil {
 		fmt.Fprintln(w, "No text found.")
 	} else {
@@ -520,7 +520,7 @@ func detectDocumentTextURI(w io.Writer, file string) error {
 	if err != nil {
 		return err
 	}
-
+	
 	if annotation == nil {
 		fmt.Fprintln(w, "No text found.")
 	} else {

--- a/vision/detect/detect.go
+++ b/vision/detect/detect.go
@@ -193,7 +193,7 @@ func detectDocumentText(w io.Writer, file string) error {
 	if err != nil {
 		return err
 	}
-	
+
 	if annotation == nil {
 		fmt.Fprintln(w, "No text found.")
 	} else {
@@ -520,7 +520,7 @@ func detectDocumentTextURI(w io.Writer, file string) error {
 	if err != nil {
 		return err
 	}
-	
+
 	if annotation == nil {
 		fmt.Fprintln(w, "No text found.")
 	} else {

--- a/vision/detect/generated/sample-template.go
+++ b/vision/detect/generated/sample-template.go
@@ -116,7 +116,7 @@ func detectDocumentText(w io.Writer, file string) error {
 	if err != nil {
 		return err
 	}
-	
+
 	if annotation == nil {
 		fmt.Fprintln(w, "No text found.")
 	} else {

--- a/vision/detect/generated/sample-template.go
+++ b/vision/detect/generated/sample-template.go
@@ -116,9 +116,13 @@ func detectDocumentText(w io.Writer, file string) error {
 	if err != nil {
 		return err
 	}
-
-	fmt.Fprintln(w, "Text:")
-	fmt.Fprintf(w, "%q\n", annotation.Text)
+	
+	if annotation == nil {
+		fmt.Fprintln(w, "No text found.")
+	} else {
+		fmt.Fprintln(w, "Text:")
+		fmt.Fprintf(w, "%q\n", annotation.Text)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Related to issues #305 and #307. I'm sorry, but I was not aware of the generator and edited the `detect.go` source file directly. This commit provides the fix in the correct place (`generated/sample-template.go`).

I've also added a section to the README to help bringing awareness to necessity of using the generator to modify `detect.go`.

Finally, I've added an entry for the `vision/detect` example in the master table.