### PR TITLE
Use "http.MethodGet" instead of "GET".

### DIFF
--- a/appengine/gophers/gophers-3/main.go
+++ b/appengine/gophers/gophers-3/main.go
@@ -40,7 +40,7 @@ func indexHandler(w http.ResponseWriter, r *http.Request) {
 	// [START handling]
 	params := templateParams{}
 
-	if r.Method == "GET" {
+	if r.Method == http.MethodGet {
 		indexTemplate.Execute(w, params)
 		return
 	}


### PR DESCRIPTION
I think it would be better if the default Go package const is used instead of a string.

Cleaner code and line 57 does this too.