### PR TITLE
getting-started: remove erroneous api_version field

### DIFF
--- a/getting-started/bookshelf/app/app.yaml
+++ b/getting-started/bookshelf/app/app.yaml
@@ -1,6 +1,5 @@
 runtime: go
 env: flex
-api_version: go1
 
 env_variables:
   OAUTH2_CALLBACK: https://<your-project-id>.appspot.com/oauth2callback

--- a/getting-started/bookshelf/pubsub_worker/app.yaml
+++ b/getting-started/bookshelf/pubsub_worker/app.yaml
@@ -1,6 +1,5 @@
 runtime: go
 env: flex
-api_version: go1
 service: worker
 
 resources:

--- a/getting-started/helloworld/app.yaml
+++ b/getting-started/helloworld/app.yaml
@@ -1,5 +1,4 @@
 # [START runtime]
 runtime: go
-api_version: go1
 env: flex
 # [END runtime]


### PR DESCRIPTION
This is only used for GAE standard. This app is deployed on GAE flex.