### PR TITLE
profiler: add Start sample

### DIFF
--- a/profiler/profiler_quickstart/main.go
+++ b/profiler/profiler_quickstart/main.go
@@ -36,6 +36,8 @@ func main() {
 		NoHeapProfiling:      true,
 		NoGoroutineProfiling: true,
 		DebugLogging:         true,
+		// ProjectID must be set if not running on GCP.
+		// ProjectID: "my-project",
 	})
 	if err != nil {
 		log.Fatalf("failed to start the profiler: %v", err)

--- a/profiler/snippets/snippets.go
+++ b/profiler/snippets/snippets.go
@@ -1,0 +1,25 @@
+// Copyright 2016 Google Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+// snippets is an example of starting cloud.google.com/go/profiler.
+package main
+
+// [START profiler_start]
+import (
+	"cloud.google.com/go/profiler"
+)
+
+func main() {
+	// Profiler initialization, best done as early as possible.
+	if err := profiler.Start(profiler.Config{
+		Service:        "myservice",
+		ServiceVersion: "1.0.0",
+		// ProjectID must be set if not running on GCP.
+		// ProjectID: "my-project",
+	}); err != nil {
+		// TODO: Handle error.
+	}
+}
+
+// [END profiler_start]


### PR DESCRIPTION
I also mention `ProjectID` needs to be set when not running on GCP since
it was a surprise when I tried to run this. cc @jba - I wonder if we can
pull the project ID automatically to make this easier.

I didn't add a test because `ProjectID` needs to be set in the
`profiler.Config`, which would complicate the sample.