### PR TITLE
kokoro: add basic config and build script

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+set -x
+
+rm -rf $GOPATH/src/github.com/go-sql-driver/mysql
+
+cd ${KOKORO_ARTIFACTS_DIR}/github/golang-samples
+
+GO_IMPORTS=$(go list -f '{{join .Imports "\n"}}{{"\n"}}{{join .TestImports "\n"}}' ./... | sort | uniq | grep -v golang-samples)
+go get -u -v -d $GO_IMPORTS
+
+# pin go-sql-driver/mysql to v1.3 (which supports Go 1.6)
+if go version | grep go1\.6\.; then
+  pushd $GOPATH/src/github.com/go-sql-driver/mysql;
+  git checkout v1.3;
+  popd;
+fi
+
+go install -v $GO_IMPORTS
+go get -u -v github.com/rakyll/gotest
+
+# Basic build to test Kokoro configuration.
+go build

--- a/.kokoro/system_tests.cfg
+++ b/.kokoro/system_tests.cfg
@@ -1,0 +1,3 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+build_file: "golang-samples/.kokoro/build.sh"


### PR DESCRIPTION
I'll expand this to get secrets and run tests after builds are working.

Part of #440.