### PR TITLE
 BigQuery sample updates and region tag changes.

### DIFF
--- a/bigquery/simpleapp/simpleapp.go
+++ b/bigquery/simpleapp/simpleapp.go
@@ -61,7 +61,6 @@ func query(proj string) (*bigquery.RowIterator, error) {
 		LIMIT 10;`)
 	return query.Read(ctx)
 	// [END bigquery_simple_app_query]
-
 }
 
 // [START bigquery_simple_app_print]
@@ -87,4 +86,4 @@ func printResults(w io.Writer, iter *bigquery.RowIterator) error {
 }
 
 // [END bigquery_simple_app_print]
-// [START bigquery_simple_app_all]
+// [END bigquery_simple_app_all]

--- a/bigquery/simpleapp/simpleapp.go
+++ b/bigquery/simpleapp/simpleapp.go
@@ -5,6 +5,7 @@
 // Command simpleapp queries the Stack Overflow public dataset in Google BigQuery.
 package main
 
+// [START bigquery_simple_app_all]
 // [START bigquery_simple_app_deps]
 import (
 	"fmt"
@@ -47,6 +48,7 @@ func query(proj string) (*bigquery.RowIterator, error) {
 	}
 	// [END bigquery_simple_app_client]
 
+	// [START bigquery_simple_app_query]
 	query := client.Query(
 		`SELECT
 			CONCAT(
@@ -58,6 +60,8 @@ func query(proj string) (*bigquery.RowIterator, error) {
 		ORDER BY view_count DESC
 		LIMIT 10;`)
 	return query.Read(ctx)
+	// [END bigquery_simple_app_query]
+
 }
 
 // [START bigquery_simple_app_print]
@@ -83,3 +87,4 @@ func printResults(w io.Writer, iter *bigquery.RowIterator) error {
 }
 
 // [END bigquery_simple_app_print]
+// [START bigquery_simple_app_all]

--- a/bigquery/snippets/snippet.go
+++ b/bigquery/snippets/snippet.go
@@ -379,6 +379,67 @@ func exportToGCS(client *bigquery.Client, datasetID, tableID, gcsURI string) err
 	return nil
 }
 
+func exportSampleTableAsCSV(client *bigquery.Client, gcsURI string) error {
+	ctx := context.Background()
+	// [START bigquery_extract_table]
+	srcProject := "bigquery-public-data"
+	srcDataset := "samples"
+	srcTable := "shakespeare"
+
+	// For example, gcsUri = "gs://mybucket/shakespeare.csv"
+	gcsRef := bigquery.NewGCSReference(gcsURI)
+	gcsRef.FieldDelimiter = ","
+
+	extractor := client.DatasetInProject(srcProject, srcDataset).Table(srcTable).ExtractorTo(gcsRef)
+	extractor.DisableHeader = true
+	// run the job in the US location
+	extractor.Location = "US"
+
+	job, err := extractor.Run(ctx)
+	if err != nil {
+		return err
+	}
+	status, err := job.Wait(ctx)
+	if err != nil {
+		return err
+	}
+	if err := status.Err(); err != nil {
+		return err
+	}
+	// [END bigquery_extract_table]
+	return nil
+}
+
+func exportSampleTableAsJSON(client *bigquery.Client, gcsURI string) error {
+	ctx := context.Background()
+	// [START bigquery_extract_table_json]
+	srcProject := "bigquery-public-data"
+	srcDataset := "samples"
+	srcTable := "shakespeare"
+
+	// For example, gcsUri = "gs://mybucket/shakespeare.json"
+	gcsRef := bigquery.NewGCSReference(gcsURI)
+	gcsRef.DestinationFormat = bigquery.JSON
+
+	extractor := client.DatasetInProject(srcProject, srcDataset).Table(srcTable).ExtractorTo(gcsRef)
+	// run the job in the US location
+	extractor.Location = "US"
+
+	job, err := extractor.Run(ctx)
+	if err != nil {
+		return err
+	}
+	status, err := job.Wait(ctx)
+	if err != nil {
+		return err
+	}
+	if err := status.Err(); err != nil {
+		return err
+	}
+	// [END bigquery_extract_table_json]
+	return nil
+}
+
 func importJSONExplicitSchema(client *bigquery.Client, datasetID, tableID string) error {
 	ctx := context.Background()
 	// [START bigquery_load_table_gcs_json]

--- a/bigquery/snippets/snippet.go
+++ b/bigquery/snippets/snippet.go
@@ -20,7 +20,7 @@ func createDataset(client *bigquery.Client, datasetID string) error {
 	ctx := context.Background()
 	// [START bigquery_create_dataset]
 	meta := &bigquery.DatasetMetadata{
-		Location: "US", // Create the dataset in the US
+		Location: "US", // Create the dataset in the US.
 	}
 	if err := client.Dataset(datasetID).Create(ctx, meta); err != nil {
 		return err
@@ -73,7 +73,7 @@ func updateDatasetAccessControl(client *bigquery.Client, datasetID string) error
 	if err != nil {
 		return err
 	}
-	// Append a new access control entry to the existing access list
+	// Append a new access control entry to the existing access list.
 	changes := bigquery.DatasetMetadataToUpdate{
 		Access: append(original.Access, &bigquery.AccessEntry{
 			Role:       bigquery.ReaderRole,
@@ -132,7 +132,7 @@ func (i *Item) Save() (map[string]bigquery.Value, string, error) {
 
 func createTableInferredSchema(client *bigquery.Client, datasetID, tableID string) error {
 	ctx := context.Background()
-	// Demonstrates inferring a BigQuery schema from Go native types
+	// bigquery.InferSchema infers BQ schema from native Go types.
 	schema, err := bigquery.InferSchema(Item{})
 	if err != nil {
 		return err
@@ -147,7 +147,6 @@ func createTableInferredSchema(client *bigquery.Client, datasetID, tableID strin
 func createTableExplicitSchema(client *bigquery.Client, datasetID, tableID string) error {
 	ctx := context.Background()
 	// [START bigquery_create_table]
-	// Represent email_addrs as an array of strings, rather than a single address
 	sampleSchema := bigquery.Schema{
 		{Name: "full_name", Type: bigquery.StringFieldType},
 		{Name: "age", Type: bigquery.IntegerFieldType},
@@ -155,7 +154,7 @@ func createTableExplicitSchema(client *bigquery.Client, datasetID, tableID strin
 
 	metaData := &bigquery.TableMetadata{
 		Schema:         sampleSchema,
-		ExpirationTime: time.Now().AddDate(1, 0, 0), // Table will be automatically deleted in 1 year
+		ExpirationTime: time.Now().AddDate(1, 0, 0), // Table will be automatically deleted in 1 year.
 	}
 	tableRef := client.Dataset(datasetID).Table(tableID)
 	if err := tableRef.Create(ctx, metaData); err != nil {
@@ -186,8 +185,7 @@ func updateTableDescription(client *bigquery.Client, datasetID, tableID string) 
 	newMeta := bigquery.TableMetadataToUpdate{
 		Description: "Updated description.",
 	}
-	_, err = tableRef.Update(ctx, newMeta, original.ETag)
-	if err != nil {
+	if _, err = tableRef.Update(ctx, newMeta, original.ETag); err != nil {
 		return err
 	}
 	// [END bigquery_update_table_description]
@@ -204,10 +202,9 @@ func updateTableExpiration(client *bigquery.Client, datasetID, tableID string) e
 		return err
 	}
 	newMeta := bigquery.TableMetadataToUpdate{
-		ExpirationTime: time.Now().Add(time.Duration(5*24) * time.Hour), // table expiration in 5 days
+		ExpirationTime: time.Now().Add(time.Duration(5*24) * time.Hour), // table expiration in 5 days.
 	}
-	_, err = tableRef.Update(ctx, newMeta, original.ETag)
-	if err != nil {
+	if _, err = tableRef.Update(ctx, newMeta, original.ETag); err != nil {
 		return err
 	}
 	// [END bigquery_update_table_expiration]
@@ -322,7 +319,7 @@ func printTableMetadataSimple(client *bigquery.Client, datasetID, tableID string
 	if err != nil {
 		return err
 	}
-	// Print information about the table
+	// Print basic information about the table.
 	fmt.Printf("Schema has %d top-level fields\n", len(meta.Schema))
 	fmt.Printf("Description: %s\n", meta.Description)
 	fmt.Printf("Row in managed storage: %d\n", meta.NumRows)
@@ -390,8 +387,8 @@ func importCSVFromFile(client *bigquery.Client, datasetID, tableID, filename str
 		return err
 	}
 	source := bigquery.NewReaderSource(f)
-	source.AutoDetect = true   // Allow BigQuery to determine schema
-	source.SkipLeadingRows = 1 // CSV has a single header line
+	source.AutoDetect = true   // Allow BigQuery to determine schema.
+	source.SkipLeadingRows = 1 // CSV has a single header line.
 
 	loader := client.Dataset(datasetID).Table(tableID).LoaderFrom(source)
 
@@ -504,8 +501,8 @@ func exportSampleTableAsCSV(client *bigquery.Client, gcsURI string) error {
 
 	extractor := client.DatasetInProject(srcProject, srcDataset).Table(srcTable).ExtractorTo(gcsRef)
 	extractor.DisableHeader = true
-	// You can choose to run the job in a specific location for more complex data locality scenarios
-	// Ex: In this example, source dataset and GCS bucket are in the US
+	// You can choose to run the job in a specific location for more complex data locality scenarios.
+	// Ex: In this example, source dataset and GCS bucket are in the US.
 	extractor.Location = "US"
 
 	job, err := extractor.Run(ctx)
@@ -536,8 +533,8 @@ func exportSampleTableAsCompressedCSV(client *bigquery.Client, gcsURI string) er
 
 	extractor := client.DatasetInProject(srcProject, srcDataset).Table(srcTable).ExtractorTo(gcsRef)
 	extractor.DisableHeader = true
-	// You can choose to run the job in a specific location for more complex data locality scenarios
-	// Ex: In this example, source dataset and GCS bucket are in the USi
+	// You can choose to run the job in a specific location for more complex data locality scenarios.
+	// Ex: In this example, source dataset and GCS bucket are in the US.
 	extractor.Location = "US"
 
 	job, err := extractor.Run(ctx)
@@ -567,8 +564,8 @@ func exportSampleTableAsJSON(client *bigquery.Client, gcsURI string) error {
 	gcsRef.DestinationFormat = bigquery.JSON
 
 	extractor := client.DatasetInProject(srcProject, srcDataset).Table(srcTable).ExtractorTo(gcsRef)
-	// You can choose to run the job in a specific location for more complex data locality scenarios
-	// Ex: In this example, source dataset and GCS bucket are in the US
+	// You can choose to run the job in a specific location for more complex data locality scenarios.
+	// Ex: In this example, source dataset and GCS bucket are in the US.
 	extractor.Location = "US"
 
 	job, err := extractor.Run(ctx)

--- a/bigquery/snippets/snippet.go
+++ b/bigquery/snippets/snippet.go
@@ -410,6 +410,37 @@ func exportSampleTableAsCSV(client *bigquery.Client, gcsURI string) error {
 	return nil
 }
 
+func exportSampleTableAsCompressedCSV(client *bigquery.Client, gcsURI string) error {
+	ctx := context.Background()
+	// [START bigquery_extract_table_compressed]
+	srcProject := "bigquery-public-data"
+	srcDataset := "samples"
+	srcTable := "shakespeare"
+
+	// For example, gcsUri = "gs://mybucket/shakespeare.csv"
+	gcsRef := bigquery.NewGCSReference(gcsURI)
+	gcsRef.Compression = bigquery.Gzip
+
+	extractor := client.DatasetInProject(srcProject, srcDataset).Table(srcTable).ExtractorTo(gcsRef)
+	extractor.DisableHeader = true
+	// run the job in the US location
+	extractor.Location = "US"
+
+	job, err := extractor.Run(ctx)
+	if err != nil {
+		return err
+	}
+	status, err := job.Wait(ctx)
+	if err != nil {
+		return err
+	}
+	if err := status.Err(); err != nil {
+		return err
+	}
+	// [END bigquery_extract_table_compressed]
+	return nil
+}
+
 func exportSampleTableAsJSON(client *bigquery.Client, gcsURI string) error {
 	ctx := context.Background()
 	// [START bigquery_extract_table_json]

--- a/bigquery/snippets/snippet_test.go
+++ b/bigquery/snippets/snippet_test.go
@@ -72,25 +72,25 @@ func TestAll(t *testing.T) {
 		t.Errorf("listDatasets: %v", err)
 	}
 
-	tblInferredSchema := fmt.Sprintf("golang_example_table_inferred_%d", time.Now().Unix())
-	tblExplicitSchema := fmt.Sprintf("golang_example_table_explicit_%d", time.Now().Unix())
-	tblEmptySchema := fmt.Sprintf("golang_example_table_emptyschema_%d", time.Now().Unix())
+	inferred := fmt.Sprintf("golang_example_table_inferred_%d", time.Now().Unix())
+	explicit := fmt.Sprintf("golang_example_table_explicit_%d", time.Now().Unix())
+	empty := fmt.Sprintf("golang_example_table_emptyschema_%d", time.Now().Unix())
 
-	if err := createTableInferredSchema(client, datasetID, tblInferredSchema); err != nil {
-		t.Errorf("createTableInferredSchema(dataset:%q table:%q): %v", datasetID, tblInferredSchema, err)
+	if err := createTableInferredSchema(client, datasetID, inferred); err != nil {
+		t.Errorf("createTableInferredSchema(dataset:%q table:%q): %v", datasetID, inferred, err)
 	}
-	if err := createTableExplicitSchema(client, datasetID, tblExplicitSchema); err != nil {
-		t.Errorf("createTableExplicitSchema(dataset:%q table:%q): %v", datasetID, tblExplicitSchema, err)
+	if err := createTableExplicitSchema(client, datasetID, explicit); err != nil {
+		t.Errorf("createTableExplicitSchema(dataset:%q table:%q): %v", datasetID, explicit, err)
 	}
-	if err := createTableEmptySchema(client, datasetID, tblEmptySchema); err != nil {
-		t.Errorf("createTableEmptySchema(dataset:%q table:%q): %v", datasetID, tblEmptySchema, err)
+	if err := createTableEmptySchema(client, datasetID, empty); err != nil {
+		t.Errorf("createTableEmptySchema(dataset:%q table:%q): %v", datasetID, empty, err)
 	}
 
-	if err := updateTableDescription(client, datasetID, tblExplicitSchema); err != nil {
-		t.Errorf("updateTableDescription(dataset:%q table:%q): %v", datasetID, tblExplicitSchema, err)
+	if err := updateTableDescription(client, datasetID, explicit); err != nil {
+		t.Errorf("updateTableDescription(dataset:%q table:%q): %v", datasetID, explicit, err)
 	}
-	if err := updateTableExpiration(client, datasetID, tblExplicitSchema); err != nil {
-		t.Errorf("updateTableExpiration(dataset:%q table:%q): %v", datasetID, tblExplicitSchema, err)
+	if err := updateTableExpiration(client, datasetID, explicit); err != nil {
+		t.Errorf("updateTableExpiration(dataset:%q table:%q): %v", datasetID, explicit, err)
 	}
 
 	buf := &bytes.Buffer{}
@@ -98,44 +98,44 @@ func TestAll(t *testing.T) {
 		t.Errorf("listTables(%q): %v", datasetID, err)
 	}
 	// Ensure all three tables are in the list.
-	if got := buf.String(); !strings.Contains(got, tblInferredSchema) {
-		t.Errorf("want table list %q to contain table %q", got, tblInferredSchema)
+	if got := buf.String(); !strings.Contains(got, inferred) {
+		t.Errorf("want table list %q to contain table %q", got, inferred)
 	}
-	if got := buf.String(); !strings.Contains(got, tblExplicitSchema) {
-		t.Errorf("want table list %q to contain table %q", got, tblExplicitSchema)
+	if got := buf.String(); !strings.Contains(got, explicit) {
+		t.Errorf("want table list %q to contain table %q", got, explicit)
 	}
-	if got := buf.String(); !strings.Contains(got, tblEmptySchema) {
-		t.Errorf("want table list %q to contain table %q", got, tblEmptySchema)
+	if got := buf.String(); !strings.Contains(got, empty) {
+		t.Errorf("want table list %q to contain table %q", got, empty)
 	}
 
 	// Stream data, read, query the inferred schema table.
-	if err := insertRows(client, datasetID, tblInferredSchema); err != nil {
-		t.Errorf("insertRows(dataset:%q table:%q): %v", datasetID, tblInferredSchema, err)
+	if err := insertRows(client, datasetID, inferred); err != nil {
+		t.Errorf("insertRows(dataset:%q table:%q): %v", datasetID, inferred, err)
 	}
-	if err := listRows(client, datasetID, tblInferredSchema); err != nil {
-		t.Errorf("listRows(dataset:%q table:%q): %v", datasetID, tblInferredSchema, err)
+	if err := listRows(client, datasetID, inferred); err != nil {
+		t.Errorf("listRows(dataset:%q table:%q): %v", datasetID, inferred, err)
 	}
-	if err := browseTable(client, datasetID, tblInferredSchema); err != nil {
-		t.Errorf("browseTable(dataset:%q table:%q): %v", datasetID, tblInferredSchema, err)
+	if err := browseTable(client, datasetID, inferred); err != nil {
+		t.Errorf("browseTable(dataset:%q table:%q): %v", datasetID, inferred, err)
 	}
-	if err := basicQuery(client, datasetID, tblInferredSchema); err != nil {
-		t.Errorf("basicQuery(dataset:%q table:%q): %v", datasetID, tblInferredSchema, err)
+	if err := basicQuery(client, datasetID, inferred); err != nil {
+		t.Errorf("basicQuery(dataset:%q table:%q): %v", datasetID, inferred, err)
 	}
 
 	// Print information about tables (extended and simple).
-	if err := printTableMetadataSimple(client, datasetID, tblInferredSchema); err != nil {
-		t.Errorf("printTableMetadata(dataset:%q table:%q): %v", datasetID, tblInferredSchema, err)
+	if err := printTableMetadataSimple(client, datasetID, inferred); err != nil {
+		t.Errorf("printTableMetadata(dataset:%q table:%q): %v", datasetID, inferred, err)
 	}
-	if err := printTableMetadataSimple(client, datasetID, tblExplicitSchema); err != nil {
-		t.Errorf("printTableMetadata(dataset:%q table:%q): %v", datasetID, tblExplicitSchema, err)
+	if err := printTableMetadataSimple(client, datasetID, explicit); err != nil {
+		t.Errorf("printTableMetadata(dataset:%q table:%q): %v", datasetID, explicit, err)
 	}
 
 	dstTableID := fmt.Sprintf("golang_example_tabledst_%d", time.Now().Unix())
-	if err := copyTable(client, datasetID, tblInferredSchema, dstTableID); err != nil {
-		t.Errorf("copyTable(dataset:%q src:%q dst:%q): %v", datasetID, tblInferredSchema, dstTableID, err)
+	if err := copyTable(client, datasetID, inferred, dstTableID); err != nil {
+		t.Errorf("copyTable(dataset:%q src:%q dst:%q): %v", datasetID, inferred, dstTableID, err)
 	}
-	if err := deleteTable(client, datasetID, tblInferredSchema); err != nil {
-		t.Errorf("deleteTable(dataset:%q table:%q): %v", datasetID, tblInferredSchema, err)
+	if err := deleteTable(client, datasetID, inferred); err != nil {
+		t.Errorf("deleteTable(dataset:%q table:%q): %v", datasetID, inferred, err)
 	}
 	if err := deleteTable(client, datasetID, dstTableID); err != nil {
 		t.Errorf("deleteTable(dataset:%q table:%q): %v", datasetID, dstTableID, err)

--- a/bigquery/snippets/snippet_test.go
+++ b/bigquery/snippets/snippet_test.go
@@ -113,6 +113,13 @@ func TestAll(t *testing.T) {
 		t.Errorf("asyncQuery(dataset:%q table:%q): %v", datasetID, tblInferredSchema, err)
 	}
 
+	if err := printTableMetadata(client, datasetID, tblInferredSchema); err != nil {
+		t.Errorf("printTableMetadata(dataset:%q table:%q): %v", datasetID, tblInferredSchema, err)
+	}
+	if err := printTableMetadata(client, datasetID, tblExplicitSchema); err != nil {
+		t.Errorf("printTableMetadata(dataset:%q table:%q): %v", datasetID, tblExplicitSchema, err)
+	}
+
 	dstTableID := fmt.Sprintf("golang_example_tabledst_%d", time.Now().Unix())
 	if err := copyTable(client, datasetID, tblInferredSchema, dstTableID); err != nil {
 		t.Errorf("copyTable(dataset:%q src:%q dst:%q): %v", datasetID, tblInferredSchema, dstTableID, err)

--- a/bigquery/snippets/snippet_test.go
+++ b/bigquery/snippets/snippet_test.go
@@ -195,7 +195,7 @@ func TestImportExport(t *testing.T) {
 		t.Errorf("exportSampleTableAsCompressedCSV(%q): %v", gcsURI, err)
 	}
 
-	// extract shakespear sample as newline-delimited JSON
+	// extract shakespeare sample as newline-delimited JSON
 	gcsURI = fmt.Sprintf("gs://%s/%s", bucket, "shakespeare.json")
 	if err := exportSampleTableAsJSON(client, gcsURI); err != nil {
 		t.Errorf("exportSampleTableAsJSON(%q): %v", gcsURI, err)

--- a/bigquery/snippets/snippet_test.go
+++ b/bigquery/snippets/snippet_test.go
@@ -123,7 +123,7 @@ func TestAll(t *testing.T) {
 	}
 
 	// Print information about tables (extended and simple).
-	if err := printTableMetadataExtended(client, datasetID, tblInferredSchema); err != nil {
+	if err := printTableMetadataSimple(client, datasetID, tblInferredSchema); err != nil {
 		t.Errorf("printTableMetadata(dataset:%q table:%q): %v", datasetID, tblInferredSchema, err)
 	}
 	if err := printTableMetadataSimple(client, datasetID, tblExplicitSchema); err != nil {

--- a/bigquery/snippets/snippet_test.go
+++ b/bigquery/snippets/snippet_test.go
@@ -189,6 +189,12 @@ func TestImportExport(t *testing.T) {
 		t.Errorf("exportSampleTableAsCSV(%q): %v", gcsURI, err)
 	}
 
+	// extract shakespeare sample as GZIP-compressed CSV
+	gcsURI = fmt.Sprintf("gs://%s/%s", bucket, "shakespeare.csv.gz")
+	if err := exportSampleTableAsCompressedCSV(client, gcsURI); err != nil {
+		t.Errorf("exportSampleTableAsCompressedCSV(%q): %v", gcsURI, err)
+	}
+
 	// extract shakespear sample as newline-delimited JSON
 	gcsURI = fmt.Sprintf("gs://%s/%s", bucket, "shakespeare.json")
 	if err := exportSampleTableAsJSON(client, gcsURI); err != nil {

--- a/bigquery/snippets/snippet_test.go
+++ b/bigquery/snippets/snippet_test.go
@@ -53,7 +53,7 @@ func TestAll(t *testing.T) {
 		t.Errorf("updateDataSetAccessControl(%q): %v", datasetID, err)
 	}
 
-	// test empty dataset creation/ttl/delete
+	// Test empty dataset creation/ttl/delete.
 	deletionDatasetID := fmt.Sprintf("%s_quickdelete", datasetID)
 	if err := createDataset(client, deletionDatasetID); err != nil {
 		t.Errorf("createDataset(%q): %v", deletionDatasetID, err)
@@ -80,10 +80,10 @@ func TestAll(t *testing.T) {
 		t.Errorf("createTableInferredSchema(dataset:%q table:%q): %v", datasetID, tblInferredSchema, err)
 	}
 	if err := createTableExplicitSchema(client, datasetID, tblExplicitSchema); err != nil {
-		t.Errorf("createTableExplicitSchema(dataset:%q table:%q): %v", datasetID, tblInferredSchema, err)
+		t.Errorf("createTableExplicitSchema(dataset:%q table:%q): %v", datasetID, tblExplicitSchema, err)
 	}
 	if err := createTableEmptySchema(client, datasetID, tblEmptySchema); err != nil {
-		t.Errorf("createTableEmptySchema(dataset:%q table:%q): %v", datasetID, tblInferredSchema, err)
+		t.Errorf("createTableEmptySchema(dataset:%q table:%q): %v", datasetID, tblEmptySchema, err)
 	}
 
 	if err := updateTableDescription(client, datasetID, tblExplicitSchema); err != nil {
@@ -97,7 +97,7 @@ func TestAll(t *testing.T) {
 	if err := listTables(client, buf, datasetID); err != nil {
 		t.Errorf("listTables(%q): %v", datasetID, err)
 	}
-	// Ensure all three tables are in the list
+	// Ensure all three tables are in the list.
 	if got := buf.String(); !strings.Contains(got, tblInferredSchema) {
 		t.Errorf("want table list %q to contain table %q", got, tblInferredSchema)
 	}
@@ -108,6 +108,7 @@ func TestAll(t *testing.T) {
 		t.Errorf("want table list %q to contain table %q", got, tblEmptySchema)
 	}
 
+	// Stream data, read, query the inferred schema table.
 	if err := insertRows(client, datasetID, tblInferredSchema); err != nil {
 		t.Errorf("insertRows(dataset:%q table:%q): %v", datasetID, tblInferredSchema, err)
 	}
@@ -121,6 +122,7 @@ func TestAll(t *testing.T) {
 		t.Errorf("basicQuery(dataset:%q table:%q): %v", datasetID, tblInferredSchema, err)
 	}
 
+	// Print information about tables (extended and simple).
 	if err := printTableMetadataExtended(client, datasetID, tblInferredSchema); err != nil {
 		t.Errorf("printTableMetadata(dataset:%q table:%q): %v", datasetID, tblInferredSchema, err)
 	}

--- a/bigquery/snippets/snippet_test.go
+++ b/bigquery/snippets/snippet_test.go
@@ -187,19 +187,19 @@ func TestImportExport(t *testing.T) {
 		t.Fatalf("importCSVFromFile(dataset:%q table:%q filename:%q): %v", datasetID, tableID, filename, err)
 	}
 
-	tblExplicitCSV := fmt.Sprintf("golang_example_dataset_importcsv_explicit_%d", time.Now().Unix())
-	if err := importCSVExplicitSchema(client, datasetID, tblExplicitCSV); err != nil {
-		t.Fatalf("importCSVExplicitSchema(dataset:%q table:%q): %v", datasetID, tblExplicitCSV, err)
+	explicitCSV := fmt.Sprintf("golang_example_dataset_importcsv_explicit_%d", time.Now().Unix())
+	if err := importCSVExplicitSchema(client, datasetID, explicitCSV); err != nil {
+		t.Fatalf("importCSVExplicitSchema(dataset:%q table:%q): %v", datasetID, explicitCSV, err)
 	}
 
-	tblExplicitJSON := fmt.Sprintf("golang_example_dataset_importjson_explicit_%d", time.Now().Unix())
-	if err := importJSONExplicitSchema(client, datasetID, tblExplicitJSON); err != nil {
-		t.Fatalf("importJSONExplicitSchema(dataset:%q table:%q): %v", datasetID, tblExplicitJSON, err)
+	explicitJSON := fmt.Sprintf("golang_example_dataset_importjson_explicit_%d", time.Now().Unix())
+	if err := importJSONExplicitSchema(client, datasetID, explicitJSON); err != nil {
+		t.Fatalf("importJSONExplicitSchema(dataset:%q table:%q): %v", datasetID, explicitJSON, err)
 	}
 
-	tblAutodetectJSON := fmt.Sprintf("golang_example_dataset_importjson_autodetect_%d", time.Now().Unix())
-	if err := importJSONAutodetectSchema(client, datasetID, tblAutodetectJSON); err != nil {
-		t.Fatalf("importJSONAutodetectSchema(dataset:%q table:%q): %v", datasetID, tblAutodetectJSON, err)
+	autodetectJSON := fmt.Sprintf("golang_example_dataset_importjson_autodetect_%d", time.Now().Unix())
+	if err := importJSONAutodetectSchema(client, datasetID, autodetectJSON); err != nil {
+		t.Fatalf("importJSONAutodetectSchema(dataset:%q table:%q): %v", datasetID, autodetectJSON, err)
 	}
 	bucket := fmt.Sprintf("golang-example-bigquery-importexport-bucket-%d", time.Now().Unix())
 	const object = "values.csv"

--- a/bigquery/snippets/snippet_test.go
+++ b/bigquery/snippets/snippet_test.go
@@ -71,36 +71,54 @@ func TestAll(t *testing.T) {
 		t.Errorf("listDatasets: %v", err)
 	}
 
-	tableID := fmt.Sprintf("golang_example_table_%d", time.Now().Unix())
-	if err := createTable(client, datasetID, tableID); err != nil {
-		t.Errorf("createTable(dataset:%q  table:%q): %v", datasetID, tableID, err)
+	tblInferredSchema := fmt.Sprintf("golang_example_table_inferred_%d", time.Now().Unix())
+	tblExplicitSchema := fmt.Sprintf("golang_example_table_explicit_%d", time.Now().Unix())
+	tblEmptySchema := fmt.Sprintf("golang_example_table_emptyschema_%d", time.Now().Unix())
+
+	if err := createTableInferredSchema(client, datasetID, tblInferredSchema); err != nil {
+		t.Errorf("createTableInferredSchema(dataset:%q table:%q): %v", datasetID, tblInferredSchema, err)
 	}
+	if err := createTableExplicitSchema(client, datasetID, tblExplicitSchema); err != nil {
+		t.Errorf("createTableExplicitSchema(dataset:%q table:%q): %v", datasetID, tblInferredSchema, err)
+	}
+	if err := createTableEmptySchema(client, datasetID, tblEmptySchema); err != nil {
+		t.Errorf("createTableEmptySchema(dataset:%q table:%q): %v", datasetID, tblInferredSchema, err)
+	}
+
 	buf := &bytes.Buffer{}
 	if err := listTables(client, buf, datasetID); err != nil {
 		t.Errorf("listTables(%q): %v", datasetID, err)
 	}
-	if got := buf.String(); !strings.Contains(got, tableID) {
-		t.Errorf("want table list %q to contain table %q", got, tableID)
+	// Ensure all three tables are in the list
+	if got := buf.String(); !strings.Contains(got, tblInferredSchema) {
+		t.Errorf("want table list %q to contain table %q", got, tblInferredSchema)
 	}
-	if err := insertRows(client, datasetID, tableID); err != nil {
-		t.Errorf("insertRows(dataset:%q table:%q): %v", datasetID, tableID, err)
+	if got := buf.String(); !strings.Contains(got, tblExplicitSchema) {
+		t.Errorf("want table list %q to contain table %q", got, tblExplicitSchema)
 	}
-	if err := listRows(client, datasetID, tableID); err != nil {
-		t.Errorf("listRows(dataset:%q table:%q): %v", datasetID, tableID, err)
+	if got := buf.String(); !strings.Contains(got, tblEmptySchema) {
+		t.Errorf("want table list %q to contain table %q", got, tblEmptySchema)
 	}
-	if err := browseTable(client, datasetID, tableID); err != nil {
-		t.Errorf("browseTable(dataset:%q table:%q): %v", datasetID, tableID, err)
+
+	if err := insertRows(client, datasetID, tblInferredSchema); err != nil {
+		t.Errorf("insertRows(dataset:%q table:%q): %v", datasetID, tblInferredSchema, err)
 	}
-	if err := asyncQuery(client, datasetID, tableID); err != nil {
-		t.Errorf("failed to async query: %v", err)
+	if err := listRows(client, datasetID, tblInferredSchema); err != nil {
+		t.Errorf("listRows(dataset:%q table:%q): %v", datasetID, tblInferredSchema, err)
+	}
+	if err := browseTable(client, datasetID, tblInferredSchema); err != nil {
+		t.Errorf("browseTable(dataset:%q table:%q): %v", datasetID, tblInferredSchema, err)
+	}
+	if err := asyncQuery(client, datasetID, tblInferredSchema); err != nil {
+		t.Errorf("asyncQuery(dataset:%q table:%q): %v", datasetID, tblInferredSchema, err)
 	}
 
 	dstTableID := fmt.Sprintf("golang_example_tabledst_%d", time.Now().Unix())
-	if err := copyTable(client, datasetID, tableID, dstTableID); err != nil {
-		t.Errorf("failed to copy table (dataset:%q src:%q dst:%q): %v", datasetID, tableID, dstTableID, err)
+	if err := copyTable(client, datasetID, tblInferredSchema, dstTableID); err != nil {
+		t.Errorf("copyTable(dataset:%q src:%q dst:%q): %v", datasetID, tblInferredSchema, dstTableID, err)
 	}
-	if err := deleteTable(client, datasetID, tableID); err != nil {
-		t.Errorf("deleteTable(dataset:%q table:%q): %v", datasetID, tableID, err)
+	if err := deleteTable(client, datasetID, tblInferredSchema); err != nil {
+		t.Errorf("deleteTable(dataset:%q table:%q): %v", datasetID, tblInferredSchema, err)
 	}
 	if err := deleteTable(client, datasetID, dstTableID); err != nil {
 		t.Errorf("deleteTable(dataset:%q table:%q): %v", datasetID, dstTableID, err)

--- a/bigquery/snippets/testdata/people.csv
+++ b/bigquery/snippets/testdata/people.csv
@@ -1,0 +1,3 @@
+full_name,age
+Phred Phlyntstone,32
+Wylma Phlyntstone,29


### PR DESCRIPTION
A variety of BigQuery updates, mostly to cleanup bad region labels and align the examples with other language implementations.

Region updates:
update: bigquery_create_table to match others (build an explicit schema, not go type inference)
add: bigquery_create_table_without_schema
add: bigquery_update_table_description
add: bigquery_update_table_expiration
rename/update: bigquery_insert_stream -> bigquery_table_insert_rows
remove region tag: bigquery_list_rows (leave snippet)
rename/update: bigquery_async_query -> bigquery_query
remove region and impl: bigquery_import_from_gcs
add: bigquery_load_table_gcs_csv
rename/update: bigquery_import_from_file -> bigquery_load_from_file
remove region and impl: bigquery_export_gcs
add: bigquery_get_table (and a more complex variant not yet in a region)

other minor changes:
* add Location to inital createDataset to be explicit about US locality creation
* add local CSV testdata/people.csv for loading data via POST upload.