### PR TITLE
testing/kokoro: add builds for Go 1.6, 1.8, & 1.9

### DIFF
--- a/testing/kokoro/go16.cfg
+++ b/testing/kokoro/go16.cfg
@@ -1,0 +1,7 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/golang-samples-tests/go16"
+}

--- a/testing/kokoro/go18.cfg
+++ b/testing/kokoro/go18.cfg
@@ -1,0 +1,7 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/golang-samples-tests/go18"
+}

--- a/testing/kokoro/go19.cfg
+++ b/testing/kokoro/go19.cfg
@@ -1,0 +1,7 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/golang-samples-tests/go19"
+}


### PR DESCRIPTION
1.10 will be added later since it fails the gofmt check right now. Part of issue #440. See #406 for 1.10.