### PR TITLE
travis: test with most recent minor go version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ branches:
 
 matrix:
   include:
+    - go: 1.6.x
     - go: 1.7.x
     - go: 1.8.x
     - go: 1.9.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ branches:
 
 matrix:
   include:
-    - go: 1.7.5
-    - go: 1.8.4
-    - go: 1.9.1
+    - go: 1.7.x
+    - go: 1.8.x
+    - go: 1.9.x
       env: ALLOW_E2E=true # Don't run e2e tests more than once.
     # NOTE: no tip, see https://github.com/travis-ci/gimme/issues/38
 


### PR DESCRIPTION
Just doing this for consistency with other cloud clients (which i'm updating atm to add 1.9).
Feel free to reject if you disagree.