### PR TITLE
storage: add example for set a CORS

### DIFF
--- a/storage/buckets/main_test.go
+++ b/storage/buckets/main_test.go
@@ -93,3 +93,11 @@ func TestDelete(t *testing.T) {
 		t.Fatalf("failed to delete bucket (%q): %v", bucketName, err)
 	}
 }
+
+func TestSetCors(t *testing.T) {
+	testutil.SystemTest(t)
+	_, err := setCors(bucketName)
+	if err != nil {
+		t.Errorf("setCors: %v", err)
+	}
+}


### PR DESCRIPTION
add the example for setting a cors on the bucket.
I can't found a method that set a cors on cloud.google.com/go/storage.
So I'm using google.golang.org/api/storage/v1