### PR TITLE
storage/gcsupload: don't close client and return handles

### DIFF
--- a/storage/gcsupload/gcsupload.go
+++ b/storage/gcsupload/gcsupload.go
@@ -103,7 +103,6 @@ func upload(ctx context.Context, r io.Reader, projectID, bucket, name string, pu
 	if err != nil {
 		return nil, nil, err
 	}
-	defer client.Close()
 
 	bh := client.Bucket(bucket)
 	// Next check if the bucket exists


### PR DESCRIPTION
Handles aren't valid once the client is closed.

See: https://code-review.googlesource.com/16950