### PR TITLE
BigQuery: many new samples

### DIFF
--- a/bigquery/snippets/snippet.go
+++ b/bigquery/snippets/snippet.go
@@ -23,6 +23,7 @@ func noOpCommentFunc() {
 	// [START bigquery_add_empty_column]
 	// [START bigquery_add_column_query_append]
 	// [START bigquery_browse_table]
+	// [START bigquery_cancel_job]
 	// [START bigquery_copy_table]
 	// [START bigquery_copy_table_cmek]
 	// [START bigquery_copy_table_multiple_source]
@@ -40,6 +41,7 @@ func noOpCommentFunc() {
 	// [START bigquery_extract_table_json]
 	// [START bigquery_get_dataset]
 	// [START bigquery_get_dataset_labels]
+	// [START bigquery_get_job]
 	// [START bigquery_get_table]
 	// [START bigquery_get_table_labels]
 	// [START bigquery_label_dataset]
@@ -93,6 +95,7 @@ func noOpCommentFunc() {
 	// [END bigquery_add_empty_column]
 	// [END bigquery_add_column_query_append]
 	// [END bigquery_browse_table]
+	// [END bigquery_cancel_job]
 	// [END bigquery_copy_table]
 	// [END bigquery_copy_table_cmek]
 	// [END bigquery_copy_table_multiple_source]
@@ -110,6 +113,7 @@ func noOpCommentFunc() {
 	// [END bigquery_extract_table_json]
 	// [END bigquery_get_dataset]
 	// [END bigquery_get_dataset_labels]
+	// [END bigquery_get_job]
 	// [END bigquery_get_table]
 	// [END bigquery_get_table_labels]
 	// [END bigquery_label_dataset]
@@ -155,6 +159,17 @@ func noOpCommentFunc() {
 	// [END bigquery_update_dataset_expiration]
 	// [END bigquery_update_table_description]
 	// [END bigquery_update_table_expiration]
+}
+
+func cancelJob(client *bigquery.Client, jobID string) error {
+	ctx := context.Background()
+	// [START bigquery_cancel_job]
+	job, err := client.JobFromID(ctx, jobID)
+	if err != nil {
+		return nil
+	}
+	return job.Cancel(ctx)
+	// [END bigquery_cancel_job]
 }
 
 func createDataset(client *bigquery.Client, datasetID string) error {
@@ -1324,6 +1339,30 @@ func deleteAndUndeleteTable(client *bigquery.Client, datasetID, tableID string) 
 	ds.Table(recoverTableID).Delete(ctx)
 	return nil
 
+}
+
+func getJobInfo(client *bigquery.Client, jobID string) error {
+	ctx := context.Background()
+	// [START bigquery_get_job]
+	job, err := client.JobFromID(ctx, jobID)
+	if err != nil {
+		return err
+	}
+
+	status := job.LastStatus()
+	state := "Unknown"
+	switch status.State {
+	case bigquery.Pending:
+		state = "Pending"
+	case bigquery.Running:
+		state = "Running"
+	case bigquery.Done:
+		state = "Done"
+	}
+	fmt.Printf("Job %s was created %v and is in state %s\n",
+		jobID, status.Statistics.CreationTime, state)
+	// [END bigquery_get_job]
+	return nil
 }
 
 func importCSVFromFile(client *bigquery.Client, datasetID, tableID, filename string) error {

--- a/bigquery/snippets/snippet.go
+++ b/bigquery/snippets/snippet.go
@@ -16,129 +16,142 @@ import (
 	"google.golang.org/api/iterator"
 )
 
-// Use a common block to inline comments related to importing the library
-// and constructing a client.
-// [START bigquery_add_empty_column]
-// [START bigquery_add_column_query_append]
-// [START bigquery_browse_table]
-// [START bigquery_copy_table]
-// [START bigquery_copy_table_cmek]
-// [START bigquery_copy_table_multiple_source]
-// [START bigquery_create_dataset]
-// [START bigquery_create_table]
-// [START bigquery_create_table_clustered]
-// [START bigquery_create_table_partitioned]
-// [START bigquery_delete_dataset]
-// [START bigquery_delete_label_dataset]
-// [START bigquery_delete_label_table]
-// [START bigquery_delete_table]
-// [START bigquery_extract_table]
-// [START bigquery_extract_table_compressed]
-// [START bigquery_extract_table_json]
-// [START bigquery_get_dataset]
-// [START bigquery_get_dataset_labels]
-// [START bigquery_get_table]
-// [START bigquery_get_table_labels]
-// [START bigquery_label_dataset]
-// [START bigquery_label_table]
-// [START bigquery_list_datasets]
-// [START bigquery_list_datasets_by_label]
-// [START bigquery_list_jobs]
-// [START bigquery_list_tables]
-// [START bigquery_load_from_file]
-// [START bigquery_load_table_clustered]
-// [START bigquery_load_table_gcs_csv]
-// [START bigquery_load_table_gcs_json]
-// [START bigquery_load_table_gcs_json_autodetect]
-// [START bigquery_load_table_gcs_parquet]
-// [START bigquery_load_table_gcs_parquet_truncate]
-// [START bigquery_load_table_partitioned]
-// [START bigquery_nested_repeated_schema]
-// [START bigquery_query]
-// [START bigquery_query_batch]
-// [START bigquery_query_clustered_table]
-// [START bigquery_query_destination_table]
-// [START bigquery_query_dry_run]
-// [START bigquery_query_legacy]
-// [START bigquery_query_legacy_large_results]
-// [START bigquery_query_no_cache]
-// [START bigquery_query_params_arrays]
-// [START bigquery_query_params_named]
-// [START bigquery_query_params_positional]
-// [START bigquery_query_params_structs]
-// [START bigquery_query_params_timestamps]
-// [START bigquery_query_partitioned_table]
-// [START bigquery_relax_column]
-// [START bigquery_table_insert_rows]
-// [START bigquery_undelete_table]
-// [START bigquery_update_dataset_access]
-// [START bigquery_update_dataset_description]
-// [START bigquery_update_dataset_expiration]
-// [START bigquery_update_table_description]
-// [START bigquery_update_table_expiration]
-// To run this sample, you will need to create (or reuse) a context and
-// an instance of the bigquery client.  For example:
-// import "cloud.google.com/go/bigquery"
-// ctx := context.Background()
-// client, err := bigquery.NewClient(ctx, "your-project-id")
-// [END bigquery_add_empty_column]
-// [END bigquery_add_column_query_append]
-// [END bigquery_browse_table]
-// [END bigquery_copy_table]
-// [END bigquery_copy_table_cmek]
-// [END bigquery_copy_table_multiple_source]
-// [END bigquery_create_dataset]
-// [END bigquery_create_table]
-// [END bigquery_create_table_clustered]
-// [END bigquery_create_table_partitioned]
-// [END bigquery_delete_dataset]
-// [END bigquery_delete_label_dataset]
-// [END bigquery_delete_label_table]
-// [END bigquery_delete_table]
-// [END bigquery_extract_table]
-// [END bigquery_extract_table_compressed]
-// [END bigquery_extract_table_json]
-// [END bigquery_get_dataset]
-// [END bigquery_get_dataset_labels]
-// [END bigquery_get_table]
-// [END bigquery_get_table_labels]
-// [END bigquery_label_dataset]
-// [END bigquery_label_table]
-// [END bigquery_list_datasets]
-// [END bigquery_list_datasets_by_label]
-// [END bigquery_list_jobs]
-// [END bigquery_list_tables]
-// [END bigquery_load_from_file]
-// [END bigquery_load_table_clustered]
-// [END bigquery_load_table_gcs_csv]
-// [END bigquery_load_table_gcs_json]
-// [END bigquery_load_table_gcs_json_autodetect]
-// [END bigquery_load_table_gcs_parquet]
-// [END bigquery_load_table_gcs_parquet_truncate]
-// [END bigquery_load_table_partitioned]
-// [END bigquery_nested_repeated_schema]
-// [END bigquery_query]
-// [END bigquery_query_batch]
-// [END bigquery_query_clustered_table]
-// [END bigquery_query_destination_table]
-// [END bigquery_query_dry_run]
-// [END bigquery_query_legacy]
-// [END bigquery_query_legacy_large_results]
-// [END bigquery_query_no_cache]
-// [END bigquery_query_params_arrays]
-// [END bigquery_query_params_named]
-// [END bigquery_query_params_positional]
-// [END bigquery_query_params_structs]
-// [END bigquery_query_params_timestamps]
-// [END bigquery_query_partitioned_table]
-// [END bigquery_relax_column]
-// [END bigquery_table_insert_rows]
-// [END bigquery_undelete_table]
-// [END bigquery_update_dataset_access]
-// [END bigquery_update_dataset_description]
-// [END bigquery_update_dataset_expiration]
-// [END bigquery_update_table_description]
-// [END bigquery_update_table_expiration]
+func noOpCommentFunc() {
+	// Use a common block to inline comments related to importing the library
+	// and constructing a client.  Inside a func to ensure the indentation is
+	// consistent between multiple includes.
+	// [START bigquery_add_empty_column]
+	// [START bigquery_add_column_query_append]
+	// [START bigquery_browse_table]
+	// [START bigquery_copy_table]
+	// [START bigquery_copy_table_cmek]
+	// [START bigquery_copy_table_multiple_source]
+	// [START bigquery_create_dataset]
+	// [START bigquery_create_table]
+	// [START bigquery_create_table_clustered]
+	// [START bigquery_create_table_cmek]
+	// [START bigquery_create_table_partitioned]
+	// [START bigquery_delete_dataset]
+	// [START bigquery_delete_label_dataset]
+	// [START bigquery_delete_label_table]
+	// [START bigquery_delete_table]
+	// [START bigquery_extract_table]
+	// [START bigquery_extract_table_compressed]
+	// [START bigquery_extract_table_json]
+	// [START bigquery_get_dataset]
+	// [START bigquery_get_dataset_labels]
+	// [START bigquery_get_table]
+	// [START bigquery_get_table_labels]
+	// [START bigquery_label_dataset]
+	// [START bigquery_label_table]
+	// [START bigquery_list_datasets]
+	// [START bigquery_list_datasets_by_label]
+	// [START bigquery_list_jobs]
+	// [START bigquery_list_tables]
+	// [START bigquery_load_from_file]
+	// [START bigquery_load_table_clustered]
+	// [START bigquery_load_table_gcs_csv]
+	// [START bigquery_load_table_gcs_json]
+	// [START bigquery_load_table_gcs_json_autodetect]
+	// [START bigquery_load_table_gcs_json_cmek]
+	// [START bigquery_load_table_gcs_parquet]
+	// [START bigquery_load_table_gcs_parquet_truncate]
+	// [START bigquery_load_table_partitioned]
+	// [START bigquery_nested_repeated_schema]
+	// [START bigquery_query]
+	// [START bigquery_query_batch]
+	// [START bigquery_query_clustered_table]
+	// [START bigquery_query_destination_table]
+	// [START bigquery_query_dry_run]
+	// [START bigquery_query_legacy]
+	// [START bigquery_query_legacy_large_results]
+	// [START bigquery_query_no_cache]
+	// [START bigquery_query_params_arrays]
+	// [START bigquery_query_params_named]
+	// [START bigquery_query_params_positional]
+	// [START bigquery_query_params_structs]
+	// [START bigquery_query_params_timestamps]
+	// [START bigquery_query_partitioned_table]
+	// [START bigquery_relax_column]
+	// [START bigquery_relax_column_load_append]
+	// [START bigquery_relax_column_query_append]
+	// [START bigquery_table_insert_rows]
+	// [START bigquery_undelete_table]
+	// [START bigquery_update_dataset_access]
+	// [START bigquery_update_dataset_description]
+	// [START bigquery_update_dataset_expiration]
+	// [START bigquery_update_table_cmek]
+	// [START bigquery_update_table_description]
+	// [START bigquery_update_table_expiration]
+	// To run this sample, you will need to create (or reuse) a context and
+	// an instance of the bigquery client.  For example:
+	// import "cloud.google.com/go/bigquery"
+	// ctx := context.Background()
+	// client, err := bigquery.NewClient(ctx, "your-project-id")
+	// [END bigquery_add_empty_column]
+	// [END bigquery_add_column_query_append]
+	// [END bigquery_browse_table]
+	// [END bigquery_copy_table]
+	// [END bigquery_copy_table_cmek]
+	// [END bigquery_copy_table_multiple_source]
+	// [END bigquery_create_dataset]
+	// [END bigquery_create_table]
+	// [END bigquery_create_table_clustered]
+	// [END bigquery_create_table_cmek]
+	// [END bigquery_create_table_partitioned]
+	// [END bigquery_delete_dataset]
+	// [END bigquery_delete_label_dataset]
+	// [END bigquery_delete_label_table]
+	// [END bigquery_delete_table]
+	// [END bigquery_extract_table]
+	// [END bigquery_extract_table_compressed]
+	// [END bigquery_extract_table_json]
+	// [END bigquery_get_dataset]
+	// [END bigquery_get_dataset_labels]
+	// [END bigquery_get_table]
+	// [END bigquery_get_table_labels]
+	// [END bigquery_label_dataset]
+	// [END bigquery_label_table]
+	// [END bigquery_list_datasets]
+	// [END bigquery_list_datasets_by_label]
+	// [END bigquery_list_jobs]
+	// [END bigquery_list_tables]
+	// [END bigquery_load_from_file]
+	// [END bigquery_load_table_clustered]
+	// [END bigquery_load_table_gcs_csv]
+	// [END bigquery_load_table_gcs_json]
+	// [END bigquery_load_table_gcs_json_autodetect]
+	// [END bigquery_load_table_gcs_json_cmek]
+	// [END bigquery_load_table_gcs_parquet]
+	// [END bigquery_load_table_gcs_parquet_truncate]
+	// [END bigquery_load_table_partitioned]
+	// [END bigquery_nested_repeated_schema]
+	// [END bigquery_query]
+	// [END bigquery_query_batch]
+	// [END bigquery_query_clustered_table]
+	// [END bigquery_query_destination_table]
+	// [END bigquery_query_dry_run]
+	// [END bigquery_query_legacy]
+	// [END bigquery_query_legacy_large_results]
+	// [END bigquery_query_no_cache]
+	// [END bigquery_query_params_arrays]
+	// [END bigquery_query_params_named]
+	// [END bigquery_query_params_positional]
+	// [END bigquery_query_params_structs]
+	// [END bigquery_query_params_timestamps]
+	// [END bigquery_query_partitioned_table]
+	// [END bigquery_relax_column]
+	// [END bigquery_relax_column_load_append]
+	// [END bigquery_relax_column_query_append]
+	// [END bigquery_table_insert_rows]
+	// [END bigquery_undelete_table]
+	// [END bigquery_update_dataset_access]
+	// [END bigquery_update_table_cmek]
+	// [END bigquery_update_dataset_description]
+	// [END bigquery_update_dataset_expiration]
+	// [END bigquery_update_table_description]
+	// [END bigquery_update_table_expiration]
+}
 
 func createDataset(client *bigquery.Client, datasetID string) error {
 	ctx := context.Background()
@@ -457,7 +470,7 @@ func createTableComplexSchema(client *bigquery.Client, datasetID, tableID string
 
 func createTableWithCMEK(client *bigquery.Client, datasetID, tableID string) error {
 	ctx := context.Background()
-	// [START bigquery_create_table_cmek
+	// [START bigquery_create_table_cmek]
 	tableRef := client.Dataset(datasetID).Table(tableID)
 	meta := &bigquery.TableMetadata{
 		EncryptionConfig: &bigquery.EncryptionConfig{
@@ -468,11 +481,11 @@ func createTableWithCMEK(client *bigquery.Client, datasetID, tableID string) err
 	if err := tableRef.Create(ctx, meta); err != nil {
 		return err
 	}
-	// [END bigquery_create_table_cmek
+	// [END bigquery_create_table_cmek]
 	return nil
 }
 
-func createTableRequiredThenRelax(client *bigquery.Client, datasetID, tableID string) error {
+func relaxTableAPI(client *bigquery.Client, datasetID, tableID string) error {
 	ctx := context.Background()
 	// [START bigquery_relax_column]
 	sampleSchema := bigquery.Schema{
@@ -499,6 +512,80 @@ func createTableRequiredThenRelax(client *bigquery.Client, datasetID, tableID st
 		return err
 	}
 	// [END  bigquery_relax_column]
+	return nil
+}
+
+func relaxTableImport(client *bigquery.Client, datasetID, tableID, filename string) error {
+	ctx := context.Background()
+	// [START bigquery_relax_column_load_append]
+	sampleSchema := bigquery.Schema{
+		{Name: "full_name", Type: bigquery.StringFieldType, Required: true},
+		{Name: "age", Type: bigquery.IntegerFieldType, Required: true},
+	}
+	meta := &bigquery.TableMetadata{
+		Schema: sampleSchema,
+	}
+	tableRef := client.Dataset(datasetID).Table(tableID)
+	if err := tableRef.Create(ctx, meta); err != nil {
+		return err
+	}
+	// Now, import data from a local file, but specify relaxation of required
+	// fields as a side effect while the data is appended.
+	f, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	source := bigquery.NewReaderSource(f)
+	source.AutoDetect = true   // Allow BigQuery to determine schema.
+	source.SkipLeadingRows = 1 // CSV has a single header line.
+
+	loader := client.Dataset(datasetID).Table(tableID).LoaderFrom(source)
+	loader.SchemaUpdateOptions = []string{"ALLOW_FIELD_RELAXATION"}
+	job, err := loader.Run(ctx)
+	if err != nil {
+		return err
+	}
+	status, err := job.Wait(ctx)
+	if err != nil {
+		return err
+	}
+	if err := status.Err(); err != nil {
+		return err
+	}
+	// [END  bigquery_relax_column_load_append]
+	return nil
+}
+
+func relaxTableQuery(client *bigquery.Client, datasetID, tableID string) error {
+	ctx := context.Background()
+	// [START bigquery_relax_column_query_append]
+	sampleSchema := bigquery.Schema{
+		{Name: "full_name", Type: bigquery.StringFieldType, Required: true},
+		{Name: "age", Type: bigquery.IntegerFieldType, Required: true},
+	}
+	meta := &bigquery.TableMetadata{
+		Schema: sampleSchema,
+	}
+	tableRef := client.Dataset(datasetID).Table(tableID)
+	if err := tableRef.Create(ctx, meta); err != nil {
+		return err
+	}
+	// Now, append a query result that includes nulls, but allow the job to relax
+	// all required columns.
+	q := client.Query("SELECT \"Beyonce\" as full_name")
+	q.QueryConfig.Dst = client.Dataset(datasetID).Table(tableID)
+	q.SchemaUpdateOptions = []string{"ALLOW_FIELD_RELAXATION"}
+	q.WriteDisposition = bigquery.WriteAppend
+	q.Location = "US"
+	job, err := q.Run(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = job.Wait(ctx)
+	if err != nil {
+		return err
+	}
+	// [END bigquery_relax_column_query_append]
 	return nil
 }
 

--- a/bigquery/snippets/snippet.go
+++ b/bigquery/snippets/snippet.go
@@ -725,6 +725,7 @@ func updateTableChangeCMEK(client *bigquery.Client, datasetID, tableID string) e
 	}
 	update := bigquery.TableMetadataToUpdate{
 		EncryptionConfig: &bigquery.EncryptionConfig{
+			// TODO: Replace this key with a key you have created in Cloud KMS.
 			KMSKeyName: "projects/cloud-samples-tests/locations/us-central1/keyRings/test/cryptoKeys/otherkey",
 		},
 	}
@@ -1536,7 +1537,7 @@ func importORCTruncate(client *bigquery.Client, datasetID, tableID string) error
 	gcsRef := bigquery.NewGCSReference("gs://cloud-samples-data/bigquery/us-states/us-states.orc")
 	gcsRef.SourceFormat = bigquery.ORC
 	loader := client.Dataset(datasetID).Table(tableID).LoaderFrom(gcsRef)
-	// default for import jobs is to append data to a table.  WriteTruncate
+	// Default for import jobs is to append data to a table.  WriteTruncate
 	// specifies that existing data should instead be replaced/overwritten.
 	loader.WriteDisposition = bigquery.WriteTruncate
 

--- a/bigquery/snippets/snippet.go
+++ b/bigquery/snippets/snippet.go
@@ -22,6 +22,7 @@ import (
 
 // [START bigquery_browse_table]
 // [START bigquery_copy_table]
+// [START bigquery_copy_table_cmek]
 // [START bigquery_copy_table_multiple_source]
 // [START bigquery_create_dataset]
 // [START bigquery_create_table]
@@ -81,6 +82,7 @@ import (
 // [END bigquery_add_empty_column]
 // [END bigquery_browse_table]
 // [END bigquery_copy_table]
+// [END bigquery_copy_table_cmek]
 // [END bigquery_copy_table_multiple_source]
 // [END bigquery_create_dataset]
 // [END bigquery_create_table]
@@ -1002,6 +1004,29 @@ func copyTable(client *bigquery.Client, datasetID, srcID, dstID string) error {
 		return err
 	}
 	// [END bigquery_copy_table]
+	return nil
+}
+
+func copyTableWithCMEK(client *bigquery.Client, datasetID, tableID string) error {
+	ctx := context.Background()
+	// [START bigquery_copy_table_cmek]
+	srcTable := client.DatasetInProject("bigquery-public-data", "samples").Table("shakespeare")
+	copier := client.Dataset(datasetID).Table(tableID).CopierFrom(srcTable)
+	copier.DestinationEncryptionConfig = &bigquery.EncryptionConfig{
+		KMSKeyName: "projects/cloud-samples-tests/locations/us-central1/keyRings/test/cryptoKeys/test",
+	}
+	job, err := copier.Run(ctx)
+	if err != nil {
+		return err
+	}
+	status, err := job.Wait(ctx)
+	if err != nil {
+		return err
+	}
+	if err := status.Err(); err != nil {
+		return err
+	}
+	// [END bigquery_copy_table_cmek]
 	return nil
 }
 

--- a/bigquery/snippets/snippet.go
+++ b/bigquery/snippets/snippet.go
@@ -54,6 +54,8 @@ func noOpCommentFunc() {
 	// [START bigquery_load_table_gcs_json]
 	// [START bigquery_load_table_gcs_json_autodetect]
 	// [START bigquery_load_table_gcs_json_cmek]
+	// [START bigquery_load_table_gcs_orc]
+	// [START bigquery_load_table_gcs_orc_truncate]
 	// [START bigquery_load_table_gcs_parquet]
 	// [START bigquery_load_table_gcs_parquet_truncate]
 	// [START bigquery_load_table_partitioned]
@@ -122,6 +124,8 @@ func noOpCommentFunc() {
 	// [END bigquery_load_table_gcs_json]
 	// [END bigquery_load_table_gcs_json_autodetect]
 	// [END bigquery_load_table_gcs_json_cmek]
+	// [END bigquery_load_table_gcs_orc]
+	// [END bigquery_load_table_gcs_orc_truncate]
 	// [END bigquery_load_table_gcs_parquet]
 	// [END bigquery_load_table_gcs_parquet_truncate]
 	// [END bigquery_load_table_partitioned]
@@ -1458,6 +1462,55 @@ func importJSONWithCMEK(client *bigquery.Client, datasetID, tableID string) erro
 	}
 
 	// [END bigquery_load_table_gcs_json_cmek]
+	return nil
+}
+
+func importORC(client *bigquery.Client, datasetID, tableID string) error {
+	ctx := context.Background()
+	// [START bigquery_load_table_gcs_orc]
+	gcsRef := bigquery.NewGCSReference("gs://cloud-samples-data/bigquery/us-states/us-states.orc")
+	gcsRef.SourceFormat = bigquery.ORC
+	loader := client.Dataset(datasetID).Table(tableID).LoaderFrom(gcsRef)
+
+	job, err := loader.Run(ctx)
+	if err != nil {
+		return err
+	}
+	status, err := job.Wait(ctx)
+	if err != nil {
+		return err
+	}
+
+	if status.Err() != nil {
+		return fmt.Errorf("Job completed with error: %v", status.Err())
+	}
+	// [END bigquery_load_table_gcs_orc]
+	return nil
+}
+
+func importORCTruncate(client *bigquery.Client, datasetID, tableID string) error {
+	ctx := context.Background()
+	// [START bigquery_load_table_gcs_orc_truncate]
+	gcsRef := bigquery.NewGCSReference("gs://cloud-samples-data/bigquery/us-states/us-states.orc")
+	gcsRef.SourceFormat = bigquery.ORC
+	loader := client.Dataset(datasetID).Table(tableID).LoaderFrom(gcsRef)
+	// default for import jobs is to append data to a table.  WriteTruncate
+	// specifies that existing data should instead be replaced/overwritten.
+	loader.WriteDisposition = bigquery.WriteTruncate
+
+	job, err := loader.Run(ctx)
+	if err != nil {
+		return err
+	}
+	status, err := job.Wait(ctx)
+	if err != nil {
+		return err
+	}
+
+	if status.Err() != nil {
+		return fmt.Errorf("Job completed with error: %v", status.Err())
+	}
+	// [END bigquery_load_table_gcs_orc_truncate]
 	return nil
 }
 

--- a/bigquery/snippets/snippet_test.go
+++ b/bigquery/snippets/snippet_test.go
@@ -126,6 +126,10 @@ func TestAll(t *testing.T) {
 	if err := createTableRequiredThenRelax(client, datasetID, required); err != nil {
 		t.Errorf("createTableRequiredThenRelax(dataset:%q table:%q): %v", datasetID, required, err)
 	}
+	tableCMEK := uniqueBQName("golang_example_table_cmek")
+	if err := createTableWithCMEK(client, datasetID, tableCMEK); err != nil {
+		t.Errorf("createTableWithCMEK(dataset:%q table:%q): %v", datasetID, tableCMEK, err)
+	}
 
 	if err := updateTableDescription(client, datasetID, explicit); err != nil {
 		t.Errorf("updateTableDescription(dataset:%q table:%q): %v", datasetID, explicit, err)
@@ -208,6 +212,10 @@ func TestAll(t *testing.T) {
 	persisted := uniqueBQName("golang_example_table_queryresult")
 	if err := queryWithDestination(client, datasetID, persisted); err != nil {
 		t.Errorf("queryWithDestination(dataset:%q table:%q): %v", datasetID, persisted, err)
+	}
+	persistedCMEK := uniqueBQName("golang_example_table_queryresult_cmek")
+	if err := queryWithDestinationCMEK(client, datasetID, persistedCMEK); err != nil {
+		t.Errorf("queryWithDestinationCMEK(dataset:%q table:%q): %v", datasetID, persistedCMEK, err)
 	}
 
 	// Print information about tables (extended and simple).

--- a/bigquery/snippets/snippet_test.go
+++ b/bigquery/snippets/snippet_test.go
@@ -122,13 +122,15 @@ func TestAll(t *testing.T) {
 	if err := createTableComplexSchema(client, datasetID, complex); err != nil {
 		t.Errorf("createTableComplexSchema(dataset:%q table:%q): %v", datasetID, complex, err)
 	}
-	required := uniqueBQName("golang_example_table_required")
-	if err := createTableRequiredThenRelax(client, datasetID, required); err != nil {
-		t.Errorf("createTableRequiredThenRelax(dataset:%q table:%q): %v", datasetID, required, err)
-	}
+
 	tableCMEK := uniqueBQName("golang_example_table_cmek")
 	if err := createTableWithCMEK(client, datasetID, tableCMEK); err != nil {
 		t.Errorf("createTableWithCMEK(dataset:%q table:%q): %v", datasetID, tableCMEK, err)
+	}
+
+	required := uniqueBQName("golang_example_table_required")
+	if err := relaxTableAPI(client, datasetID, required); err != nil {
+		t.Errorf("relaxTableApi(dataset:%q table:%q): %v", datasetID, required, err)
 	}
 
 	widen := uniqueBQName("golang_example_table_widen")
@@ -308,6 +310,17 @@ func TestImportExport(t *testing.T) {
 	}
 	if err := importParquetTruncate(client, datasetID, parquet); err != nil {
 		t.Errorf("importParquetTruncate(dataset:%q table: %q): %v", datasetID, parquet, err)
+	}
+
+	requiredImport := uniqueBQName("golang_example_table_required_import")
+	filenameRelax := "testdata/people.csv"
+	if err := relaxTableImport(client, datasetID, requiredImport, filenameRelax); err != nil {
+		t.Errorf("relaxTableImport(dataset:%q table:%q): %v", datasetID, requiredImport, err)
+	}
+
+	requiredQuery := uniqueBQName("golang_example_table_required_query")
+	if err := relaxTableQuery(client, datasetID, requiredQuery); err != nil {
+		t.Errorf("relaxTableQuery(dataset:%q table:%q): %v", datasetID, requiredImport, err)
 	}
 
 	bucket := uniqueBucketName("golang-example-bucket", tc.ProjectID)

--- a/bigquery/snippets/snippet_test.go
+++ b/bigquery/snippets/snippet_test.go
@@ -122,6 +122,10 @@ func TestAll(t *testing.T) {
 	if err := createTableComplexSchema(client, datasetID, complex); err != nil {
 		t.Errorf("createTableComplexSchema(dataset:%q table:%q): %v", datasetID, complex, err)
 	}
+	required := uniqueBQName("golang_example_table_required")
+	if err := createTableRequiredThenRelax(client, datasetID, required); err != nil {
+		t.Errorf("createTableRequiredThenRelax(dataset:%q table:%q): %v", datasetID, required, err)
+	}
 
 	if err := updateTableDescription(client, datasetID, explicit); err != nil {
 		t.Errorf("updateTableDescription(dataset:%q table:%q): %v", datasetID, explicit, err)

--- a/bigquery/snippets/snippet_test.go
+++ b/bigquery/snippets/snippet_test.go
@@ -291,6 +291,12 @@ func TestImportExport(t *testing.T) {
 	if err := importJSONAutodetectSchema(client, datasetID, autodetectJSON); err != nil {
 		t.Fatalf("importJSONAutodetectSchema(dataset:%q table:%q): %v", datasetID, autodetectJSON, err)
 	}
+
+	autoJSONwithCMEK := uniqueBQName("golang_example_importjson_cmek")
+	if err := importJSONWithCMEK(client, datasetID, autoJSONwithCMEK); err != nil {
+		t.Fatalf("importJSONWithCMEK(dataset:%q table:%q): %v", datasetID, autoJSONwithCMEK, err)
+	}
+
 	bucket := uniqueBucketName("golang-example-bucket", tc.ProjectID)
 	const object = "values.csv"
 

--- a/bigquery/snippets/snippet_test.go
+++ b/bigquery/snippets/snippet_test.go
@@ -233,6 +233,10 @@ func TestAll(t *testing.T) {
 	if err := copyMultiTable(client, datasetID, dstTableID); err != nil {
 		t.Errorf("copyMultiTable(dataset:%q table:%q): %v", datasetID, dstTableID, err)
 	}
+	dstTableID = uniqueBQName("golang_example_copycmek")
+	if err := copyTableWithCMEK(client, datasetID, dstTableID); err != nil {
+		t.Errorf("copyTableWithCMEK(dataset:%q table:%q): %v", datasetID, dstTableID, err)
+	}
 
 	if err := listJobs(client); err != nil {
 		t.Errorf("listJobs: %v", err)

--- a/bigquery/snippets/snippet_test.go
+++ b/bigquery/snippets/snippet_test.go
@@ -131,6 +131,11 @@ func TestAll(t *testing.T) {
 		t.Errorf("createTableWithCMEK(dataset:%q table:%q): %v", datasetID, tableCMEK, err)
 	}
 
+	widen := uniqueBQName("golang_example_table_widen")
+	if err := createTableAndWiden(client, datasetID, widen); err != nil {
+		t.Errorf("createTableAndWiden(dataset:%q table:%q): %v", datasetID, widen, err)
+	}
+
 	if err := updateTableDescription(client, datasetID, explicit); err != nil {
 		t.Errorf("updateTableDescription(dataset:%q table:%q): %v", datasetID, explicit, err)
 	}
@@ -295,6 +300,14 @@ func TestImportExport(t *testing.T) {
 	autoJSONwithCMEK := uniqueBQName("golang_example_importjson_cmek")
 	if err := importJSONWithCMEK(client, datasetID, autoJSONwithCMEK); err != nil {
 		t.Fatalf("importJSONWithCMEK(dataset:%q table:%q): %v", datasetID, autoJSONwithCMEK, err)
+	}
+
+	parquet := uniqueBQName("golang_example_importparquet")
+	if err := importParquet(client, datasetID, parquet); err != nil {
+		t.Errorf("importParquet(dataset:%q table: %q): %v", datasetID, parquet, err)
+	}
+	if err := importParquetTruncate(client, datasetID, parquet); err != nil {
+		t.Errorf("importParquetTruncate(dataset:%q table: %q): %v", datasetID, parquet, err)
 	}
 
 	bucket := uniqueBucketName("golang-example-bucket", tc.ProjectID)

--- a/bigquery/snippets/snippet_test.go
+++ b/bigquery/snippets/snippet_test.go
@@ -304,6 +304,14 @@ func TestImportExport(t *testing.T) {
 		t.Fatalf("importJSONWithCMEK(dataset:%q table:%q): %v", datasetID, autoJSONwithCMEK, err)
 	}
 
+	orc := uniqueBQName("golang_example_importorc")
+	if err := importORC(client, datasetID, orc); err != nil {
+		t.Errorf("importOrc(dataset:%q table: %q): %v", datasetID, orc, err)
+	}
+	if err := importORCTruncate(client, datasetID, orc); err != nil {
+		t.Errorf("importOrcTruncate(dataset:%q table: %q): %v", datasetID, orc, err)
+	}
+
 	parquet := uniqueBQName("golang_example_importparquet")
 	if err := importParquet(client, datasetID, parquet); err != nil {
 		t.Errorf("importParquet(dataset:%q table: %q): %v", datasetID, parquet, err)

--- a/bigquery/snippets/snippet_test.go
+++ b/bigquery/snippets/snippet_test.go
@@ -225,6 +225,19 @@ func TestAll(t *testing.T) {
 		t.Errorf("queryWithDestinationCMEK(dataset:%q table:%q): %v", datasetID, persistedCMEK, err)
 	}
 
+	// Control a job lifecycle explicitly: create, report status, cancel.
+	exampleJobID := uniqueBQName("golang_example_job")
+	q := client.Query("Select 17 as foo")
+	q.JobID = exampleJobID
+	q.Priority = bigquery.BatchPriority
+	q.Run(ctx)
+	if err := getJobInfo(client, exampleJobID); err != nil {
+		t.Errorf("getJobInfo(%s): %v", exampleJobID, err)
+	}
+	if err := cancelJob(client, exampleJobID); err != nil {
+		t.Errorf("cancelJobInfo(%s): %v", exampleJobID, err)
+	}
+
 	// Print information about tables (extended and simple).
 	if err := printTableInfo(client, datasetID, inferred); err != nil {
 		t.Errorf("printTableInfo(dataset:%q table:%q): %v", datasetID, inferred, err)

--- a/bigquery/snippets/snippet_test.go
+++ b/bigquery/snippets/snippet_test.go
@@ -118,12 +118,19 @@ func TestAll(t *testing.T) {
 	if err := createTableExplicitSchema(client, datasetID, explicit); err != nil {
 		t.Errorf("createTableExplicitSchema(dataset:%q table:%q): %v", datasetID, explicit, err)
 	}
+	complex := uniqueBQName("golang_example_table_complex")
+	if err := createTableComplexSchema(client, datasetID, complex); err != nil {
+		t.Errorf("createTableComplexSchema(dataset:%q table:%q): %v", datasetID, complex, err)
+	}
 
 	if err := updateTableDescription(client, datasetID, explicit); err != nil {
 		t.Errorf("updateTableDescription(dataset:%q table:%q): %v", datasetID, explicit, err)
 	}
 	if err := updateTableExpiration(client, datasetID, explicit); err != nil {
 		t.Errorf("updateTableExpiration(dataset:%q table:%q): %v", datasetID, explicit, err)
+	}
+	if err := updateTableAddColumn(client, datasetID, explicit); err != nil {
+		t.Errorf("updateTableAddColumn(dataset:%q table:%q): %v", datasetID, explicit, err)
 	}
 	if err := addTableLabel(client, datasetID, explicit); err != nil {
 		t.Errorf("updateTableAddLabel(dataset:%q table:%q): %v", datasetID, explicit, err)


### PR DESCRIPTION
Introduces a variety of sample snippets across the product.  ORC format, Parquet format, CMEK, schema manipulations.

Also, wraps common include block used by all samples in a no-op function, to ensure that samples have a consistent indent depth.