### PR TITLE
storage/buckets: use ProjectID for test buckets

### DIFF
--- a/storage/buckets/main.go
+++ b/storage/buckets/main.go
@@ -78,7 +78,7 @@ func main() {
 	}
 
 	// delete the bucket
-	if err := delete(client, name); err != nil {
+	if err := deleteBucket(client, name); err != nil {
 		log.Fatal(err)
 	}
 	fmt.Printf("deleted bucket: %v\n", name)
@@ -127,7 +127,7 @@ func list(client *storage.Client, projectID string) ([]string, error) {
 	return buckets, nil
 }
 
-func delete(client *storage.Client, bucketName string) error {
+func deleteBucket(client *storage.Client, bucketName string) error {
 	ctx := context.Background()
 	// [START delete_bucket]
 	if err := client.Bucket(bucketName).Delete(ctx); err != nil {

--- a/storage/buckets/main_test.go
+++ b/storage/buckets/main_test.go
@@ -41,7 +41,7 @@ func TestCreateWithAttrs(t *testing.T) {
 	tc := testutil.SystemTest(t)
 	name := bucketName + "-attrs"
 	// Clean up bucket before running test.
-	deleteBucket(storageClient, bucketName+"-attrs")
+	deleteBucket(storageClient, name)
 	if err := createWithAttrs(storageClient, tc.ProjectID, name); err != nil {
 		t.Fatalf("failed to create bucket (%q): %v", name, err)
 	}
@@ -73,6 +73,7 @@ outer:
 }
 
 func TestIAM(t *testing.T) {
+	testutil.SystemTest(t)
 	if _, err := getPolicy(storageClient, bucketName); err != nil {
 		t.Errorf("getPolicy: %#v", err)
 	}
@@ -85,6 +86,7 @@ func TestIAM(t *testing.T) {
 }
 
 func TestRequesterPays(t *testing.T) {
+	testutil.SystemTest(t)
 	if err := enableRequesterPays(storageClient, bucketName); err != nil {
 		t.Errorf("enableRequesterPay: %#v", err)
 	}
@@ -97,6 +99,7 @@ func TestRequesterPays(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
+	testutil.SystemTest(t)
 	if err := deleteBucket(storageClient, bucketName); err != nil {
 		t.Fatalf("failed to delete bucket (%q): %v", bucketName, err)
 	}

--- a/storage/buckets/main_test.go
+++ b/storage/buckets/main_test.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"log"
 	"testing"
 	"time"
 
@@ -27,7 +26,7 @@ func TestCreate(t *testing.T) {
 	var err error
 	storageClient, err = storage.NewClient(ctx)
 	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
+		t.Fatalf("failed to create client: %v", err)
 	}
 
 	bucketName = tc.ProjectID + "-storage-buckets-tests"


### PR DESCRIPTION
If two different projects happen to use the same bucket name, race
conditions may cause tests to fail.

This also deletes any buckets before using them for tests. If the
buckets already exist, they will cause TestCreate to fail and may have
the wrong permissions.

I don't particularly like using `TestMain`, but it seems like the cleanest way to delete the buckets before starting.