### PR TITLE
Delete unused Datastore region tags / samples.

### DIFF
--- a/datastore/snippets/snippet_test.go
+++ b/datastore/snippets/snippet_test.go
@@ -376,21 +376,10 @@ func SnippetQuery_KeysOnly() {
 	// [START datastore_keys_only_query]
 	query := datastore.NewQuery("Task").KeysOnly()
 	// [END datastore_keys_only_query]
-	// [START datastore_run_keys_only_query]
+
 	keys, err := client.GetAll(ctx, query, nil)
-	// [END datastore_run_keys_only_query]
 	_ = err  // Make sure you check err.
 	_ = keys // Keys contains keys for all stored tasks.
-}
-
-func SnippetQuery_Distinct() {
-	// [START datastore_distinct_query]
-	query := datastore.NewQuery("Task").
-		Project("Priority", "PercentComplete").
-		Distinct().
-		Order("Category").Order("Priority")
-	// [END datastore_distinct_query]
-	_ = query // Use client.Run or client.GetAll to execute the query.
 }
 
 func SnippetQuery_DistinctOn() {

--- a/datastore/tasks/tasks.go
+++ b/datastore/tasks/tasks.go
@@ -2,8 +2,6 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
-// [START datastore_all]
-
 // A simple command-line task list manager to demonstrate using the
 // cloud.google.com/go/datastore package.
 package main
@@ -180,7 +178,6 @@ func DeleteTask(ctx context.Context, client *datastore.Client, taskID int64) err
 
 // [END datastore_delete_entity]
 
-// [START datastore_format_results]
 // PrintTasks prints the tasks to the given writer.
 func PrintTasks(w io.Writer, tasks []*Task) {
 	// Use a tab writer to help make results pretty.
@@ -196,7 +193,6 @@ func PrintTasks(w io.Writer, tasks []*Task) {
 	tw.Flush()
 }
 
-// [END datastore_format_results]
 
 func usage() {
 	fmt.Print(`Usage:
@@ -220,5 +216,3 @@ func parseCmd(line string) (cmd, args string, n int64) {
 	}
 	return cmd, args, n
 }
-
-// [END datastore_all]

--- a/datastore/tasks/tasks.go
+++ b/datastore/tasks/tasks.go
@@ -193,7 +193,6 @@ func PrintTasks(w io.Writer, tasks []*Task) {
 	tw.Flush()
 }
 
-
 func usage() {
 	fmt.Print(`Usage:
 


### PR DESCRIPTION
These samples/region tags aren't used on cloud.google.com, hence I'm removing them here.

Related:

- GoogleCloudPlatform/python-docs-samples#1531
- googleapis/nodejs-datastore#110
- GoogleCloudPlatform/java-docs-samples#1138
- GoogleCloudPlatform/php-docs-samples#631
- GoogleCloudPlatform/ruby-docs-samples#292
- GoogleCloudPlatform/dotnet-docs-samples#569