### PR TITLE
Remove unused region tag

### DIFF
--- a/translate/snippets/snippet.go
+++ b/translate/snippets/snippet.go
@@ -11,11 +11,9 @@ import (
 
 	"golang.org/x/net/context"
 
-	// [START imports]
 	"cloud.google.com/go/translate"
 	"golang.org/x/text/language"
 	"google.golang.org/api/option"
-	// [END imports]
 )
 
 func createClientWithKey() {


### PR DESCRIPTION
I verified that this region tag is not used by cloud.google.com. Recommend removal to clean up sample tracking.