### PR TITLE
monitoring/uptime: add update sample

### DIFF
--- a/monitoring/uptime/uptime.go
+++ b/monitoring/uptime/uptime.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/api/iterator"
 	"google.golang.org/genproto/googleapis/api/monitoredres"
 	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
+	"google.golang.org/genproto/protobuf/field_mask"
 )
 
 // [START monitoring_uptime_check_create]
@@ -137,6 +138,40 @@ func get(w io.Writer, resourceName string) {
 }
 
 // [END monitoring_uptime_check_get]
+
+// [START monitoring_uptime_check_update]
+
+// update is an example of updating an uptime check. resourceName should be
+// of the form `projects/[PROJECT_ID]/uptimeCheckConfigs/[UPTIME_CHECK_ID]`.
+func update(w io.Writer, resourceName, displayName, httpCheckPath string) {
+	ctx := context.Background()
+	client, err := monitoring.NewUptimeCheckClient(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer client.Close()
+	getReq := &monitoringpb.GetUptimeCheckConfigRequest{
+		Name: resourceName,
+	}
+	config, err := client.GetUptimeCheckConfig(ctx, getReq)
+	if err != nil {
+		log.Fatal(err)
+	}
+	config.DisplayName = displayName
+	config.GetHttpCheck().Path = httpCheckPath
+	req := &monitoringpb.UpdateUptimeCheckConfigRequest{
+		UpdateMask: &field_mask.FieldMask{
+			Paths: []string{"display_name", "http_check.path"},
+		},
+		UptimeCheckConfig: config,
+	}
+	if _, err := client.UpdateUptimeCheckConfig(ctx, req); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Fprintf(w, "Successfully updated %v", resourceName)
+}
+
+// [END monitoring_uptime_check_update]
 
 // [START monitoring_uptime_check_delete]
 

--- a/monitoring/uptime/uptime_test.go
+++ b/monitoring/uptime/uptime_test.go
@@ -95,6 +95,40 @@ func TestGet(t *testing.T) {
 	}
 }
 
