### PR TITLE
appengine_flexible/redis: use new redigo dep path

### DIFF
--- a/appengine_flexible/redis/redis.go
+++ b/appengine_flexible/redis/redis.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 
 	"google.golang.org/appengine"
 )


### PR DESCRIPTION
Fixes #421.