### PR TITLE
speech: fix calls to Reader.Read

### DIFF
--- a/speech/livecaption/livecaption.go
+++ b/speech/livecaption/livecaption.go
@@ -53,6 +53,15 @@ func main() {
 		buf := make([]byte, 1024)
 		for {
 			n, err := os.Stdin.Read(buf)
+			if n > 0 {
+				if err := stream.Send(&speechpb.StreamingRecognizeRequest{
+					StreamingRequest: &speechpb.StreamingRecognizeRequest_AudioContent{
+						AudioContent: buf[:n],
+					},
+				}); err != nil {
+					log.Printf("Could not send audio: %v", err)
+				}
+			}
 			if err == io.EOF {
 				// Nothing else to pipe, close the stream.
 				if err := stream.CloseSend(); err != nil {
@@ -63,13 +72,6 @@ func main() {
 			if err != nil {
 				log.Printf("Could not read from stdin: %v", err)
 				continue
-			}
-			if err = stream.Send(&speechpb.StreamingRecognizeRequest{
-				StreamingRequest: &speechpb.StreamingRecognizeRequest_AudioContent{
-					AudioContent: buf[:n],
-				},
-			}); err != nil {
-				log.Printf("Could not send audio: %v", err)
 			}
 		}
 	}()

--- a/speech/livecaption_from_file/livecaption_from_file.go
+++ b/speech/livecaption_from_file/livecaption_from_file.go
@@ -68,6 +68,15 @@ func main() {
 		buf := make([]byte, 1024)
 		for {
 			n, err := f.Read(buf)
+			if n > 0 {
+				if err := stream.Send(&speechpb.StreamingRecognizeRequest{
+					StreamingRequest: &speechpb.StreamingRecognizeRequest_AudioContent{
+						AudioContent: buf[:n],
+					},
+				}); err != nil {
+					log.Printf("Could not send audio: %v", err)
+				}
+			}
 			if err == io.EOF {
 				// Nothing else to pipe, close the stream.
 				if err := stream.CloseSend(); err != nil {
@@ -78,13 +87,6 @@ func main() {
 			if err != nil {
 				log.Printf("Could not read from %s: %v", audioFile, err)
 				continue
-			}
-			if err = stream.Send(&speechpb.StreamingRecognizeRequest{
-				StreamingRequest: &speechpb.StreamingRecognizeRequest_AudioContent{
-					AudioContent: buf[:n],
-				},
-			}); err != nil {
-				log.Printf("Could not send audio: %v", err)
 			}
 		}
 	}()

--- a/testing/kokoro/system_tests.sh
+++ b/testing/kokoro/system_tests.sh
@@ -102,6 +102,9 @@ if go version | grep go1\.6\.; then
   popd;
 fi
 
+# Always download internal dependencies.
+go get ./internal/...
+
 go get github.com/jstemmer/go-junit-report
 go install golang.org/x/tools/imports;
 go install -v $GO_IMPORTS


### PR DESCRIPTION
The livecaption and livecaption_from_file samples were calling Read
incorrectly: it is possible to get n > 0 bytes along with an error, so
it is important to process the bytes before checking the error.