### PR TITLE
typo in app.yaml blocking deployment to app engine

### DIFF
--- a/getting-started/bookshelf/app/app.yaml
+++ b/getting-started/bookshelf/app/app.yaml
@@ -1,6 +1,6 @@
 runtime: go
 env: flex
-api_version: 1
+api_version: go1
 
 env_variables:
   OAUTH2_CALLBACK: https://<your-project-id>.appspot.com/oauth2callback

--- a/getting-started/bookshelf/pubsub_worker/app.yaml
+++ b/getting-started/bookshelf/pubsub_worker/app.yaml
@@ -1,6 +1,6 @@
 runtime: go
 env: flex
-api_version: 1
+api_version: go1
 service: worker
 
 resources:


### PR DESCRIPTION
results in:

```
------------------------------------ STDERR ------------------------------------
2018/03/31 16:27:35 invalid api_version value 1
--------------------------------------------------------------------------------
```

otherwise