### PR TITLE
oauth: add explicit snippets

### DIFF
--- a/auth/snippets.go
+++ b/auth/snippets.go
@@ -14,12 +14,14 @@ import (
 	"golang.org/x/oauth2/google"
 	cloudkms "google.golang.org/api/cloudkms/v1"
 	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
 )
 
-func adc() {
-	ctx := context.Background()
+// [START auth_cloud_implicit]
 
-	// [START auth_cloud_implicit]
+// implicit uses Application Default Credentials to authenticate.
+func implicit() {
+	ctx := context.Background()
 
 	// For API packages whose import path is starting with "cloud.google.com/go",
 	// such as cloud.google.com/go/storage in this case, if there are no credentials
@@ -54,6 +56,64 @@ func adc() {
 		log.Fatal(err)
 	}
 
-	// [END auth_cloud_implicit]
 	_ = kmsService
 }
+
+// [END auth_cloud_implicit]
+
+// [START auth_cloud_explicit]
+
+// explicit reads credentials from the specified path.
+func explicit(jsonPath, projectID string) {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx, option.WithCredentialsFile(jsonPath))
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("Buckets:")
+	it := client.Buckets(ctx, projectID)
+	for {
+		battrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(battrs.Name)
+	}
+}
+
+// [END auth_cloud_explicit]
+
+// [START auth_cloud_explicit_compute_engine]
+// [START auth_cloud_explicit_app_engine]
+
+// explicitDefault finds the default credentials.
+func explicitDefault(projectID string) {
+	ctx := context.Background()
+
+	creds, err := google.FindDefaultCredentials(ctx, storage.ScopeReadOnly)
+	if err != nil {
+		log.Fatal(err)
+	}
+	client, err := storage.NewClient(ctx, option.WithCredentials(creds))
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("Buckets:")
+	it := client.Buckets(ctx, projectID)
+	for {
+		battrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(battrs.Name)
+	}
+}
+
+// [END auth_cloud_explicit_compute_engine]
+// [END auth_cloud_explicit_app_engine]

--- a/auth/snippets.go
+++ b/auth/snippets.go
@@ -90,6 +90,10 @@ func explicit(jsonPath, projectID string) {
 // [START auth_cloud_explicit_app_engine]
 
 // explicitDefault finds the default credentials.
+//
+// It is very uncommon to need to explicitly get the default credentials in Go.
+// Most of the time, client libraries can use Application Default Credentials
+// without having to pass the credentials in directly. See implicit above.
 func explicitDefault(projectID string) {
 	ctx := context.Background()
 


### PR DESCRIPTION
The snippets correspond to this page: https://cloud.google.com/docs/authentication/production.

I moved the tags out of the implicit function to match most of the other snippets on that page.