### PR TITLE
testing/kokoro: only run gofmt & go vet on Go 1.9

### DIFF
--- a/testing/kokoro/go19.cfg
+++ b/testing/kokoro/go19.cfg
@@ -5,3 +5,9 @@ env_vars: {
     key: "TRAMPOLINE_IMAGE"
     value: "gcr.io/golang-samples-tests/go19"
 }
+
+# Check `go vet` and `gofmt`.
+env_vars: {
+    key: "GOLANG_SAMPLES_GO_VET"
+    value: "1"
+}

--- a/testing/kokoro/system_tests.sh
+++ b/testing/kokoro/system_tests.sh
@@ -36,8 +36,10 @@ mv github/golang-samples $target
 cd $target/golang-samples
 
 # Do the easy stuff first. Fail fast!
-diff -u <(echo -n) <(gofmt -d -s .)
-go vet ./...
+if [ $GOLANG_SAMPLES_GO_VET ]; then
+  diff -u <(echo -n) <(gofmt -d -s .)
+  go vet ./...
+fi
 
 # Check use of Go 1.7 context package
 ! grep -R '"context"$' * || { echo "Use golang.org/x/net/context"; false; }


### PR DESCRIPTION
Running `gofmt` and `go vet` on every version can lead to conflicts when the tools change. We should only run them for the latest version of Go.

See #406 and #440.