### PR TITLE
readme: organize examples by category

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Note: samples under `docs/appengine` are not shown because they mostly do not ru
 |[getting-started/bookshelf/pubsub_worker](getting-started/bookshelf/pubsub_worker)|Sample pubsub_worker demonstrates the use of the Cloud Pub/Sub API to communicate between two modules.|
 |[getting-started/helloworld](getting-started/helloworld)|Sample helloworld is a basic App Engine flexible app.|
 
-### Management
+### Logging and Monitoring (Stackdriver)
 
 |Path|Description|
 |---|---|
@@ -74,8 +74,6 @@ Note: samples under `docs/appengine` are not shown because they mostly do not ru
 |---|---|
 |[datastore/tasks](datastore/tasks)|A simple command-line task list manager to demonstrate using the cloud.google.com/go/datastore package.|
 |[storage/buckets](storage/buckets)|Sample buckets creates a bucket, lists buckets and deletes a bucket using the Google Storage API.|
-
-### Networking
 
 ### Big Data
 

--- a/README.md
+++ b/README.md
@@ -27,13 +27,31 @@ go list -f '|[{{.Dir}}]({{.Dir}})|{{.Doc}}|' ./... | egrep -v '/(internal|docs/a
 
 Note: samples under `docs/appengine` are not shown because they mostly do not run, they are just code snippets.
 
+### Getting Started
+
+|Path|Description|
+|---|---|
+|[getting-started/bookshelf](getting-started/bookshelf)|Package bookshelf contains the bookshelf database and app configuration, shared by the main app module and the worker module.|
+|[getting-started/bookshelf/app](getting-started/bookshelf/app)|Sample bookshelf is a fully-featured app demonstrating several Google Cloud APIs, including Datastore, Cloud SQL, Cloud Storage.|
+|[getting-started/bookshelf/pubsub_worker](getting-started/bookshelf/pubsub_worker)|Sample pubsub_worker demonstrates the use of the Cloud Pub/Sub API to communicate between two modules.|
+|[getting-started/helloworld](getting-started/helloworld)|Sample helloworld is a basic App Engine flexible app.|
+
+### Management
+
+|Path|Description|
+|---|---|
+|[docs/error-reporting/fluent](docs/error-reporting/fluent)|Sample fluent demonstrates integration of fluent and Cloud Error reporting.|
+|[docs/sql/listinstances](docs/sql/listinstances)|Sample listinstances lists the Cloud SQL instances for a given project ID.|
+|[docs/storage/listbuckets](docs/storage/listbuckets)|Command listbuckets lists the Google Cloud buckets for a given project ID.|
+|[logging/simplelog](logging/simplelog)|Sample simplelog writes some entries, lists them, then deletes the log.|
+|[monitoring/custommetric](monitoring/custommetric)|Command custommetric creates a custom metric and writes TimeSeries value to it.|
+|[monitoring/listresources](monitoring/listresources)|Command listresources lists the Google Cloud Monitoring v3 Environment against an authenticated user.|
+
+### Compute
+
 |Path|Description|
 |---|---|
 |[appengine/bigquery](appengine/bigquery)|This App Engine application uses its default service account to list all the BigQuery datasets accessible via the BigQuery REST API.|