+func TestUpdate(t *testing.T) {
+	c := testutil.SystemTest(t)
+	uc := createTestUptimeCheck(c.ProjectID)
+	buf := new(bytes.Buffer)
+	displayName := "New display name"
+	path := "example.com/example"
+	update(buf, uc.GetName(), displayName, path)
+
+	want := "Successfully"
+	if got := buf.String(); !strings.Contains(got, want) {
+		t.Errorf("%q not found in output: %q", want, got)
+	}
+
+	ctx := context.Background()
+	client, err := monitoring.NewUptimeCheckClient(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	req := &monitoringpb.GetUptimeCheckConfigRequest{
+		Name: uc.GetName(),
+	}
+	updated, err := client.GetUptimeCheckConfig(ctx, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := updated.GetDisplayName(); got != displayName {
+		t.Errorf("Display name not updated: got %q, want %q", got, displayName)
+	}
+	if got := updated.GetHttpCheck().GetPath(); got != path {
+		t.Errorf("HTTP path not updated: got %q, want %q", got, displayName)
+	}
+}
+
 func TestDelete(t *testing.T) {
 	c := testutil.SystemTest(t)
 	uc := createTestUptimeCheck(c.ProjectID)

--- a/monitoring/uptime/uptime_test.go
+++ b/monitoring/uptime/uptime_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc. All rights reserved.
+// Copyright 2018 Google Inc. All rights reserved.
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
@@ -6,32 +6,33 @@ package uptime
 
 import (
 	"bytes"
-	"log"
+	"io/ioutil"
 	"strings"
 	"testing"
 
-	monitoring "cloud.google.com/go/monitoring/apiv3"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-	"github.com/golang/protobuf/ptypes/duration"
-	"golang.org/x/net/context"
-	"google.golang.org/genproto/googleapis/api/monitoredres"
-	monitoringpb "google.golang.org/genproto/googleapis/monitoring/v3"
 )
 
 func TestCreate(t *testing.T) {
 	c := testutil.SystemTest(t)
 	buf := new(bytes.Buffer)
-	create(buf, c.ProjectID)
+	config, err := create(buf, c.ProjectID)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
 	want := "Successfully"
 	if got := buf.String(); !strings.Contains(got, want) {
 		t.Errorf("%q not found in output: %q", want, got)
 	}
+	delete(ioutil.Discard, config.GetName())
 }
 
 func TestList(t *testing.T) {
 	c := testutil.SystemTest(t)
 	buf := new(bytes.Buffer)
-	list(buf, c.ProjectID)
+	if err := list(buf, c.ProjectID); err != nil {
+		t.Fatalf("list: %v", err)
+	}
 	want := "Done"
 	if got := buf.String(); !strings.Contains(got, want) {
 		t.Errorf("%q not found in output: %q", want, got)
@@ -41,86 +42,51 @@ func TestList(t *testing.T) {
 func TestListIPs(t *testing.T) {
 	testutil.SystemTest(t)
 	buf := new(bytes.Buffer)
-	listIPs(buf)
+	if err := listIPs(buf); err != nil {
+		t.Fatalf("listIPs: %v", err)
+	}
 	want := "Done"
 	if got := buf.String(); !strings.Contains(got, want) {
 		t.Errorf("%q not found in output: %q", want, got)
 	}
 }
 
-func createTestUptimeCheck(projectID string) *monitoringpb.UptimeCheckConfig {
-	ctx := context.Background()
-	client, err := monitoring.NewUptimeCheckClient(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer client.Close()
-	req := &monitoringpb.CreateUptimeCheckConfigRequest{
-		Parent: "projects/" + projectID,
-		UptimeCheckConfig: &monitoringpb.UptimeCheckConfig{
-			DisplayName: "new uptime check",
-			Resource: &monitoringpb.UptimeCheckConfig_MonitoredResource{
-				MonitoredResource: &monitoredres.MonitoredResource{
-					Type: "uptime_url",
-					Labels: map[string]string{
-						"host": "example.com",
-					},
-				},
-			},
-			CheckRequestType: &monitoringpb.UptimeCheckConfig_HttpCheck_{
-				HttpCheck: &monitoringpb.UptimeCheckConfig_HttpCheck{
-					Path: "/",
-					Port: 80,
-				},
-			},
-			Timeout: &duration.Duration{Seconds: 10},
-			Period:  &duration.Duration{Seconds: 300},
-		},
-	}
-	uc, err := client.CreateUptimeCheckConfig(ctx, req)
-	if err != nil {
-		log.Fatal(err)
-	}
-	return uc
-}
-
 func TestGet(t *testing.T) {
 	c := testutil.SystemTest(t)
-	uc := createTestUptimeCheck(c.ProjectID)
+	config, err := create(ioutil.Discard, c.ProjectID)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer delete(ioutil.Discard, config.GetName())
 	buf := new(bytes.Buffer)
-	get(buf, uc.GetName())
-	want := "Config:"
-	if got := buf.String(); !strings.Contains(got, want) {
-		t.Errorf("%q not found in output: %q", want, got)
+	got, err := get(buf, config.GetName())
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.GetDisplayName() != config.GetDisplayName() {
+		t.Fatalf("display names not equal: want %q, got %q", config.GetDisplayName(), got.GetDisplayName())
 	}
 }
 
 func TestUpdate(t *testing.T) {
 	c := testutil.SystemTest(t)
-	uc := createTestUptimeCheck(c.ProjectID)
+	config, err := create(ioutil.Discard, c.ProjectID)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer delete(ioutil.Discard, config.GetName())
 	buf := new(bytes.Buffer)
 	displayName := "New display name"
 	path := "example.com/example"
-	update(buf, uc.GetName(), displayName, path)
-
+	updated, err := update(buf, config.GetName(), displayName, path)
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
 	want := "Successfully"
 	if got := buf.String(); !strings.Contains(got, want) {
 		t.Errorf("%q not found in output: %q", want, got)
 	}
 
-	ctx := context.Background()
-	client, err := monitoring.NewUptimeCheckClient(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer client.Close()
-	req := &monitoringpb.GetUptimeCheckConfigRequest{
-		Name: uc.GetName(),
-	}
-	updated, err := client.GetUptimeCheckConfig(ctx, req)
-	if err != nil {
-		t.Fatal(err)
-	}
 	if got := updated.GetDisplayName(); got != displayName {
 		t.Errorf("Display name not updated: got %q, want %q", got, displayName)
 	}
@@ -131,9 +97,12 @@ func TestUpdate(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 	c := testutil.SystemTest(t)
-	uc := createTestUptimeCheck(c.ProjectID)
+	config, err := create(ioutil.Discard, c.ProjectID)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
 	buf := new(bytes.Buffer)
-	delete(buf, uc.GetName())
+	delete(buf, config.GetName())
 	want := "Successfully"
 	if got := buf.String(); !strings.Contains(got, want) {
 		t.Errorf("%q not found in output: %q", want, got)


### PR DESCRIPTION
Should we switch the samples to return `error` and possibly `(*monitoringpb.UptimeCheckConfig, error)`? Would simplify some of the testing and error handling (see the new `TestUpdate` -- `update` could very well return the updated config and `TestUpdate` wouldn't need to make the `get` request.)

Let me know what you think and I'll update.

**Edit**: I updated the functions to return configs and errors and I think it's better, especially because it's easier for users to copy & paste (since they probably won't want to `log.Fatal` in their application).