### PR TITLE
errorreporting: remove Flush call

### DIFF
--- a/errorreporting/errorreporting_quickstart/main.go
+++ b/errorreporting/errorreporting_quickstart/main.go
@@ -35,7 +35,6 @@ func main() {
 		log.Fatal(err)
 	}
 	defer errorClient.Close()
-	defer errorClient.Flush()
 
 	resp, err := http.Get("not-a-valid-url")
 	if err != nil {


### PR DESCRIPTION
Close now calls Flush, so remove the explicit call from the sample.