### PR TITLE
uuid.Must method requires two argments.

### DIFF
--- a/appengine_flexible/analytics/analytics.go
+++ b/appengine_flexible/analytics/analytics.go
@@ -65,7 +65,7 @@ func trackEvent(r *http.Request, category, action, label string, value *uint) er
 		//
 		// Depending on your application, this might want to be associated with the
 		// user in a cookie.
-		"cid": {uuid.Must(uuid.NewV4()).String()},
+		"cid": {uuid.Must(uuid.NewV4(), nil).String()},
 		"t":   {"event"},
 		"ec":  {category},
 		"ea":  {action},

--- a/getting-started/bookshelf/app/app.go
+++ b/getting-started/bookshelf/app/app.go
@@ -212,7 +212,7 @@ func uploadFileFromForm(r *http.Request) (url string, err error) {
 	}
 
 	// random filename, retaining existing extension.
-	name := uuid.Must(uuid.NewV4()).String() + path.Ext(fh.Filename)
+	name := uuid.Must(uuid.NewV4(), nil).String() + path.Ext(fh.Filename)
 
 	ctx := context.Background()
 	w := bookshelf.StorageBucket.Object(name).NewWriter(ctx)

--- a/getting-started/bookshelf/app/auth.go
+++ b/getting-started/bookshelf/app/auth.go
@@ -40,7 +40,7 @@ func init() {
 
 // loginHandler initiates an OAuth flow to authenticate the user.
 func loginHandler(w http.ResponseWriter, r *http.Request) *appError {
-	sessionID := uuid.Must(uuid.NewV4()).String()
+	sessionID := uuid.Must(uuid.NewV4(), nil).String()
 
 	oauthFlowSession, err := bookshelf.SessionStore.New(r, sessionID)
 	if err != nil {


### PR DESCRIPTION
I build `getting-started/bookshelf` by docker after modified config.go.

```diff
$ git diff config.go| grep ^+
+++ b/getting-started/bookshelf/config.go
+	DB, err = configureDatastoreDB("project-id")
+	StorageBucketName = "project-id"
+	StorageBucket, err = configureStorage(StorageBucketName)
+	PubsubClient, err = configurePubsub("project-id")
```

I got below build log.

```bash
$ docker build -t gcr.io/<my-project-id>/bookshelf .
...
go get -v github.com/GoogleCloudPlatform/golang-samples/getting-started/bookshelf/...
# github.com/GoogleCloudPlatform/golang-samples/getting-started/bookshelf/app
src/github.com/GoogleCloudPlatform/golang-samples/getting-started/bookshelf/app/app.go:215:19: not enough arguments in call to uuid.Must
	have (uuid.UUID)
	want (uuid.UUID, error)
src/github.com/GoogleCloudPlatform/golang-samples/getting-started/bookshelf/app/auth.go:43:24: not enough arguments in call to uuid.Must
	have (uuid.UUID)
	want (uuid.UUID, error)
```


`uuid.Must` requires two argments.
https://github.com/satori/go.uuid/blob/36e9d2ebbde5e3f13ab2e25625fd453271d6522e/uuid.go#L156-L161

```go
func Must(u UUID, err error) UUID {
	if err != nil {
		panic(err)
	}
	return u
}
```
I added argument to all `uuid.Must` calls.
```bash
$ egrep -nr  'uuid.Must'. ./
.//appengine_flexible/analytics/analytics.go:68:		"cid": {uuid.Must(uuid.NewV4()).String()},
.//getting-started/bookshelf/app/app.go:215:	name := uuid.Must(uuid.NewV4(), nil).String() + path.Ext(fh.Filename)
.//getting-started/bookshelf/app/auth.go:43:	sessionID := uuid.Must(uuid.NewV4(), nil).String()
```