### PR TITLE
testing: only get deps for modified directories

### DIFF
--- a/testing/kokoro/system_tests.sh
+++ b/testing/kokoro/system_tests.sh
@@ -54,7 +54,7 @@ if [ -z ${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-} ]; then
 fi
 
 # CHANGED_DIRS is the list of top-level directories that changed. CHANGED_DIRS will be empty when run on master.
-CHANGED_DIRS=$(git --no-pager diff --name-only HEAD $(git merge-base HEAD master) | grep "/" | cut -d/ -f1 | sort | uniq || true)
+CHANGED_DIRS=$(git --no-pager diff --name-only HEAD..master | grep "/" | cut -d/ -f1 | sort | uniq || true)
 # If test configuration is changed, run all tests.
 if [[ $CHANGED_DIRS =~ "testing" ]]; then
   RUN_ALL_TESTS="1"

--- a/testing/kokoro/system_tests.sh
+++ b/testing/kokoro/system_tests.sh
@@ -56,7 +56,7 @@ fi
 # CHANGED_DIRS is the list of top-level directories that changed. CHANGED_DIRS will be empty when run on master.
 CHANGED_DIRS=$(git --no-pager diff --name-only HEAD..master | grep "/" | cut -d/ -f1 | sort | uniq || true)
 # If test configuration is changed, run all tests.
-if [[ $CHANGED_DIRS =~ "testing" ]]; then
+if [[ $CHANGED_DIRS =~ "testing" || $CHANGED_DIRS =~ "internal" ]]; then
   RUN_ALL_TESTS="1"
 fi
 


### PR DESCRIPTION
Downloading dependencies is often the slowest part of a testing a PR. This PR changes the test script to only get dependencies needed to run tests in modified directories. `go vet` is also only run on modified directories since it requires the dependencies of what's being vetted.

This PR also simplifies the `git diff` command. From `man git-diff`:
```
"git diff A...B" is equivalent to "git diff $(git-merge-base A B) B".
```