-|[bigquery/syncquery](bigquery/syncquery)|Command syncquery queries a Google BigQuery dataset.|
-|[datastore/tasks](datastore/tasks)|A simple command-line task list manager to demonstrate using the cloud.google.com/go//datastore package.|
-|[dlp](dlp)|Samples for the [Data Loss Prevention](https://cloud.google.com/dlp/) API.|
-|[docs/error-reporting/fluent](docs/error-reporting/fluent)|Sample fluent demonstrates integration of fluent and Cloud Error reporting.|
 |[docs/managed_vms/analytics](docs/managed_vms/analytics)|Sample analytics demonstrates Google Analytics calls from App Engine flexible environment.|
 |[docs/managed_vms/cloudsql](docs/managed_vms/cloudsql)|Sample cloudsql demonstrates usage of Cloud SQL from App Engine flexible environment.|
 |[docs/managed_vms/datastore](docs/managed_vms/datastore)|Sample datastore demonstrates use of the cloud.google.com/go/datastore package from App Engine flexible.|
@@ -49,22 +67,38 @@ Note: samples under `docs/appengine` are not shown because they mostly do not ru
 |[docs/managed_vms/storage](docs/managed_vms/storage)|Sample storage demonstrates use of the cloud.google.com/go/storage package from App Engine flexible environment.|
 |[docs/managed_vms/tiny](docs/managed_vms/tiny)|Sample tiny demonstrates overall program structure: a main package with a main function that calls appengine.Main.|
 |[docs/managed_vms/twilio](docs/managed_vms/twilio)|Sample twilio demonstrates sending and receiving SMS, receiving calls via Twilio from App Engine flexible environment.|
-|[docs/sql/listinstances](docs/sql/listinstances)|Sample listinstances lists the Cloud SQL instances for a given project ID.|
-|[docs/storage/listbuckets](docs/storage/listbuckets)|Command listbuckets lists the Google Cloud buckets for a given project ID.|
-|[getting-started/bookshelf](getting-started/bookshelf)|Package bookshelf contains the bookshelf database and app configuration, shared by the main app module and the worker module.|
-|[getting-started/bookshelf/app](getting-started/bookshelf/app)|Sample bookshelf is a fully-featured app demonstrating several Google Cloud APIs, including Datastore, Cloud SQL, Cloud Storage.|
-|[getting-started/bookshelf/pubsub_worker](getting-started/bookshelf/pubsub_worker)|Sample pubsub_worker demonstrates the use of the Cloud Pub/Sub API to communicate between two modules.|
-|[getting-started/helloworld](getting-started/helloworld)|Sample helloworld is a basic App Engine flexible app.|
-|[language/analyze](language/analyze)|Command analyze performs sentiment, entity, and syntax analysis on a string of text via the Cloud Natural Language API.|
-|[logging/simplelog](logging/simplelog)|Sample simplelog writes some entries, lists them, then deletes the log.|
-|[monitoring/custommetric](monitoring/custommetric)|Command custommetric creates a custom metric and writes TimeSeries value to it.|
-|[monitoring/listresources](monitoring/listresources)|Command listresources lists the Google Cloud Monitoring v3 Environment against an authenticated user.|
+
+### Storage
+
+|Path|Description|
+|---|---|
+|[datastore/tasks](datastore/tasks)|A simple command-line task list manager to demonstrate using the cloud.google.com/go/datastore package.|
+|[storage/buckets](storage/buckets)|Sample buckets creates a bucket, lists buckets and deletes a bucket using the Google Storage API.|
+
+### Networking
+
+### Big Data
+
+|Path|Description|
+|---|---|
+|[bigquery/syncquery](bigquery/syncquery)|Command syncquery queries a Google BigQuery dataset.|
 |[pubsub/subscriptions](pubsub/subscriptions)|Command subscriptions is a tool to manage Google Cloud Pub/Sub subscriptions by using the Pub/Sub API.|
 |[pubsub/topics](pubsub/topics)|Command topics is a tool to manage Google Cloud Pub/Sub topics by using the Pub/Sub API.|
+
+### Machine Learning
+
+|Path|Description|
+|---|---|
+|[language/analyze](language/analyze)|Command analyze performs sentiment, entity, and syntax analysis on a string of text via the Cloud Natural Language API.|
 |[speech/caption](speech/caption)|Command caption reads an audio file and outputs the transcript for it.|
 |[speech/captionasync](speech/captionasync)|Command captionasync reads an audio file and outputs the transcript for it.|
 |[speech/livecaption](speech/livecaption)|Command livecaption pipes the stdin audio data to Google Speech API and outputs the transcript.|
 |[speech/wordoffset](speech/wordoffset)|Command wordoffset sends audio data to the Google Speech API and prints word offset information.|
-|[storage/buckets](storage/buckets)|Sample buckets creates a bucket, lists buckets and deletes a bucket using the Google Storage API.|
 |[vision/detect](vision/detect)|Command detect uses the Vision API's capabilities to detect several types of content (label, text, location, etc) for the given image.|
 |[vision/label](vision/label)|Command label uses the Vision API's label detection capabilities to find a label based on an image's content.|
+
+### Privacy
+
+|Path|Description|
+|---|---|
+|[dlp](dlp)|Samples for the [Data Loss Prevention](https://cloud.google.com/dlp/) API.|


### PR DESCRIPTION
I've made the modifications proposed by #309. I'm not sure if this is the best layout, because some examples seem to fit to more than one category.

I've added a `Getting Started` category to the proposal because I couldn't fit those samples to a single category. Also, there are no Networking examples available right now, but I've left the title there as a placeholder for when those are available.