### PR TITLE
firestore: remove erroneous TODO comment

### DIFF
--- a/firestore/firestore_snippets/save.go
+++ b/firestore/firestore_snippets/save.go
@@ -176,7 +176,7 @@ func updateDocNested(ctx context.Context, client *firestore.Client) error {
 		"favorites": map[string]interface{}{
 			"color": "Red",
 		},
-	}, firestore.MergeAll) // TODO(cbro): this should fail
+	}, firestore.MergeAll)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I have no idea why I wrote this TODO, but everything seems to work,
tests pass, and this just confuses people reading the snippet in the
docs.