### PR TITLE
Update main.go

### DIFF
--- a/kms/quickstart/main.go
+++ b/kms/quickstart/main.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"log"
 
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
 	cloudkms "google.golang.org/api/cloudkms/v1"
 )


### PR DESCRIPTION
As of Go 1.7 golang.org/x/net/context package is available in the standard library under the name context. https://golang.org/pkg/context.