### PR TITLE
Fix a typo in firestore snippet code marker

### DIFF
--- a/firestore/firestore_snippets/query.go
+++ b/firestore/firestore_snippets/query.go
@@ -44,7 +44,7 @@ func createQuery(client *firestore.Client) {
 func createQueryTwo(client *firestore.Client) {
 	// [START fs_create_query_two]
 	query := client.Collection("cities").Where("state", "==", "CA")
-	// [END fs_create_qiery_two]
+	// [END fs_create_query_two]
 	_ = query
 }
 


### PR DESCRIPTION
The typo breaks the rendering of the corresponding code snippet in the "Simple queries" section of this page: https://firebase.google.com/docs/firestore/query-data/queries