### PR TITLE
appengine_flexible/postgres: only build on Go 1.8+

### DIFF
--- a/appengine_flexible/cloudsql_postgres/cloudsql.go
+++ b/appengine_flexible/cloudsql_postgres/cloudsql.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+// +build go1.8
+
 // Sample cloudsql demonstrates usage of Cloud SQL from App Engine flexible environment.
 package main
 


### PR DESCRIPTION
https://github.com/lib/pq dropped support for Go versions < 1.8. See https://github.com/lib/pq/pull/729.