### PR TITLE
BigQuery: snippets related to Labels functionality.

### DIFF
--- a/bigquery/snippets/snippet.go
+++ b/bigquery/snippets/snippet.go
@@ -33,14 +33,14 @@ func updateDatasetDescription(client *bigquery.Client, datasetID string) error {
 	ctx := context.Background()
 	// [START bigquery_update_dataset_description]
 	ds := client.Dataset(datasetID)
-	original, err := ds.Metadata(ctx)
+	meta, err := ds.Metadata(ctx)
 	if err != nil {
 		return err
 	}
-	changes := bigquery.DatasetMetadataToUpdate{
+	update := bigquery.DatasetMetadataToUpdate{
 		Description: "Updated Description.",
 	}
-	if _, err = ds.Update(ctx, changes, original.ETag); err != nil {
+	if _, err = ds.Update(ctx, update, meta.ETag); err != nil {
 		return err
 	}
 	// [END bigquery_update_dataset_description]
@@ -51,14 +51,14 @@ func updateDatasetDefaultExpiration(client *bigquery.Client, datasetID string) e
 	ctx := context.Background()
 	// [START bigquery_update_dataset_expiration]
 	ds := client.Dataset(datasetID)
-	original, err := ds.Metadata(ctx)
+	meta, err := ds.Metadata(ctx)
 	if err != nil {
 		return err
 	}
-	changes := bigquery.DatasetMetadataToUpdate{
+	update := bigquery.DatasetMetadataToUpdate{
 		DefaultTableExpiration: 24 * time.Hour,
 	}
-	if _, err := client.Dataset(datasetID).Update(ctx, changes, original.ETag); err != nil {
+	if _, err := client.Dataset(datasetID).Update(ctx, update, meta.ETag); err != nil {
 		return err
 	}
 	// [END bigquery_update_dataset_expiration]
@@ -69,13 +69,13 @@ func updateDatasetAccessControl(client *bigquery.Client, datasetID string) error
 	ctx := context.Background()
 	// [START bigquery_update_dataset_access]
 	ds := client.Dataset(datasetID)
-	original, err := ds.Metadata(ctx)
+	meta, err := ds.Metadata(ctx)
 	if err != nil {
 		return err
 	}
 	// Append a new access control entry to the existing access list.
-	changes := bigquery.DatasetMetadataToUpdate{
-		Access: append(original.Access, &bigquery.AccessEntry{
+	update := bigquery.DatasetMetadataToUpdate{
+		Access: append(meta.Access, &bigquery.AccessEntry{
 			Role:       bigquery.ReaderRole,
 			EntityType: bigquery.UserEmailEntity,
 			Entity:     "sample.bigquery.dev@gmail.com"},
@@ -84,14 +84,14 @@ func updateDatasetAccessControl(client *bigquery.Client, datasetID string) error
 
 	// Leverage the ETag for the update to assert there's been no modifications to the
 	// dataset since the metadata was originally read.
-	if _, err := ds.Update(ctx, changes, original.ETag); err != nil {
+	if _, err := ds.Update(ctx, update, meta.ETag); err != nil {
 		return err
 	}
 	// [END bigquery_update_dataset_access]
 	return nil
 }
 
-func getDatasetLabels(client *bigquery.Client, w io.Writer, datasetID string) error {
+func datasetLabels(client *bigquery.Client, w io.Writer, datasetID string) error {
 	ctx := context.Background()
 	// [START bigquery_get_dataset_labels]
 	meta, err := client.Dataset(datasetID).Metadata(ctx)
@@ -99,8 +99,8 @@ func getDatasetLabels(client *bigquery.Client, w io.Writer, datasetID string) er
 		return err
 	}
 	fmt.Fprintf(w, "Dataset %s labels:\n", datasetID)
-	if meta.Labels == nil {
-		fmt.Fprintln(w, "dataset has no labels defined.")
+	if len(meta.Labels) == 0 {
+		fmt.Fprintln(w, "Dataset has no labels defined.")
 		return nil
 	}
 	for k, v := range meta.Labels {
@@ -110,35 +110,35 @@ func getDatasetLabels(client *bigquery.Client, w io.Writer, datasetID string) er
 	return nil
 }
 
-func updateDatasetAddLabel(client *bigquery.Client, datasetID string) error {
+func addDatasetLabel(client *bigquery.Client, datasetID string) error {
 	ctx := context.Background()
 	// [START bigquery_label_dataset]
 	ds := client.Dataset(datasetID)
-	original, err := ds.Metadata(ctx)
+	meta, err := ds.Metadata(ctx)
 	if err != nil {
 		return err
 	}
 
-	meta := bigquery.DatasetMetadataToUpdate{}
-	meta.SetLabel("color", "green")
-	if _, err := ds.Update(ctx, meta, original.ETag); err != nil {
+	update := bigquery.DatasetMetadataToUpdate{}
+	update.SetLabel("color", "green")
+	if _, err := ds.Update(ctx, update, meta.ETag); err != nil {
 		return err
 	}
 	// [END bigquery_label_dataset]
 	return nil
 }
 
-func updateDatasetDeleteLabel(client *bigquery.Client, datasetID string) error {
+func deleteDatasetLabel(client *bigquery.Client, datasetID string) error {
 	ctx := context.Background()
 	// [START bigquery_delete_label_dataset]
 	ds := client.Dataset(datasetID)
-	originalMeta, err := ds.Metadata(ctx)
+	meta, err := ds.Metadata(ctx)
 	if err != nil {
 		return err
 	}
-	newMeta := bigquery.DatasetMetadataToUpdate{}
-	newMeta.DeleteLabel("color")
-	if _, err := ds.Update(ctx, newMeta, originalMeta.ETag); err != nil {
+	update := bigquery.DatasetMetadataToUpdate{}
+	update.DeleteLabel("color")
+	if _, err := ds.Update(ctx, update, meta.ETag); err != nil {
 		return err
 	}
 	// [END bigquery_delete_label_dataset]
@@ -311,14 +311,14 @@ func updateTableDescription(client *bigquery.Client, datasetID, tableID string) 
 	ctx := context.Background()
 	// [START bigquery_update_table_description]
 	tableRef := client.Dataset(datasetID).Table(tableID)
-	original, err := tableRef.Metadata(ctx)
+	meta, err := tableRef.Metadata(ctx)
 	if err != nil {
 		return err
 	}
-	newMeta := bigquery.TableMetadataToUpdate{
+	update := bigquery.TableMetadataToUpdate{
 		Description: "Updated description.",
 	}
-	if _, err = tableRef.Update(ctx, newMeta, original.ETag); err != nil {
+	if _, err = tableRef.Update(ctx, update, meta.ETag); err != nil {
 		return err
 	}
 	// [END bigquery_update_table_description]
@@ -330,14 +330,14 @@ func updateTableExpiration(client *bigquery.Client, datasetID, tableID string) e
 	ctx := context.Background()
 	// [START bigquery_update_table_expiration]
 	tableRef := client.Dataset(datasetID).Table(tableID)
-	original, err := tableRef.Metadata(ctx)
+	meta, err := tableRef.Metadata(ctx)
 	if err != nil {
 		return err
 	}
-	newMeta := bigquery.TableMetadataToUpdate{
+	update := bigquery.TableMetadataToUpdate{
 		ExpirationTime: time.Now().Add(time.Duration(5*24) * time.Hour), // table expiration in 5 days.
 	}
-	if _, err = tableRef.Update(ctx, newMeta, original.ETag); err != nil {
+	if _, err = tableRef.Update(ctx, update, meta.ETag); err != nil {
 		return err
 	}
 	// [END bigquery_update_table_expiration]
@@ -345,7 +345,7 @@ func updateTableExpiration(client *bigquery.Client, datasetID, tableID string) e
 
 }
 
-func getTableLabels(client *bigquery.Client, w io.Writer, datasetID, tableID string) error {
+func tableLabels(client *bigquery.Client, w io.Writer, datasetID, tableID string) error {
 	ctx := context.Background()
 	// [START bigquery_get_table_labels]
 	meta, err := client.Dataset(datasetID).Table(tableID).Metadata(ctx)
@@ -353,8 +353,8 @@ func getTableLabels(client *bigquery.Client, w io.Writer, datasetID, tableID str
 		return err
 	}
 	fmt.Fprintf(w, "Table %s labels:\n", datasetID)
-	if meta.Labels == nil {
-		fmt.Println("dataset has no labels defined.")
+	if len(meta.Labels) == 0 {
+		fmt.Println("Table has no labels defined.")
 		return nil
 	}
 	for k, v := range meta.Labels {
@@ -364,35 +364,35 @@ func getTableLabels(client *bigquery.Client, w io.Writer, datasetID, tableID str
 	return nil
 }
 
-func updateTableAddLabel(client *bigquery.Client, datasetID, tableID string) error {
+func addTableLabel(client *bigquery.Client, datasetID, tableID string) error {
 	ctx := context.Background()
 	// [START bigquery_label_table]
 	tbl := client.Dataset(datasetID).Table(tableID)
-	original, err := tbl.Metadata(ctx)
+	meta, err := tbl.Metadata(ctx)
 	if err != nil {
 		return err
 	}
 
-	meta := bigquery.TableMetadataToUpdate{}
-	meta.SetLabel("color", "green")
-	if _, err := tbl.Update(ctx, meta, original.ETag); err != nil {
+	update := bigquery.TableMetadataToUpdate{}
+	update.SetLabel("color", "green")
+	if _, err := tbl.Update(ctx, update, meta.ETag); err != nil {
 		return err
 	}
 	// [END bigquery_label_table]
 	return nil
 }
 
-func updateTableDeleteLabel(client *bigquery.Client, datasetID, tableID string) error {
+func deleteTableLabel(client *bigquery.Client, datasetID, tableID string) error {
 	ctx := context.Background()
 	// [START bigquery_delete_label_table]
 	tbl := client.Dataset(datasetID).Table(tableID)
-	originalMeta, err := tbl.Metadata(ctx)
+	meta, err := tbl.Metadata(ctx)
 	if err != nil {
 		return err
 	}
-	newMeta := bigquery.TableMetadataToUpdate{}
-	newMeta.DeleteLabel("color")
-	if _, err := tbl.Update(ctx, newMeta, originalMeta.ETag); err != nil {
+	update := bigquery.TableMetadataToUpdate{}
+	update.DeleteLabel("color")
+	if _, err := tbl.Update(ctx, update, meta.ETag); err != nil {
 		return err
 	}
 	// [END bigquery_delete_label_table]
@@ -686,7 +686,7 @@ func printTableInfo(client *bigquery.Client, datasetID, tableID string) error {
 	// Print basic information about the table.
 	fmt.Printf("Schema has %d top-level fields\n", len(meta.Schema))
 	fmt.Printf("Description: %s\n", meta.Description)
-	fmt.Printf("Row in managed storage: %d\n", meta.NumRows)
+	fmt.Printf("Rows in managed storage: %d\n", meta.NumRows)
 	// [END bigquery_get_table]
 	return nil
 }

--- a/bigquery/snippets/snippet_test.go
+++ b/bigquery/snippets/snippet_test.go
@@ -48,8 +48,6 @@ func TestAll(t *testing.T) {
 	tc := testutil.SystemTest(t)
 	ctx := context.Background()
 
-	buf := &bytes.Buffer{}
-
 	client, err := bigquery.NewClient(ctx, tc.ProjectID)
 	if err != nil {
 		t.Fatal(err)
@@ -65,10 +63,12 @@ func TestAll(t *testing.T) {
 	if err := updateDatasetAccessControl(client, datasetID); err != nil {
 		t.Errorf("updateDataSetAccessControl(%q): %v", datasetID, err)
 	}
-	if err := updateDatasetAddLabel(client, datasetID); err != nil {
+	if err := addDatasetLabel(client, datasetID); err != nil {
 		t.Errorf("updateDatasetAddLabel: %v", err)
 	}
-	if err := getDatasetLabels(client, buf, datasetID); err != nil {
+
+	buf := &bytes.Buffer{}
+	if err := datasetLabels(client, buf, datasetID); err != nil {
 		t.Errorf("getDatasetLabels(%q): %v", datasetID, err)
 	}
 	want := "color:green"
@@ -76,7 +76,7 @@ func TestAll(t *testing.T) {
 		t.Errorf("getDatasetLabel(%q) expected %q to contain %q", datasetID, got, want)
 	}
 
-	if err := updateDatasetAddLabel(client, datasetID); err != nil {
+	if err := addDatasetLabel(client, datasetID); err != nil {
 		t.Errorf("updateDatasetAddLabel: %v", err)
 	}
 	buf.Reset()
@@ -86,7 +86,7 @@ func TestAll(t *testing.T) {
 	if got := buf.String(); !strings.Contains(got, datasetID) {
 		t.Errorf("listDatasetsByLabel expected %q to contain %q", got, want)
 	}
-	if err := updateDatasetDeleteLabel(client, datasetID); err != nil {
+	if err := deleteDatasetLabel(client, datasetID); err != nil {
 		t.Errorf("updateDatasetDeleteLabel: %v", err)
 	}
 
@@ -129,10 +129,10 @@ func TestAll(t *testing.T) {
 	if err := updateTableExpiration(client, datasetID, explicit); err != nil {
 		t.Errorf("updateTableExpiration(dataset:%q table:%q): %v", datasetID, explicit, err)
 	}
-	if err := updateTableAddLabel(client, datasetID, explicit); err != nil {
+	if err := addTableLabel(client, datasetID, explicit); err != nil {
 		t.Errorf("updateTableAddLabel(dataset:%q table:%q): %v", datasetID, explicit, err)
 	}
-	if err := updateTableDeleteLabel(client, datasetID, explicit); err != nil {
+	if err := deleteTableLabel(client, datasetID, explicit); err != nil {
 		t.Errorf("updateTableAddLabel(dataset:%q table:%q): %v", datasetID, explicit, err)
 	}
 


### PR DESCRIPTION
Adds snippets related to Labels functionality, as well as a snippet for bigquery.jobs.list.

Within the BQ API, only the Datasets collection supports the necessary label filtration at present, hence the lack of parity on labels snippets.
