### PR TITLE
BigQuery: additional snippets

### DIFF
--- a/bigquery/snippets/snippet.go
+++ b/bigquery/snippets/snippet.go
@@ -470,13 +470,13 @@ func queryLegacy(client *bigquery.Client, sqlString string) error {
 
 func queryLegacyLargeResults(client *bigquery.Client, dstDatasetID, dstTableID string) error {
 	ctx := context.Background()
-	// [START bigquery_query_legacy]
+	// [START bigquery_query_legacy_large_results]
 	q := client.Query(
 		"SELECT corpus FROM [bigquery-public-data:samples.shakespeare] GROUP BY corpus;")
 	q.UseLegacySQL = true
 	q.AllowLargeResults = true
 	q.QueryConfig.Dst = client.Dataset(dstDatasetID).Table(dstTableID)
-	// [END bigquery_query_legacy]
+	// [END bigquery_query_legacy_large_results]
 	return runAndRead(ctx, client, q)
 }
 
@@ -996,7 +996,7 @@ func runAndRead(ctx context.Context, client *bigquery.Client, q *bigquery.Query)
 	}
 	// [END bigquery_query]
 	// [END bigquery_query_destination_table]
-	// [END bigquery_query_legacy]
+	// [END bigquery_query_legacy_large_results]
 	// [END bigquery_query_params_arrays]
 	// [END bigquery_query_params_named]
 	// [END bigquery_query_params_positional]

--- a/bigquery/snippets/snippet.go
+++ b/bigquery/snippets/snippet.go
@@ -632,7 +632,8 @@ func copyTable(client *bigquery.Client, datasetID, srcID, dstID string) error {
 	return nil
 }
 
