### PR TITLE
pubsub/subscriptions: Ack all 10 messages

### DIFF
--- a/pubsub/subscriptions/main.go
+++ b/pubsub/subscriptions/main.go
@@ -113,14 +113,13 @@ func pullMsgs(client *pubsub.Client, name string, topic *pubsub.Topic) error {
 	err := sub.Receive(cctx, func(ctx context.Context, msg *pubsub.Message) {
 		mu.Lock()
 		defer mu.Unlock()
+		msg.Ack()
+		fmt.Printf("Got message: %q\n", string(msg.Data))
 		received++
-		if received >= 10 {
+		if received == 10 {
 			cancel()
-			msg.Nack()
 			return
 		}
-		fmt.Printf("Got message: %q\n", string(msg.Data))
-		msg.Ack()
 	})
 	if err != nil {
 		return err

--- a/pubsub/subscriptions/main.go
+++ b/pubsub/subscriptions/main.go
@@ -111,14 +111,13 @@ func pullMsgs(client *pubsub.Client, name string, topic *pubsub.Topic) error {
 	sub := client.Subscription(name)
 	cctx, cancel := context.WithCancel(ctx)
 	err := sub.Receive(cctx, func(ctx context.Context, msg *pubsub.Message) {
-		mu.Lock()
-		defer mu.Unlock()
 		msg.Ack()
 		fmt.Printf("Got message: %q\n", string(msg.Data))
+		mu.Lock()
+		defer mu.Unlock()
 		received++
 		if received == 10 {
 			cancel()
-			return
 		}
 	})
 	if err != nil {


### PR DESCRIPTION
Fixes #402.

The mutex should prevent skipping over 10 and never calling `cancel()` and `return`.