### PR TITLE
speech: add sample for streaming transcription from file

### DIFF
--- a/speech/livecaption_from_file/README.md
+++ b/speech/livecaption_from_file/README.md
@@ -1,0 +1,32 @@
+# Google Cloud Speech API Go example
+
+## Authentication
+
+* Create a project with the [Google Cloud Console][cloud-console], and enable
+  the [Speech API][speech-api].
+* From the Cloud Console, create a service account,
+  download its json credentials file, then set the 
+  `GOOGLE_APPLICATION_CREDENTIALS` environment variable:
+
+  ```bash
+  export GOOGLE_APPLICATION_CREDENTIALS=/path/to/your-project-credentials.json
+  ```
+
+[cloud-console]: https://console.cloud.google.com
+[speech-api]: https://console.cloud.google.com/apis/api/speech.googleapis.com/overview?project=_
+[adc]: https://cloud.google.com/docs/authentication#developer_workflow
+
+## Run the sample
+
+Before running any example you must first install the Speech API client:
+
+```bash
+go get -u cloud.google.com/go/speech/apiv1
+```
+
+To run the example with one of a sample audio file:
+
+```bash
+go build
+livecaption_from_file ../testdata/audio.raw
+```

--- a/speech/livecaption_from_file/livecaption_from_file.go
+++ b/speech/livecaption_from_file/livecaption_from_file.go
@@ -1,0 +1,108 @@
+// Copyright 2018 Google Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+// Command livecaption_from_file streams a local audio file to
+// Google Speech API and outputs the transcript.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+
+	speech "cloud.google.com/go/speech/apiv1"
+	"golang.org/x/net/context"
+	speechpb "google.golang.org/genproto/googleapis/cloud/speech/v1"
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: %s <AUDIOFILE>\n", filepath.Base(os.Args[0]))
+		fmt.Fprintf(os.Stderr, "<AUDIOFILE> must be a path to a local audio file. Audio file must be a 16-bit signed little-endian encoded with a sample rate of 16000.\n")
+
+	}
+	flag.Parse()
+	if len(flag.Args()) != 1 {
+		log.Fatal("Please pass path to your local audio file as a command line argument")
+	}
+	audioFile := flag.Arg(0)
+
+	ctx := context.Background()
+
+	// [START speech_streaming_file_recognize]
+	client, err := speech.NewClient(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	stream, err := client.StreamingRecognize(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Send the initial configuration message.
+	if err := stream.Send(&speechpb.StreamingRecognizeRequest{
+		StreamingRequest: &speechpb.StreamingRecognizeRequest_StreamingConfig{
+			StreamingConfig: &speechpb.StreamingRecognitionConfig{
+				Config: &speechpb.RecognitionConfig{
+					Encoding:        speechpb.RecognitionConfig_LINEAR16,
+					SampleRateHertz: 16000,
+					LanguageCode:    "en-US",
+				},
+			},
+		},
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	f, err := os.Open(audioFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+
+	go func() {
+		buf := make([]byte, 1024)
+		for {
+			n, err := f.Read(buf)
+			if err == io.EOF {
+				// Nothing else to pipe, close the stream.
+				if err := stream.CloseSend(); err != nil {
+					log.Fatalf("Could not close stream: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				log.Printf("Could not read from %s: %v", audioFile, err)
+				continue
+			}
+			if err = stream.Send(&speechpb.StreamingRecognizeRequest{
+				StreamingRequest: &speechpb.StreamingRecognizeRequest_AudioContent{
+					AudioContent: buf[:n],
+				},
+			}); err != nil {
+				log.Printf("Could not send audio: %v", err)
+			}
+		}
+	}()
+
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			log.Fatalf("Cannot stream results: %v", err)
+		}
+		if err := resp.Error; err != nil {
+			log.Fatalf("Could not recognize: %v", err)
+		}
+		for _, result := range resp.Results {
+			fmt.Printf("Result: %+v\n", result)
+		}
+	}
+	// [END speech_streaming_file_recognize]
+}


### PR DESCRIPTION
[This documentation](https://cloud.google.com/speech/docs/streaming-recognize) is missing a go sample for streaming Speech API requests from a local file.

Although I hope that we can eventually do away with that particular sample altogether (in *all* languages), this pull request is intended to fill the gap. It is a rather straightforward adaptation of the sample in [speech/livecaption](https://github.com/GoogleCloudPlatform/golang-samples/tree/master/speech/livecaption).

Some notes:

+ Given the relatively low value of this sample, I have not worried about supporting GCS reads.

+ Created a new directory to match the structure of the [corresponding Python samples](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/speech/cloud-client/transcribe_streaming.py). Didn't want to muddy up the code with a lot of `flag` stuff.