### PR TITLE
trace, opencensus: import Stackdriver exporter from the new path

### DIFF
--- a/opencensus/opencensus_spanner_quickstart/main.go
+++ b/opencensus/opencensus_spanner_quickstart/main.go
@@ -13,7 +13,7 @@ import (
 	"log"
 
 	"cloud.google.com/go/spanner"
-	"go.opencensus.io/exporter/stackdriver"
+	"contrib.go.opencensus.io/exporter/stackdriver"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/trace"
 	"golang.org/x/net/context"

--- a/trace/trace_quickstart/main.go
+++ b/trace/trace_quickstart/main.go
@@ -13,8 +13,8 @@ import (
 	"log"
 	"net/http"
 
-	"go.opencensus.io/exporter/stackdriver"
-	"go.opencensus.io/exporter/stackdriver/propagation"
+	"contrib.go.opencensus.io/exporter/stackdriver"
+	"contrib.go.opencensus.io/exporter/stackdriver/propagation"
 	"go.opencensus.io/plugin/ochttp"
 	"go.opencensus.io/trace"
 )


### PR DESCRIPTION
A follow up to:
https://github.com/census-instrumentation/opencensus-go/pull/724