### PR TITLE
Prevent nil deref when pubsub topic or sub already exists

### DIFF
--- a/getting-started/bookshelf/pubsub_worker/worker.go
+++ b/getting-started/bookshelf/pubsub_worker/worker.go
@@ -51,7 +51,7 @@ func main() {
 	topic := bookshelf.PubsubClient.Topic(bookshelf.PubsubTopicID)
 	exists, err := topic.Exists(ctx)
 	if err != nil {
-		log.Fatal("Error checking for topic: %v", bookshelf.PubsubTopicID, err)
+		log.Fatalf("Error checking for topic: %v", err)
 	}
 	if !exists {
 		if _, err := bookshelf.PubsubClient.CreateTopic(ctx, bookshelf.PubsubTopicID); err != nil {
@@ -63,7 +63,7 @@ func main() {
 	subscription = bookshelf.PubsubClient.Subscription(subName)
 	exists, err = subscription.Exists(ctx)
 	if err != nil {
-		log.Fatal("Error checking for subscription: %v", subName, err)
+		log.Fatalf("Error checking for subscription: %v", err)
 	}
 	if !exists {
 		if _, err = bookshelf.PubsubClient.CreateSubscription(

--- a/getting-started/bookshelf/pubsub_worker/worker.go
+++ b/getting-started/bookshelf/pubsub_worker/worker.go
@@ -50,7 +50,13 @@ func main() {
 	// ignore returned errors, which will be "already exists". If they're fatal
 	// errors, then following calls (e.g. in the subscribe function) will also fail.
 	topic, _ := bookshelf.PubsubClient.CreateTopic(ctx, bookshelf.PubsubTopicID)
+	if topic == nil {
+		topic = bookshelf.PubsubClient.Topic(bookshelf.PubsubTopicID)
+	}
 	subscription, _ = bookshelf.PubsubClient.CreateSubscription(ctx, subName, pubsub.SubscriptionConfig{Topic: topic})
+	if subscription == nil {
+		subscription = bookshelf.PubsubClient.Subscription(subName)
+	}
 
 	// Start worker goroutine.
 	go subscribe()

--- a/getting-started/bookshelf/pubsub_worker/worker.go
+++ b/getting-started/bookshelf/pubsub_worker/worker.go
@@ -47,7 +47,7 @@ func main() {
 		log.Fatalf("could not access Google Books API: %v", err)
 	}
 
-	// Create pubsub topic if it does not yet exist
+	// Create pubsub topic if it does not yet exist.
 	topic := bookshelf.PubsubClient.Topic(bookshelf.PubsubTopicID)
 	exists, err := topic.Exists(ctx)
 	if err != nil {
@@ -59,18 +59,14 @@ func main() {
 		}
 	}
 
-	// Create topic subscription if it does not yet exist
+	// Create topic subscription if it does not yet exist.
 	subscription = bookshelf.PubsubClient.Subscription(subName)
 	exists, err = subscription.Exists(ctx)
 	if err != nil {
 		log.Fatalf("Error checking for subscription: %v", err)
 	}
 	if !exists {
-		if _, err = bookshelf.PubsubClient.CreateSubscription(
-			ctx,
-			subName,
-			pubsub.SubscriptionConfig{Topic: topic},
-		); err != nil {
+		if _, err = bookshelf.PubsubClient.CreateSubscription(ctx, subName, pubsub.SubscriptionConfig{Topic: topic}); err != nil {
 			log.Fatalf("Failed to create subscription: %v", err)
 		}
 	}

--- a/getting-started/bookshelf/pubsub_worker/worker.go
+++ b/getting-started/bookshelf/pubsub_worker/worker.go
@@ -47,15 +47,32 @@ func main() {
 		log.Fatalf("could not access Google Books API: %v", err)
 	}
 
-	// ignore returned errors, which will be "already exists". If they're fatal
-	// errors, then following calls (e.g. in the subscribe function) will also fail.
-	topic, _ := bookshelf.PubsubClient.CreateTopic(ctx, bookshelf.PubsubTopicID)
-	if topic == nil {
-		topic = bookshelf.PubsubClient.Topic(bookshelf.PubsubTopicID)
+	// Create pubsub topic if it does not yet exist
+	topic := bookshelf.PubsubClient.Topic(bookshelf.PubsubTopicID)
+	exists, err := topic.Exists(ctx)
+	if err != nil {
+		log.Fatal("Error checking for topic: %v", bookshelf.PubsubTopicID, err)
 	}
-	subscription, _ = bookshelf.PubsubClient.CreateSubscription(ctx, subName, pubsub.SubscriptionConfig{Topic: topic})
-	if subscription == nil {
-		subscription = bookshelf.PubsubClient.Subscription(subName)
+	if !exists {
+		if _, err := bookshelf.PubsubClient.CreateTopic(ctx, bookshelf.PubsubTopicID); err != nil {
+			log.Fatalf("Failed to create topic: %v", err)
+		}
+	}
+
+	// Create topic subscription if it does not yet exist
+	subscription = bookshelf.PubsubClient.Subscription(subName)
+	exists, err = subscription.Exists(ctx)
+	if err != nil {
+		log.Fatal("Error checking for subscription: %v", subName, err)
+	}
+	if !exists {
+		if _, err = bookshelf.PubsubClient.CreateSubscription(
+			ctx,
+			subName,
+			pubsub.SubscriptionConfig{Topic: topic},
+		); err != nil {
+			log.Fatalf("Failed to create subscription: %v", err)
+		}
 	}
 
 	// Start worker goroutine.


### PR DESCRIPTION
Pubsub Create funcs now return nil topic and subscription upon error,
necessating this fix to prevent segfault on subsequent runs.