### PR TITLE
vision: make detect test more robust

### DIFF
--- a/vision/detect/detect_test.go
+++ b/vision/detect/detect_test.go
@@ -33,7 +33,7 @@ func TestDetect(t *testing.T) {
 		{"FullText", detectDocumentText, detectDocumentTextURI, "text.jpg", "Preparing to install"},
 		{"Crop", detectCropHints, detectCropHintsURI, "wakeupcat.jpg", "(0,0)"},
 		{"Web", detectWeb, detectWebURI, "wakeupcat.jpg", "Web properties"},
-		{"WebGeo", nil, detectWebGeoURI, "city.jpg", "Zepra"},
+		{"WebGeo", nil, detectWebGeoURI, "city.jpg", "Building"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
"Zepra" is not always in the output. But, "Building" seems to be consistent. My local tests get a different result than (some projects in) Travis, so maybe there is a new model rolling out which changes the detect result.