### PR TITLE
dlp: sleep before getting jobs

### DIFF
--- a/dlp/dlp_snippets/risk.go
+++ b/dlp/dlp_snippets/risk.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"strings"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -115,6 +116,7 @@ func riskNumerical(w io.Writer, client *dlp.Client, project, dataProject, pubSub
 			return
 		}
 		msg.Ack()
+		time.Sleep(500 * time.Millisecond)
 		resp, err := client.GetDlpJob(ctx, &dlppb.GetDlpJobRequest{
 			Name: j.GetName(),
 		})
@@ -212,6 +214,7 @@ func riskCategorical(w io.Writer, client *dlp.Client, project, dataProject, pubS
 			return
 		}
 		msg.Ack()
+		time.Sleep(500 * time.Millisecond)
 		resp, err := client.GetDlpJob(ctx, &dlppb.GetDlpJobRequest{
 			Name: j.GetName(),
 		})
@@ -314,6 +317,7 @@ func riskKAnonymity(w io.Writer, client *dlp.Client, project, dataProject, pubSu
 			return
 		}
 		msg.Ack()
+		time.Sleep(500 * time.Millisecond)
 		j, err := client.GetDlpJob(ctx, &dlppb.GetDlpJobRequest{
 			Name: j.GetName(),
 		})
@@ -423,6 +427,7 @@ func riskLDiversity(w io.Writer, client *dlp.Client, project, dataProject, pubSu
 			return
 		}
 		msg.Ack()
+		time.Sleep(500 * time.Millisecond)
 		j, err := client.GetDlpJob(ctx, &dlppb.GetDlpJobRequest{
 			Name: j.GetName(),
 		})
@@ -540,6 +545,7 @@ func riskKMap(w io.Writer, client *dlp.Client, project, dataProject, pubSubTopic
 			return
 		}
 		msg.Ack()
+		time.Sleep(500 * time.Millisecond)
 		j, err := client.GetDlpJob(ctx, &dlppb.GetDlpJobRequest{
 			Name: j.GetName(),
 		})


### PR DESCRIPTION
Sometimes, GetDlpJob reads a stale version of the job DB. Sleeping for
half a second after receiving the job finished message should prevent
not getting any results. In particular, this should reduce test
flakiness.