### PR TITLE
appengine_flexible: add cloudsql_postgres sample

### DIFF
--- a/appengine_flexible/cloudsql/cloudsql.go
+++ b/appengine_flexible/cloudsql/cloudsql.go
@@ -97,7 +97,6 @@ func queryVisits(limit int64) ([]visit, error) {
 	defer rows.Close()
 
 	var visits []visit
-
 	for rows.Next() {
 		var v visit
 		if err := rows.Scan(&v.timestamp, &v.userIP); err != nil {

--- a/appengine_flexible/cloudsql_postgres/README.md
+++ b/appengine_flexible/cloudsql_postgres/README.md
@@ -1,0 +1,5 @@
+## Google Cloud SQL on App Engine flexible environment
+
+Follow the [instructions][1] in the documentation to run this code.
+
+[1]: https://cloud.google.com/appengine/docs/flexible/go/using-cloud-sql

--- a/appengine_flexible/cloudsql_postgres/app.yaml
+++ b/appengine_flexible/cloudsql_postgres/app.yaml
@@ -1,0 +1,27 @@
+runtime: go
+env: flex
+
+automatic_scaling:
+  min_num_instances: 1
+
+#[START env]
+env_variables:
+  # See https://godoc.org/github.com/lib/pq
+  #
+  # Replace INSTANCE_CONNECTION_NAME with the same value as in the
+  # beta_settings section below.
+  POSTGRES_CONNECTION: "user=postgres password=pw dbname=db host=/cloudsql/INSTANCE_CONNECTION_NAME"
+  #
+  # If you're testing locally using the Cloud SQL proxy with TCP,
+  # instead set this environment variable:
+  # POSTGRES_CONNECTION="user=postgres password=pw dbname=db sslmode=disable"
+#[END env]
+
+#[START cloudsql_settings]
+# Replace INSTANCE_CONNECTION_NAME with the value obtained when configuring your
+# Cloud SQL instance, available from the Google Cloud Console or from the Cloud SDK.
+# For SQL v2 instances, this should be in the form of "project:region:instance".
+# Cloud SQL v1 instances are not supported.
+beta_settings:
+  cloud_sql_instances: INSTANCE_CONNECTION_NAME
+#[END cloudsql_settings]

--- a/appengine_flexible/cloudsql_postgres/cloudsql.go
+++ b/appengine_flexible/cloudsql_postgres/cloudsql.go
@@ -1,0 +1,110 @@
+// Copyright 2015 Google Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+// Sample cloudsql demonstrates usage of Cloud SQL from App Engine flexible environment.
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"google.golang.org/appengine"
+
+	_ "github.com/lib/pq"
+)
+
+var db *sql.DB
+
+func main() {
+	// Set this in app.yaml when running in production.
+	datastoreName := os.Getenv("POSTGRES_CONNECTION")
+
+	var err error
+	db, err = sql.Open("postgres", datastoreName)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Ensure the table exists.
+	// Running an SQL query also checks the connection to the MySQL server
+	// is authenticated and valid.
+	if err := createTable(); err != nil {
+		log.Fatal(err)
+	}
+
+	http.HandleFunc("/", handle)
+	appengine.Main()
+}
+
+func createTable() error {
+	stmt := `CREATE TABLE IF NOT EXISTS visits (
+			timestamp  BIGINT,
+			userip     VARCHAR(255)
+		)`
+	_, err := db.Exec(stmt)
+	return err
+}
+
+func handle(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+
+	// Get a list of the most recent visits.
+	visits, err := queryVisits(10)
+	if err != nil {
+		msg := fmt.Sprintf("Could not get recent visits: %v", err)
+		http.Error(w, msg, http.StatusInternalServerError)
+		return
+	}
+
+	// Record this visit.
+	if err := recordVisit(time.Now().UnixNano(), r.RemoteAddr); err != nil {
+		msg := fmt.Sprintf("Could not save visit: %v", err)
+		http.Error(w, msg, http.StatusInternalServerError)
+		return
+	}
+
+	fmt.Fprintln(w, "Previous visits:")
+	for _, v := range visits {
+		fmt.Fprintf(w, "[%s] %s\n", time.Unix(0, v.timestamp), v.userIP)
+	}
+	fmt.Fprintln(w, "\nSuccessfully stored an entry of the current request.")
+}
+
+type visit struct {
+	timestamp int64
+	userIP    string
+}
+
+func recordVisit(timestamp int64, userIP string) error {
+	stmt := "INSERT INTO visits (timestamp, userip) VALUES ($1, $2)"
+	_, err := db.Exec(stmt, timestamp, userIP)
+	return err
+}
+
+func queryVisits(limit int64) ([]visit, error) {
+	rows, err := db.Query("SELECT timestamp, userip FROM visits ORDER BY timestamp DESC LIMIT $1", limit)
+	if err != nil {
+		return nil, fmt.Errorf("Could not get recent visits: %v", err)
+	}
+	defer rows.Close()
+
+	var visits []visit
+
+	for rows.Next() {
+		var v visit
+		if err := rows.Scan(&v.timestamp, &v.userIP); err != nil {
+			return nil, fmt.Errorf("Could not get timestamp/user IP out of row: %v", err)
+		}
+		visits = append(visits, v)
+	}
+
+	return visits, rows.Err()
+}

--- a/appengine_flexible/cloudsql_postgres/cloudsql.go
+++ b/appengine_flexible/cloudsql_postgres/cloudsql.go
@@ -97,7 +97,6 @@ func queryVisits(limit int64) ([]visit, error) {
 	defer rows.Close()
 
 	var visits []visit
-
 	for rows.Next() {
 		var v visit
 		if err := rows.Scan(&v.timestamp, &v.userIP); err != nil {


### PR DESCRIPTION
Similar to the MySQL sample, except with a couple SQL syntax changes and
different connection strings.