### PR TITLE
bookshelf: fix format of appErrorf call

### DIFF
--- a/getting-started/bookshelf/app/template.go
+++ b/getting-started/bookshelf/app/template.go
@@ -56,7 +56,7 @@ func (tmpl *appTemplate) Execute(w http.ResponseWriter, r *http.Request, data in
 	}
 
 	if err := tmpl.t.Execute(w, d); err != nil {
-		return appErrorf(err, "could not write template: %v")
+		return appErrorf(err, "could not write template: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #404.

Without this change, the underlying template error is not printed when the template fails to Execute.