### PR TITLE
Cleanup

### DIFF
--- a/bigquery/snippets/snippet.go
+++ b/bigquery/snippets/snippet.go
@@ -279,32 +279,6 @@ func insertRows(client *bigquery.Client, datasetID, tableID string) error {
 	return nil
 }
 
-func listRows(client *bigquery.Client, datasetID, tableID string) error {
-	ctx := context.Background()
-	q := client.Query(fmt.Sprintf(`
-		SELECT name, age
-		FROM %s.%s
-		WHERE age >= 20
-	`, datasetID, tableID))
-	it, err := q.Read(ctx)
-	if err != nil {
-		return err
-	}
-
-	for {
-		var row []bigquery.Value
-		err := it.Next(&row)
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			return err
-		}
-		fmt.Println(row)
-	}
-	return nil
-}
-
 func queryBasic(client *bigquery.Client) error {
 	ctx := context.Background()
 	// [START bigquery_query]
@@ -328,35 +302,7 @@ func queryDisableCache(client *bigquery.Client) error {
 	q.DisableQueryCache = true
 	// Location must match that of the dataset(s) referenced in the query.
 	q.Location = "US"
-
-	job, err := q.Run(ctx)
-	if err != nil {
-		return err
-	}
-
-	// Wait until async querying is done.
-	status, err := job.Wait(ctx)
-	if err != nil {
-		return err
-	}
-	if err := status.Err(); err != nil {
-		return err
-	}
-
-	it, err := job.Read(ctx)
-	for {
-		var row []bigquery.Value
-		err := it.Next(&row)
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			return err
-		}
-		fmt.Println(row)
-	}
-	// [END bigquery_query_no_cache]
-	return nil
+	return runAndRead(ctx, client, q)
 }
 
 func queryBatch(client *bigquery.Client, dstDatasetID, dstTableID string) error {
@@ -409,13 +355,12 @@ func queryDryRun(client *bigquery.Client) error {
 	ctx := context.Background()
 	// [START bigquery_query_dry_run]
 	q := client.Query(`
-		SELECT 
-		   name,
-		   COUNT(*) as name_count
-		FROM ` + "`bigquery-public-data.usa_names.usa_1910_2013`" + `
-		WHERE state = 'WA' 
-		GROUP BY name
-		`)
+	SELECT
+		name,
+		COUNT(*) as name_count
+	FROM ` + "`bigquery-public-data.usa_names.usa_1910_2013`" + `
+	WHERE state = 'WA'
+	GROUP BY name`)
 	q.DryRun = true
 	// Location must match that of the dataset(s) referenced in the query.
 	q.Location = "US"
@@ -430,7 +375,6 @@ func queryDryRun(client *bigquery.Client) error {
 		return err
 	}
 	fmt.Printf("This query will process %d bytes\n", status.Statistics.TotalBytesProcessed)
-
 	// [END bigquery_query_dry_run]
 	return nil
 }
@@ -956,6 +900,7 @@ func runAndRead(ctx context.Context, client *bigquery.Client, q *bigquery.Query)
 	// [START bigquery_query_destination_table]
 	// [START bigquery_query_legacy]
 	// [START bigquery_query_legacy_large_results]
+	// [START bigquery_query_no_cache]
 	// [START bigquery_query_params_arrays]
 	// [START bigquery_query_params_named]
 	// [START bigquery_query_params_positional]
@@ -988,6 +933,7 @@ func runAndRead(ctx context.Context, client *bigquery.Client, q *bigquery.Query)
 	// [END bigquery_query_destination_table]
 	// [END bigquery_query_legacy]
 	// [END bigquery_query_legacy_large_results]
+	// [END bigquery_query_no_cache]
 	// [END bigquery_query_params_arrays]
 	// [END bigquery_query_params_named]
 	// [END bigquery_query_params_positional]

--- a/bigquery/snippets/snippet.go
+++ b/bigquery/snippets/snippet.go
@@ -302,6 +302,8 @@ func queryDisableCache(client *bigquery.Client) error {
 	q.DisableQueryCache = true
 	// Location must match that of the dataset(s) referenced in the query.
 	q.Location = "US"
+	// [END bigquery_query_no_cache]
+
 	return runAndRead(ctx, client, q)
 }
 


### PR DESCRIPTION
* reduces some duplicate code by adding another runAndRead use
* removes the unused listRows implementation
* reduces whitespace in a multiline sql string
* adds a uniqueName func to the BQ snippets test rather than having string formatters littered throughout the tests.

Semi-Related: https://github.com/GoogleCloudPlatform/golang-samples/issues/501 is derived from a backend issue rather than a real collision in naming resources, but centralizing the logic should make it easier to deal with this should client issues arise in the future.