### PR TITLE
endpoints: add managed rollout

### DIFF
--- a/endpoints/getting-started-grpc/README.md
+++ b/endpoints/getting-started-grpc/README.md
@@ -60,7 +60,7 @@ gcloud container builds submit --tag gcr.io/YOUR_PROJECT_ID/go-grpc-hello:1.0 .
     gcloud compute ssh grpc-host
     ```
 
-1. Set some environment variables (you'll need to manually set the service config ID):
+1. Set some environment variables:
 
     ```bash
     GOOGLE_CLOUD_PROJECT=$(curl -s "http://metadata.google.internal/computeMetadata/v1/project/project-id" -H "Metadata-Flavor: Google")
@@ -142,7 +142,7 @@ This sample shows how to make requests authenticated by a service account using 
 
 1. First, [create a service account](https://console.developers.google.com/apis/credentials)
 
-1. Edit `api_config_auth.yaml`. Replace `PROJECT_ID`.
+1. Edit `api_config_auth.yaml`. Replace `PROJECT_ID` and `SERVICE-ACCOUNT-ID`.
 
 1. Update the service configuration using `api_config_auth.yaml` instead of `api_config.yaml`:
 

--- a/endpoints/getting-started-grpc/README.md
+++ b/endpoints/getting-started-grpc/README.md
@@ -41,15 +41,6 @@ $ go run client/main.go
     gcloud endpoints services deploy out.pb api_config.yaml
     ```
 
-    Your config ID should be printed out, it looks like `2017-03-30r0`.
-    Take a note of it, you'll need it later.
-
-    You can list the config IDs using this command:
-
-    ```bash
-    gcloud endpoints configs list --service hellogrpc.endpoints.YOUR_PROJECT_ID.cloud.goog
-    ```
-
 ## Building the server's Docker container
 
 Build and tag your gRPC server, storing it in your private container registry:
@@ -74,7 +65,6 @@ gcloud container builds submit --tag gcr.io/YOUR_PROJECT_ID/go-grpc-hello:1.0 .
     ```bash
     GOOGLE_CLOUD_PROJECT=$(curl -s "http://metadata.google.internal/computeMetadata/v1/project/project-id" -H "Metadata-Flavor: Google")
     SERVICE_NAME=hellogrpc.endpoints.${GOOGLE_CLOUD_PROJECT}.cloud.goog
-    SERVICE_CONFIG_ID=<Your Config ID>
     ```
 
 1. Pull your credentials to access your private container registry:
@@ -99,7 +89,7 @@ gcloud container builds submit --tag gcr.io/YOUR_PROJECT_ID/go-grpc-hello:1.0 .
         --link=grpc-hello:grpc-hello \
         gcr.io/endpoints-release/endpoints-runtime:1 \
         --service=${SERVICE_NAME} \
-        --version=${SERVICE_CONFIG_ID} \
+        --rollout_strategy=managed \
         --http2_port=9000 \
         --backend=grpc://grpc-hello:50051
     ```
@@ -116,7 +106,7 @@ gcloud container builds submit --tag gcr.io/YOUR_PROJECT_ID/go-grpc-hello:1.0 .
 
 If you haven't got a cluster, first [create one](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-container-cluster).
 
-1. Edit `deployment.yaml`. Replace `<YOUR_PROJECT_ID>` and `<SERVICE_CONFIG_ID>`.
+1. Edit `deployment.yaml`. Replace `<YOUR_PROJECT_ID>`.
 
 1. Create the deployment and service:
 
@@ -152,7 +142,7 @@ This sample shows how to make requests authenticated by a service account using 
 
 1. First, [create a service account](https://console.developers.google.com/apis/credentials)
 
-1. Edit `api_config_auth.yaml`. Replace `PROJECT_ID` and `SERVICE-ACCOUNT-ID`.
+1. Edit `api_config_auth.yaml`. Replace `PROJECT_ID`.
 
 1. Update the service configuration using `api_config_auth.yaml` instead of `api_config.yaml`:
 

--- a/endpoints/getting-started-grpc/deployment.yaml
+++ b/endpoints/getting-started-grpc/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           "-P", "9000",
           "-a", "grpc://127.0.0.1:50051",
           "-s", "hellogrpc.endpoints.<YOUR_PROJECT_ID>.cloud.goog", # replace <YOUR_PROJECT_ID>
-          "--rollout_strategy", "managed", # e.g. "2017-03-30r0"
+          "--rollout_strategy", "managed",
         ]
         ports:
           - containerPort: 9000

--- a/endpoints/getting-started-grpc/deployment.yaml
+++ b/endpoints/getting-started-grpc/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           "-P", "9000",
           "-a", "grpc://127.0.0.1:50051",
           "-s", "hellogrpc.endpoints.<YOUR_PROJECT_ID>.cloud.goog", # replace <YOUR_PROJECT_ID>
-          "-v", "<SERVICE_CONFIG_ID>", # e.g. "2017-03-30r0"
+          "--rollout_strategy", "managed", # e.g. "2017-03-30r0"
         ]
         ports:
           - containerPort: 9000

--- a/endpoints/getting-started/app.yaml
+++ b/endpoints/getting-started/app.yaml
@@ -6,5 +6,5 @@ endpoints_api_service:
   # The following values are to be replaced by information from the output of
   # 'gcloud endpoints services deploy openapi-appengine.yaml' command.
   name: ENDPOINTS-SERVICE-NAME
-  config_id: ENDPOINTS-CONFIG-ID
+  rollout_strategy: managed
 # [END configuration]

--- a/endpoints/getting-started/deployment.yaml
+++ b/endpoints/getting-started/deployment.yaml
@@ -45,7 +45,7 @@ spec:
           "--http_port", "8081",
           "--backend", "127.0.0.1:8080",
           "--service", "SERVICE_NAME",
-          "--version", "SERVICE_CONFIG_ID",
+          "--rollout_strategy", "managed",
         ]
       # [END esp]
         ports:


### PR DESCRIPTION
We introduce a new feature where we can specify in YAML that service configuration for Endpoints is going to be managed. This means that the service will pull latest deployed service configuration automatically, rather than requiring customer to specify specific version of service configuration.

New flag:
**--rollout_strategy=managed**
Previously the only way to specify a version was using the following flag:
**--version=SERVICE_CONFIG_ID**