### PR TITLE
Add 1.10.x to Travis build versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ branches:
 matrix:
   include:
     - go: 1.6.x
-    - go: 1.7.x
     - go: 1.8.x
     - go: 1.9.x
     - go: 1.10.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,13 +60,13 @@ before_install:
     ./testing/travis/configure_gcloud.bash;
   fi
 - '! grep -R ''"context"$'' * || { echo "Use golang.org/x/net/context"; false; }'
-- go vet ./...
-- diff -u <(echo -n) <(gofmt -d -s .)
 
 install:
 # Install all external dependencies, ensuring they are updated.
 - GO_IMPORTS=$(go list -f '{{join .Imports "\n"}}{{"\n"}}{{join .TestImports "\n"}}' ./... | sort | uniq | grep -v golang-samples)
 - go get -u -v -d $GO_IMPORTS
+- go vet ./...
+- diff -u <(echo -n) <(gofmt -d -s .)
 # pin go-sql-driver/mysql to v1.3 (which supports Go 1.6)
 - if go version | grep go1\.6\.; then
     pushd $GOPATH/src/github.com/go-sql-driver/mysql;

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
     - go: 1.7.x
     - go: 1.8.x
     - go: 1.9.x
+    - go: 1.10.x
       env: ALLOW_E2E=true # Don't run e2e tests more than once.
     # NOTE: no tip, see https://github.com/travis-ci/gimme/issues/38
 


### PR DESCRIPTION
`1.10` would be interpreted as a float, but I think `1.10.x` is OK without quotes. Will confirm with the auto-Travis run on this PR.