### PR TITLE
appengine_flexible/pubsub: remove GOOGLE_CLOUD_PROJECT variable

### DIFF
--- a/appengine_flexible/pubsub/app.yaml
+++ b/appengine_flexible/pubsub/app.yaml
@@ -6,6 +6,5 @@ automatic_scaling:
 
 #[START env_variables]
 env_variables:
-  GOOGLE_CLOUD_PROJECT: your-project-id
   PUBSUB_TOPIC: your-topic
 #[END env_variables]


### PR DESCRIPTION
The environment variable has been reserved for AppEngine use.
`gcloud app deploy` said:

```
ERROR: (gcloud.app.deploy) Error Response: [13] Environment variable(s) ['GOOGLE_CLOUD_PROJECT'] are reserved for App Engine use.
```
/cc @broady 