### PR TITLE
Endpoints example with JWT authentication.

### DIFF
--- a/endpoints/getting-started-grpc/api_config_auth.yaml
+++ b/endpoints/getting-started-grpc/api_config_auth.yaml
@@ -1,0 +1,37 @@
+# An example API configuration.
+#
+# Below, replace YOUR_PROJECT_ID with your Google Cloud Project ID.
+
+# The configuration schema is defined by service.proto file
+# https://github.com/googleapis/googleapis/blob/master/google/api/service.proto
+type: google.api.Service
+config_version: 3
+
+# Name of the service configuration.
+name: hellogrpc.endpoints.PROJECT_ID.cloud.goog
+
+# API title to appear in the user interface (Google Cloud Console).
+title: Hello gRPC API
+apis:
+- name: helloworld.Greeter
+
+
+authentication:
+  providers:
+  - id: google_service_account
+    # Replace PROJECT_ID with the ID of your GCP project:
+    audiences: hellogrpc.endpoints.PROJECT_ID.cloud.goog
+    # Replace SERVICE-ACCOUNT-ID with your service account's email address.
+    issuer: SERVICE-ACCOUNT-ID
+    jwks_uri: https://www.googleapis.com/robot/v1/metadata/x509/SERVICE-ACCOUNT-ID
+  rules:
+  # This auth rule will apply to all methods.
+  - selector: "*"
+    requirements:
+      - provider_id: google_service_account
+
+
+usage:
+  rules:
+  - selector: "*"
+    allow_unregistered_calls: true

--- a/endpoints/getting-started-grpc/client/main.go
+++ b/endpoints/getting-started-grpc/client/main.go
@@ -83,6 +83,8 @@ func main() {
 			log.Fatalf("Unable to generate JWT token: %v", err)
 		}
 		*token = jwt.AccessToken
+		// Note: the generated JWT token has a 1h TTL.
+		// Make sure to refresh the token before it expires (see jwt.Expiry).
 	}
 
 	ctx := context.Background()

--- a/endpoints/getting-started-grpc/client/main.go
+++ b/endpoints/getting-started-grpc/client/main.go
@@ -40,11 +40,10 @@ import (
 	"log"
 
 	"golang.org/x/net/context"
+	"golang.org/x/oauth2/google"
 	"google.golang.org/grpc"
 	pb "google.golang.org/grpc/examples/helloworld/helloworld"
 	"google.golang.org/grpc/metadata"
-
-	googleoauth2 "golang.org/x/oauth2/google"
 )
 
 const defaultName = "world"
@@ -70,12 +69,12 @@ func main() {
 
 	if *keyfile != "" {
 		log.Printf("Authenticating using Google service account key in %s", *keyfile)
-		sakey, err := ioutil.ReadFile(*keyfile)
+		keyBytes, err := ioutil.ReadFile(*keyfile)
 		if err != nil {
-			log.Fatalf("Unable to read service account key file %s: %s", *keyfile, err)
+			log.Fatalf("Unable to read service account key file %s: %v", *keyfile, err)
 		}
 
-		tokenSource, err := googleoauth2.JWTAccessTokenSourceFromJSON(sakey, *audience)
+		tokenSource, err := google.JWTAccessTokenSourceFromJSON(keyBytes, *audience)
 		if err != nil {
 			log.Fatalf("Error building JWT access token source: %v", err)
 		}

--- a/endpoints/getting-started-grpc/client/main.go
+++ b/endpoints/getting-started-grpc/client/main.go
@@ -83,8 +83,9 @@ func main() {
 			log.Fatalf("Unable to generate JWT token: %v", err)
 		}
 		*token = jwt.AccessToken
-		// Note: the generated JWT token has a 1h TTL.
-		// Make sure to refresh the token before it expires (see jwt.Expiry).
+		// NOTE: the generated JWT token has a 1h TTL.
+		// Make sure to refresh the token before it expires by calling TokenSource.Token() for each outgoing requests.
+		// Calls to this particular implementation of TokenSource.Token() are cheap.
 	}
 
 	ctx := context.Background()

--- a/endpoints/getting-started-grpc/server/main.go
+++ b/endpoints/getting-started-grpc/server/main.go
@@ -34,6 +34,7 @@
 package main
 
 import (
+	"flag"
 	"log"
 	"net"
 
@@ -43,8 +44,8 @@ import (
 	"google.golang.org/grpc/reflection"
 )
 
-const (
-	port = ":50051"
+var (
+	listen = flag.String("listen", ":50051", "Network interface:port to listen on for gRPC connections.")
 )
 
 // server is used to implement helloworld.GreeterServer.
@@ -52,11 +53,14 @@ type server struct{}
 
 // SayHello implements helloworld.GreeterServer
 func (s *server) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
+	log.Printf("Handling SayHello request [%s] with context %s", in, ctx)
 	return &pb.HelloReply{Message: "Hello " + in.Name}, nil
 }
 
 func main() {
-	lis, err := net.Listen("tcp", port)
+	flag.Parse()
+
+	lis, err := net.Listen("tcp", *listen)
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}

--- a/endpoints/getting-started-grpc/server/main.go
+++ b/endpoints/getting-started-grpc/server/main.go
@@ -45,7 +45,7 @@ import (
 )
 
 var (
-	listen = flag.String("listen", ":50051", "Network interface:port to listen on for gRPC connections.")
+	addr = flag.String("addr", ":50051", "Network host:port to listen on for gRPC connections.")
 )
 
 // server is used to implement helloworld.GreeterServer.
@@ -53,14 +53,14 @@ type server struct{}
 
 // SayHello implements helloworld.GreeterServer
 func (s *server) SayHello(ctx context.Context, in *pb.HelloRequest) (*pb.HelloReply, error) {
-	log.Printf("Handling SayHello request [%s] with context %s", in, ctx)
+	log.Printf("Handling SayHello request [%v] with context %v", in, ctx)
 	return &pb.HelloReply{Message: "Hello " + in.Name}, nil
 }
 
 func main() {
 	flag.Parse()
 
-	lis, err := net.Listen("tcp", *listen)
+	lis, err := net.Listen("tcp", *addr)
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}


### PR DESCRIPTION
 - Add flag to configure the interface used by the server.
 - Add flag to specify an authentication bearer token in the client.
 - Add service configuration for authentication through Google service
   account.
 - Update client to optionally authenticate request using a JWT token
   signed by a Google service account.
 - Add documentation for service account authentication.
 - `gcloud service-management` -> `gcloud endpoints services`

@p-buse @navinger Please take a look. This change adds an example of authentication of a request using a JWT token signed by a Google service account.