-// Create a quick table by issuing a CREATE TABLE AS SELECT query.
+// generateTableCTAS creates a quick table by issuing a CREATE TABLE AS SELECT
+// query.
 func generateTableCTAS(client *bigquery.Client, datasetID, tableID string) error {
 	ctx := context.Background()
 	q := client.Query(

--- a/bigquery/snippets/snippet.go
+++ b/bigquery/snippets/snippet.go
@@ -305,13 +305,27 @@ func listRows(client *bigquery.Client, datasetID, tableID string) error {
 	return nil
 }
 
-func basicQuery(client *bigquery.Client, datasetID, tableID string) error {
+func queryBasic(client *bigquery.Client) error {
 	ctx := context.Background()
 	// [START bigquery_query]
+
 	q := client.Query(
 		"SELECT name FROM `bigquery-public-data.usa_names.usa_1910_2013` " +
 			"WHERE state = \"TX\" " +
 			"LIMIT 100")
+	// Location must match that of the dataset(s) referenced in the query.
+	q.Location = "US"
+	// [END bigquery_query]
+	return runAndRead(ctx, client, q)
+}
+
+func queryBasicDisableCache(client *bigquery.Client) error {
+	ctx := context.Background()
+	// [START bigquery_query_no_cache]
+
+	q := client.Query(
+		"SELECT corpus FROM `bigquery-public-data.samples.shakespeare` GROUP BY corpus;")
+	q.DisableQueryCache = true
 	// Location must match that of the dataset(s) referenced in the query.
 	q.Location = "US"
 
@@ -341,7 +355,85 @@ func basicQuery(client *bigquery.Client, datasetID, tableID string) error {
 		}
 		fmt.Println(row)
 	}
-	// [END bigquery_query]
+	// [END bigquery_query_no_cache]
+	return nil
+}
+
+func queryBatch(client *bigquery.Client, dstDatasetID, dstTableID string) error {
+	ctx := context.Background()
+	// [START bigquery_query_batch]
+	// Build an aggregate table
+	q := client.Query(`
+		SELECT
+  			corpus,
+  			SUM(word_count) as total_words,
+  			COUNT(1) as unique_words
+		FROM ` + "`bigquery-public-data.samples.shakespeare`" + `
+		GROUP BY corpus;`)
+	q.Priority = bigquery.BatchPriority
+	q.QueryConfig.Dst = client.Dataset(dstDatasetID).Table(dstTableID)
+
+	// Run job, then wait until asynchronous execution is complete.
+	job, err := q.Run(ctx)
+	if err != nil {
+		return err
+	}
+	// Job is started, and will progress without interaction.
+	// To demonstrate other work being done, we simply sleep here.
+	time.Sleep(5 * time.Second)
+	status, err := job.Status(ctx)
+	if err != nil {
+		return err
+	}
+
+	state := "Unknown"
+	switch status.State {
+	case bigquery.Pending:
+		state = "Pending"
+	case bigquery.Running:
+		state = "Running"
+	case bigquery.Done:
+		state = "Done"
+	}
+	// You can continue to monitor job progress until it reaches
+	// the Done state by polling periodically.  In this example,
+	// we simply print the latest status.
+	fmt.Printf("Job %s in Location %s currently in state: %s\n", job.ID(), job.Location(), state)
+
+	// [END bigquery_query_batch]
+	job.Cancel(ctx)
+	return nil
+}
+
+func queryDryRun(client *bigquery.Client) error {
+	ctx := context.Background()
+	// [START bigquery_query_dry_run]
+
+	q := client.Query(
+		`
+		SELECT 
+		   name,
+		   COUNT(*) as name_count
+		FROM ` + "`bigquery-public-data.usa_names.usa_1910_2013`" + `
+		WHERE state = 'WA' 
+		GROUP BY name
+		`)
+	q.DryRun = true
+	// Location must match that of the dataset(s) referenced in the query.
+	q.Location = "US"
+
+	job, err := q.Run(ctx)
+	if err != nil {
+		return err
+	}
+	//Dry run is not asynchronous, so get the latest status and statistics.
+	status := job.LastStatus()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("This query will process %d bytes\n", status.Statistics.TotalBytesProcessed)
+
+	// [END bigquery_query_dry_run]
 	return nil
 }
 
@@ -352,35 +444,8 @@ func queryWithDestination(client *bigquery.Client, destDatasetID, destTableID st
 	q := client.Query("SELECT 17 as my_col")
 	q.Location = "US" // Location must match the dataset(s) referenced in query.
 	q.QueryConfig.Dst = destRef
-
-	// Run job, then wait until asyncronous execution is complete.
-	job, err := q.Run(ctx)
-	if err != nil {
-		return err
-	}
-	status, err := job.Wait(ctx)
-	if err != nil {
-		return err
-	}
-	if err := status.Err(); err != nil {
-		return err
-	}
-	// At this point, the query has completed and results are persisted to the
-	// destination table.  You can also choose to read from the table.
-	it, err := job.Read(ctx)
-	for {
-		var row []bigquery.Value
-		err := it.Next(&row)
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			return err
-		}
-		fmt.Println(row)
-	}
 	// [END bigquery_query_destination_table]
-	return nil
+	return runAndRead(ctx, client, q)
 }
 
 func queryLegacy(client *bigquery.Client, sqlString string) error {
@@ -403,6 +468,121 @@ func queryLegacy(client *bigquery.Client, sqlString string) error {
 	}
 	// [END bigquery_query_legacy]
 	return nil
+}
+
+func queryLegacyLargeResults(client *bigquery.Client, dstDatasetID, dstTableID string) error {
+	ctx := context.Background()
+	// [START bigquery_query_legacy]
+	q := client.Query(
+		"SELECT corpus FROM [bigquery-public-data:samples.shakespeare] GROUP BY corpus;")
+	q.UseLegacySQL = true
+	q.AllowLargeResults = true
+	q.QueryConfig.Dst = client.Dataset(dstDatasetID).Table(dstTableID)
+	// [END bigquery_query_legacy]
+	return runAndRead(ctx, client, q)
+}
+
+func queryWithArrayParams(client *bigquery.Client) error {
+	ctx := context.Background()
+	// [START bigquery_query_params_arrays]
+	q := client.Query(
+		`SELECT name, sum(number) as count 
+        FROM ` + "`bigquery-public-data.usa_names.usa_1910_2013`" + `
+        WHERE gender = @gender
+        AND state IN UNNEST(@states)
+        GROUP BY name
+        ORDER BY count DESC
+		LIMIT 10;`)
+	q.Parameters = []bigquery.QueryParameter{
+		{
+			Name:  "gender",
+			Value: "M",
+		},
+		{
+			Name:  "states",
+			Value: []string{"WA", "WI", "WV", "WY"},
+		},
+	}
+	// [END bigquery_query_params_arrays]
+	return runAndRead(ctx, client, q)
+}
+
+func queryWithNamedParams(client *bigquery.Client) error {
+	ctx := context.Background()
+	// [START bigquery_query_params_named]
+	q := client.Query(
+		`SELECT word, word_count
+        FROM ` + "`bigquery-public-data.samples.shakespeare`" + `
+        WHERE corpus = @corpus
+        AND word_count >= @min_word_count
+        ORDER BY word_count DESC;`)
+	q.Parameters = []bigquery.QueryParameter{
+		{
+			Name:  "corpus",
+			Value: "romeoandjuliet",
+		},
+		{
+			Name:  "min_word_count",
+			Value: 250,
+		},
+	}
+	// [END bigquery_query_params_named]
+	return runAndRead(ctx, client, q)
+}
+
+func queryWithPositionalParams(client *bigquery.Client) error {
+	ctx := context.Background()
+	// [START bigquery_query_params_positional]
+	q := client.Query(
+		`SELECT word, word_count
+        FROM ` + "`bigquery-public-data.samples.shakespeare`" + `
+        WHERE corpus = ?
+        AND word_count >= ?
+        ORDER BY word_count DESC;`)
+	q.Parameters = []bigquery.QueryParameter{
+		{
+			Value: "romeoandjuliet",
+		},
+		{
+			Value: 250,
+		},
+	}
+	// [END bigquery_query_params_positional]
+	return runAndRead(ctx, client, q)
+}
+
+func queryWithTimestampParam(client *bigquery.Client) error {
+	ctx := context.Background()
+	// [START bigquery_query_params_timestamps]
+	q := client.Query(
+		`SELECT TIMESTAMP_ADD(@ts_value, INTERVAL 1 HOUR);`)
+	q.Parameters = []bigquery.QueryParameter{
+		{
+			Name:  "ts_value",
+			Value: time.Date(2016, 12, 7, 8, 0, 0, 0, time.UTC),
+		},
+	}
+	// [END bigquery_query_params_timestamps]
+	return runAndRead(ctx, client, q)
+}
+
+func queryWithStructParam(client *bigquery.Client) error {
+	ctx := context.Background()
+	// [START bigquery_query_params_structs]
+	type MyStruct struct {
+		X int64
+		Y string
+	}
+	q := client.Query(
+		`SELECT @struct_value as s;`)
+	q.Parameters = []bigquery.QueryParameter{
+		{
+			Name:  "struct_value",
+			Value: MyStruct{X: 1, Y: "foo"},
+		},
+	}
+	// [END bigquery_query_params_structs]
+	return runAndRead(ctx, client, q)
 }
 
 func printTableInfo(client *bigquery.Client, datasetID, tableID string) error {
@@ -461,6 +641,64 @@ func copyTable(client *bigquery.Client, datasetID, srcID, dstID string) error {
 	return nil
 }
 
+func generateTableCTAS(client *bigquery.Client, datasetID, tableID string) error {
+	ctx := context.Background()
+	q := client.Query(
+		fmt.Sprintf(
+			`CREATE TABLE %s.%s 
+		AS
+		SELECT
+		  2000 + CAST(18 * RAND() as INT64) as year,
+		  IF(RAND() > 0.5,"foo","bar") as token
+		FROM
+		  UNNEST(GENERATE_ARRAY(0,5,1)) as r`, datasetID, tableID))
+	job, err := q.Run(ctx)
+	if err != nil {
+		return err
+	}
+	status, err := job.Wait(ctx)
+	if err != nil {
+		return err
+	}
+	if err := status.Err(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func copyMultiTable(client *bigquery.Client, datasetID, dstTableID string) error {
+	ctx := context.Background()
+	// Generate some dummy tables via a quick CTAS.
+	if err := generateTableCTAS(client, datasetID, "table1"); err != nil {
+		return err
+	}
+	if err := generateTableCTAS(client, datasetID, "table2"); err != nil {
+		return err
+	}
+	// [START bigquery_copy_table_multiple_source]
+	dataset := client.Dataset(datasetID)
+
+	srcTableIDs := []string{"table1", "table2"}
+	var tableRefs []*bigquery.Table
+	for _, v := range srcTableIDs {
+		tableRefs = append(tableRefs, dataset.Table(v))
+	}
+	copier := dataset.Table(dstTableID).CopierFrom(tableRefs...)
+	copier.WriteDisposition = bigquery.WriteTruncate
+	job, err := copier.Run(ctx)
+	if err != nil {
+		return err
+	}
+	status, err := job.Wait(ctx)
+	if err != nil {
+		return err
+	}
+	if err := status.Err(); err != nil {
+		return err
+	}
+	// [END bigquery_copy_table_multiple_source]
+	return nil
+}
 func deleteTable(client *bigquery.Client, datasetID, tableID string) error {
 	ctx := context.Background()
 	// [START bigquery_delete_table]
@@ -470,6 +708,49 @@ func deleteTable(client *bigquery.Client, datasetID, tableID string) error {
 	}
 	// [END bigquery_delete_table]
 	return nil
+}
+
+func deleteAndUndeleteTable(client *bigquery.Client, datasetID, tableID string) error {
+	ctx := context.Background()
+	// [START bigquery_undelete_table]
+
+	ds := client.Dataset(datasetID)
+	if _, err := ds.Table(tableID).Metadata(ctx); err != nil {
+		return err
+	}
+	// Table exists at the current time.  Record this so we can restore table to
+	// state at this time.
+	snapTime := time.Now()
+
+	// "Accidentally" delete the table.
+	if err := client.Dataset(datasetID).Table(tableID).Delete(ctx); err != nil {
+		return err
+	}
+
+	// Construct the restore-from tableID using a snapshot decorator.
+	snapshotTableID := fmt.Sprintf("%s@%d", tableID, snapTime.UnixNano()/1e6)
+	// Choose a new table ID for the recovered table data.
+	recoverTableID := fmt.Sprintf("%s_recovered", tableID)
+
+	// Construct and run a copy job.
+	copier := ds.Table(recoverTableID).CopierFrom(ds.Table(snapshotTableID))
+	copier.WriteDisposition = bigquery.WriteTruncate
+	job, err := copier.Run(ctx)
+	if err != nil {
+		return err
+	}
+	status, err := job.Wait(ctx)
+	if err != nil {
+		return err
+	}
+	if err := status.Err(); err != nil {
+		return err
+	}
+
+	// [END bigquery_undelete_table]
+	ds.Table(recoverTableID).Delete(ctx)
+	return nil
+
 }
 
 func importCSVFromFile(client *bigquery.Client, datasetID, tableID, filename string) error {
@@ -673,5 +954,50 @@ func exportSampleTableAsJSON(client *bigquery.Client, gcsURI string) error {
 		return err
 	}
 	// [END bigquery_extract_table_json]
+	return nil
+}
+
+// Many example functions differ only in the construction of the query.
+// Generalize the work of running a query to completion and printing results.
+func runAndRead(ctx context.Context, client *bigquery.Client, q *bigquery.Query) error {
+	// [START bigquery_query]
+	// [START bigquery_query_destination_table]
+	// [START bigquery_query_legacy]
+	// [START bigquery_query_params_arrays]
+	// [START bigquery_query_params_named]
+	// [START bigquery_query_params_positional]
+	// [START bigquery_query_params_timestamps]
+	// [START bigquery_query_params_structs]
+	job, err := q.Run(ctx)
+	if err != nil {
+		return err
+	}
+	status, err := job.Wait(ctx)
+	if err != nil {
+		return err
+	}
+	if err := status.Err(); err != nil {
+		return err
+	}
+	it, err := job.Read(ctx)
+	for {
+		var row []bigquery.Value
+		err := it.Next(&row)
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		fmt.Println(row)
+	}
+	// [END bigquery_query]
+	// [END bigquery_query_destination_table]
+	// [END bigquery_query_legacy]
+	// [END bigquery_query_params_arrays]
+	// [END bigquery_query_params_named]
+	// [END bigquery_query_params_positional]
+	// [END bigquery_query_params_timestamps]
+	// [END bigquery_query_params_structs]
 	return nil
 }

--- a/bigquery/snippets/snippet.go
+++ b/bigquery/snippets/snippet.go
@@ -319,7 +319,7 @@ func queryBasic(client *bigquery.Client) error {
 	return runAndRead(ctx, client, q)
 }
 
-func queryBasicDisableCache(client *bigquery.Client) error {
+func queryDisableCache(client *bigquery.Client) error {
 	ctx := context.Background()
 	// [START bigquery_query_no_cache]
 
@@ -362,7 +362,7 @@ func queryBasicDisableCache(client *bigquery.Client) error {
 func queryBatch(client *bigquery.Client, dstDatasetID, dstTableID string) error {
 	ctx := context.Background()
 	// [START bigquery_query_batch]
-	// Build an aggregate table
+	// Build an aggregate table.
 	q := client.Query(`
 		SELECT
   			corpus,
@@ -378,8 +378,8 @@ func queryBatch(client *bigquery.Client, dstDatasetID, dstTableID string) error 
 	if err != nil {
 		return err
 	}
-	// Job is started, and will progress without interaction.
-	// To demonstrate other work being done, we simply sleep here.
+	// Job is started and will progress without interaction.
+	// To simulate other work being done, sleep a few seconds.
 	time.Sleep(5 * time.Second)
 	status, err := job.Status(ctx)
 	if err != nil {
@@ -397,7 +397,7 @@ func queryBatch(client *bigquery.Client, dstDatasetID, dstTableID string) error 
 	}
 	// You can continue to monitor job progress until it reaches
 	// the Done state by polling periodically.  In this example,
-	// we simply print the latest status.
+	// we print the latest status.
 	fmt.Printf("Job %s in Location %s currently in state: %s\n", job.ID(), job.Location(), state)
 
 	// [END bigquery_query_batch]
@@ -409,8 +409,7 @@ func queryDryRun(client *bigquery.Client) error {
 	ctx := context.Background()
 	// [START bigquery_query_dry_run]
 
-	q := client.Query(
-		`
+	q := client.Query(`
 		SELECT 
 		   name,
 		   COUNT(*) as name_count
@@ -426,7 +425,7 @@ func queryDryRun(client *bigquery.Client) error {
 	if err != nil {
 		return err
 	}
-	//Dry run is not asynchronous, so get the latest status and statistics.
+	// Dry run is not asynchronous, so get the latest status and statistics.
 	status := job.LastStatus()
 	if err != nil {
 		return err
@@ -641,6 +640,7 @@ func copyTable(client *bigquery.Client, datasetID, srcID, dstID string) error {
 	return nil
 }
 
+// Create a quick table by issuing a CREATE TABLE AS SELECT query.
 func generateTableCTAS(client *bigquery.Client, datasetID, tableID string) error {
 	ctx := context.Background()
 	q := client.Query(
@@ -718,8 +718,8 @@ func deleteAndUndeleteTable(client *bigquery.Client, datasetID, tableID string) 
 	if _, err := ds.Table(tableID).Metadata(ctx); err != nil {
 		return err
 	}
-	// Table exists at the current time.  Record this so we can restore table to
-	// state at this time.
+	// Record the current time.  We'll use this as the snapshot time
+	// for recovering the table.
 	snapTime := time.Now()
 
 	// "Accidentally" delete the table.
@@ -957,8 +957,7 @@ func exportSampleTableAsJSON(client *bigquery.Client, gcsURI string) error {
 	return nil
 }
 
-// Many example functions differ only in the construction of the query.
-// Generalize the work of running a query to completion and printing results.
+// runAndRead executes a query then prints results.
 func runAndRead(ctx context.Context, client *bigquery.Client, q *bigquery.Query) error {
 	// [START bigquery_query]
 	// [START bigquery_query_destination_table]

--- a/bigquery/snippets/snippet.go
+++ b/bigquery/snippets/snippet.go
@@ -452,20 +452,8 @@ func queryLegacy(client *bigquery.Client, sqlString string) error {
 	q := client.Query(sqlString)
 	q.UseLegacySQL = true
 
-	// Run job, then wait until asyncronous execution is complete.
-	job, err := q.Run(ctx)
-	if err != nil {
-		return err
-	}
-	status, err := job.Wait(ctx)
-	if err != nil {
-		return err
-	}
-	if err := status.Err(); err != nil {
-		return err
-	}
 	// [END bigquery_query_legacy]
-	return nil
+	return runAndRead(ctx, client, q)
 }
 
 func queryLegacyLargeResults(client *bigquery.Client, dstDatasetID, dstTableID string) error {
@@ -966,6 +954,7 @@ func runAndRead(ctx context.Context, client *bigquery.Client, q *bigquery.Query)
 	// [START bigquery_query]
 	// [START bigquery_query_destination_table]
 	// [START bigquery_query_legacy]
+	// [START bigquery_query_legacy_large_results]
 	// [START bigquery_query_params_arrays]
 	// [START bigquery_query_params_named]
 	// [START bigquery_query_params_positional]
@@ -996,6 +985,7 @@ func runAndRead(ctx context.Context, client *bigquery.Client, q *bigquery.Query)
 	}
 	// [END bigquery_query]
 	// [END bigquery_query_destination_table]
+	// [END bigquery_query_legacy]
 	// [END bigquery_query_legacy_large_results]
 	// [END bigquery_query_params_arrays]
 	// [END bigquery_query_params_named]

--- a/bigquery/snippets/snippet_test.go
+++ b/bigquery/snippets/snippet_test.go
@@ -122,19 +122,48 @@ func TestAll(t *testing.T) {
 	if err := browseTable(client, datasetID, inferred); err != nil {
 		t.Errorf("browseTable(dataset:%q table:%q): %v", datasetID, inferred, err)
 	}
-	if err := basicQuery(client, datasetID, inferred); err != nil {
-		t.Errorf("basicQuery(dataset:%q table:%q): %v", datasetID, inferred, err)
+
+	if err := queryBasic(client); err != nil {
+		t.Errorf("queryBasic: %v", err)
+	}
+	batchTable := fmt.Sprintf("golang_example_batchresults_%d", time.Now().Unix())
+	if err := queryBatch(client, datasetID, batchTable); err != nil {
+		t.Errorf("queryBatch(dataset:%q table:%q): %v", datasetID, batchTable, err)
+	}
+	if err := queryBasicDisableCache(client); err != nil {
+		t.Errorf("queryBasicDisableCache: %v", err)
+	}
+	if err := queryDryRun(client); err != nil {
+		t.Errorf("queryDryRun: %v", err)
+	}
+	sql := "SELECT 17 as foo"
+	if err := queryLegacy(client, sql); err != nil {
+		t.Errorf("queryLegacy: %v", err)
+	}
+	largeResults := fmt.Sprintf("golang_example_legacy_largeresults_%d", time.Now().Unix())
+	if err := queryLegacyLargeResults(client, datasetID, largeResults); err != nil {
+		t.Errorf("queryLegacyLargeResults(dataset:%q table:%q): %v", datasetID, largeResults, err)
+	}
+	if err := queryWithArrayParams(client); err != nil {
+		t.Errorf("queryWithArrayParams: %v", err)
+	}
+	if err := queryWithNamedParams(client); err != nil {
+		t.Errorf("queryWithNamedParams: %v", err)
+	}
+	if err := queryWithPositionalParams(client); err != nil {
+		t.Errorf("queryWithPositionalParams: %v", err)
+	}
+	if err := queryWithTimestampParam(client); err != nil {
+		t.Errorf("queryWithTimestampParam: %v", err)
+	}
+	if err := queryWithStructParam(client); err != nil {
+		t.Errorf("queryWithStructParam: %v", err)
 	}
 
 	// Run query variations
 	persisted := fmt.Sprintf("golang_example_table_queryresult_%d", time.Now().Unix())
 	if err := queryWithDestination(client, datasetID, persisted); err != nil {
 		t.Errorf("queryWithDestination(dataset:%q table:%q): %v", datasetID, persisted, err)
-	}
-
-	sql := "SELECT 17 as foo"
-	if err := queryLegacy(client, sql); err != nil {
-		t.Errorf("queryLegacy: %v", err)
 	}
 
 	// Print information about tables (extended and simple).
@@ -152,8 +181,13 @@ func TestAll(t *testing.T) {
 	if err := deleteTable(client, datasetID, inferred); err != nil {
 		t.Errorf("deleteTable(dataset:%q table:%q): %v", datasetID, inferred, err)
 	}
-	if err := deleteTable(client, datasetID, dstTableID); err != nil {
-		t.Errorf("deleteTable(dataset:%q table:%q): %v", datasetID, dstTableID, err)
+	if err := deleteAndUndeleteTable(client, datasetID, dstTableID); err != nil {
+		t.Errorf("undeleteTable(dataset:%q table:%q): %v", datasetID, dstTableID, err)
+	}
+
+	dstTableID = fmt.Sprintf("golang_multicopydest_%d", time.Now().Unix())
+	if err := copyMultiTable(client, datasetID, dstTableID); err != nil {
+		t.Errorf("copyMultiTable(dataset:%q table:%q): %v", datasetID, dstTableID, err)
 	}
 
 }

--- a/bigquery/snippets/snippet_test.go
+++ b/bigquery/snippets/snippet_test.go
@@ -130,7 +130,7 @@ func TestAll(t *testing.T) {
 	if err := queryBatch(client, datasetID, batchTable); err != nil {
 		t.Errorf("queryBatch(dataset:%q table:%q): %v", datasetID, batchTable, err)
 	}
-	if err := queryBasicDisableCache(client); err != nil {
+	if err := queryDisableCache(client); err != nil {
 		t.Errorf("queryBasicDisableCache: %v", err)
 	}
 	if err := queryDryRun(client); err != nil {

--- a/profiler/hotapp/Dockerfile
+++ b/profiler/hotapp/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:alpine
+
+WORKDIR /go/src/hotapp
+COPY *.go .
+
+RUN apk update \
+    && apk add --no-cache git \
+    && go get -d ./... \
+    && apk del git
+
+RUN go install ./...
+
+CMD ["hotapp"]


### PR DESCRIPTION
Add new snippets and refactors some existing query snippets.  

Moves the logic common to many of the query examples to a shared method, and uses multiple region tag areas to stitch them together.

new regions:

[START bigquery_copy_table_multiple_source]
[START bigquery_query]
[START bigquery_query_batch]
[START bigquery_query_destination_table]
[START bigquery_query_dry_run]
[START bigquery_query_legacy]
[START bigquery_query_no_cache]
[START bigquery_query_params_arrays]
[START bigquery_query_params_named]
[START bigquery_query_params_positional]
[START bigquery_query_params_structs]
[START bigquery_query_params_timestamps]
[START bigquery_undelete_table]