### PR TITLE
add accessTokenSample

### DIFF
--- a/auth/accesstoken.go
+++ b/auth/accesstoken.go
@@ -1,5 +1,3 @@
-package authsnippets
-
 // Copyright 2018 Google Inc. All rights reserved.
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
@@ -8,8 +6,9 @@ package authsnippets
 // This sample demonstrates AccessTokenCredentials:
 // https://godoc.org/golang.org/x/oauth2/google#JWTAccessTokenSourceFromJSON
 
-// To use, create a service accountJSON file and allow it PubSubAdmin IAM
+// To use, create a service accountJSON file and allow atleast Pub/Sub Viewer IAM
 // permissions on allow listing Topics on a project.
+package authsnippets
 
 import (
 	"io/ioutil"
@@ -23,9 +22,10 @@ import (
 	"google.golang.org/api/option"
 )
 
-// audience values for other services can be found in the repo here similar to PubSub
-// https://github.com/googleapis/googleapis/blob/master/google/pubsub/pubsub.yaml#L6
-const audience string = "https://pubsub.googleapis.com/google.pubsub.v1.Publisher"
+// audience values for other services can be found in the repo here similar to
+// PubSub
+// https://github.com/googleapis/googleapis/blob/master/google/pubsub/pubsub.yaml
+const aud string = "https://pubsub.googleapis.com/google.pubsub.v1.Publisher"
 
 func authsnippets() {
 
@@ -37,7 +37,7 @@ func authsnippets() {
 	if err != nil {
 		log.Fatalf("Unable to read service account key file  %v", err)
 	}
-	tokenSource, err := google.JWTAccessTokenSourceFromJSON(keyBytes, audience)
+	tokenSource, err := google.JWTAccessTokenSourceFromJSON(keyBytes, aud)
 	if err != nil {
 		log.Fatalf("Error building JWT access token source: %v", err)
 	}
@@ -47,13 +47,13 @@ func authsnippets() {
 	}
 	log.Println(jwt.AccessToken)
 
-	pubsubClient, err := pubsub.NewClient(ctx, projectID, option.WithTokenSource(tokenSource))
+	client, err := pubsub.NewClient(ctx, projectID, option.WithTokenSource(tokenSource))
 	if err != nil {
 		log.Fatalf("Could not create pubsub Client: %v", err)
 	}
-	pit := pubsubClient.Topics(ctx)
+	topics := client.Topics(ctx)
 	for {
-		topic, err := pit.Next()
+		topic, err := topics.Next()
 		if err == iterator.Done {
 			break
 		}

--- a/auth/accesstoken.go
+++ b/auth/accesstoken.go
@@ -1,0 +1,66 @@
+package authsnippets
+
+// Copyright 2018 Google Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+// Package authsnippets contains Google Cloud authentication snippets.
+// This sample demonstrates AccessTokenCredentials:
+// https://godoc.org/golang.org/x/oauth2/google#JWTAccessTokenSourceFromJSON
+
+// To use, create a service accountJSON file and allow it PubSubAdmin IAM
+// permissions on allow listing Topics on a project.
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2/google"
+
+	"cloud.google.com/go/pubsub"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+)
+
+func accesstoken() {
+
+	ctx := context.Background()
+	projectID := "YOUR_PROJECT"
+	keyfile := "service_account.json"
+
+	// audience values for other services can be found in the repo here similar to PubSub
+	// // https://github.com/googleapis/googleapis/blob/master/google/pubsub/pubsub.yaml#L6
+	audience := "https://pubsub.googleapis.com/google.pubsub.v1.Publisher"
+
+	keyBytes, err := ioutil.ReadFile(keyfile)
+	if err != nil {
+		log.Fatalf("Unable to read service account key file  %v", err)
+	}
+	tokenSource, err := google.JWTAccessTokenSourceFromJSON(keyBytes, audience)
+	if err != nil {
+		log.Fatalf("Error building JWT access token source: %v", err)
+	}
+	jwt, err := tokenSource.Token()
+	if err != nil {
+		log.Fatalf("Unable to generate JWT token: %v", err)
+	}
+	fmt.Println(jwt.AccessToken)
+
+	pubsubClient, err := pubsub.NewClient(ctx, projectID, option.WithTokenSource(tokenSource))
+	if err != nil {
+		log.Fatalf("Could not create pubsub Client: %v", err)
+	}
+	pit := pubsubClient.Topics(ctx)
+	for {
+		topic, err := pit.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			fmt.Println(err)
+		}
+		fmt.Println(topic)
+	}
+}

--- a/auth/accesstoken.go
+++ b/auth/accesstoken.go
@@ -12,7 +12,6 @@ package authsnippets
 // permissions on allow listing Topics on a project.
 
 import (
-	"fmt"
 	"io/ioutil"
 	"log"
 
@@ -24,16 +23,16 @@ import (
 	"google.golang.org/api/option"
 )
 
-func accesstoken() {
+// audience values for other services can be found in the repo here similar to PubSub
+// https://github.com/googleapis/googleapis/blob/master/google/pubsub/pubsub.yaml#L6
+const audience string = "https://pubsub.googleapis.com/google.pubsub.v1.Publisher"
 
-	ctx := context.Background()
+func authsnippets() {
+
 	projectID := "YOUR_PROJECT"
 	keyfile := "service_account.json"
 
-	// audience values for other services can be found in the repo here similar to PubSub
-	// // https://github.com/googleapis/googleapis/blob/master/google/pubsub/pubsub.yaml#L6
-	audience := "https://pubsub.googleapis.com/google.pubsub.v1.Publisher"
-
+	ctx := context.Background()
 	keyBytes, err := ioutil.ReadFile(keyfile)
 	if err != nil {
 		log.Fatalf("Unable to read service account key file  %v", err)
@@ -46,7 +45,7 @@ func accesstoken() {
 	if err != nil {
 		log.Fatalf("Unable to generate JWT token: %v", err)
 	}
-	fmt.Println(jwt.AccessToken)
+	log.Println(jwt.AccessToken)
 
 	pubsubClient, err := pubsub.NewClient(ctx, projectID, option.WithTokenSource(tokenSource))
 	if err != nil {
@@ -59,8 +58,8 @@ func accesstoken() {
 			break
 		}
 		if err != nil {
-			fmt.Println(err)
+			log.Fatalf("Error listing topics %v", err)
 		}
-		fmt.Println(topic)
+		log.Println(topic)
 	}
 }

--- a/auth/accesstoken/accesstoken.go
+++ b/auth/accesstoken/accesstoken.go
@@ -2,12 +2,11 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
-// Package authsnippets contains Google Cloud authentication snippets.
 // This sample demonstrates AccessTokenCredentials:
 // https://godoc.org/golang.org/x/oauth2/google#JWTAccessTokenSourceFromJSON
 
-// To use, create a service accountJSON file and allow atleast Pub/Sub Viewer IAM
-// permissions on allow listing Topics on a project.
+// To use, create a service accountJSON file and allow it atleast Pub/Sub Viewer IAM
+// permissions to list Topics on a project.
 package main
 
 import (
@@ -24,11 +23,6 @@ import (
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
-
-// audience values for other services can be found in the repo here similar to
-// PubSub
-// https://github.com/googleapis/googleapis/blob/master/google/pubsub/pubsub.yaml
-const aud string = "https://pubsub.googleapis.com/google.pubsub.v1.Publisher"
 
 var (
 	projectID = flag.String("project", "", "Project ID")
@@ -48,6 +42,12 @@ func main() {
 		flag.Usage()
 		os.Exit(2)
 	}
+
+  // [START jwtaccesstoken_sample]
+	// audience values for other services can be found in the repo here similar to
+	// PubSub
+	// https://github.com/googleapis/googleapis/blob/master/google/pubsub/pubsub.yaml
+	var aud string = "https://pubsub.googleapis.com/google.pubsub.v1.Publisher"
 
 	ctx := context.Background()
 	keyBytes, err := ioutil.ReadFile(*keyfile)
@@ -79,4 +79,5 @@ func main() {
 		}
 		log.Println(topic)
 	}
+	// [END jwtaccesstoken_sample]
 }

--- a/auth/accesstoken/accesstoken.go
+++ b/auth/accesstoken/accesstoken.go
@@ -8,11 +8,14 @@
 
 // To use, create a service accountJSON file and allow atleast Pub/Sub Viewer IAM
 // permissions on allow listing Topics on a project.
-package authsnippets
+package main
 
 import (
+	"flag"
+	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
 
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
@@ -27,13 +30,27 @@ import (
 // https://github.com/googleapis/googleapis/blob/master/google/pubsub/pubsub.yaml
 const aud string = "https://pubsub.googleapis.com/google.pubsub.v1.Publisher"
 
-func authsnippets() {
+var (
+	projectID = flag.String("project", "", "Project ID")
+	keyfile   = flag.String("keyfile", "", "Service Account JSON keyfile")
+)
 
-	projectID := "YOUR_PROJECT"
-	keyfile := "service_account.json"
+func main() {
+	flag.Parse()
+
+	if *projectID == "" {
+		fmt.Fprintln(os.Stderr, "missing -project flag")
+		flag.Usage()
+		os.Exit(2)
+	}
+	if *keyfile == "" {
+		fmt.Fprintln(os.Stderr, "missing -keyfile flag")
+		flag.Usage()
+		os.Exit(2)
+	}
 
 	ctx := context.Background()
-	keyBytes, err := ioutil.ReadFile(keyfile)
+	keyBytes, err := ioutil.ReadFile(*keyfile)
 	if err != nil {
 		log.Fatalf("Unable to read service account key file  %v", err)
 	}
@@ -47,7 +64,7 @@ func authsnippets() {
 	}
 	log.Println(jwt.AccessToken)
 
-	client, err := pubsub.NewClient(ctx, projectID, option.WithTokenSource(tokenSource))
+	client, err := pubsub.NewClient(ctx, *projectID, option.WithTokenSource(tokenSource))
 	if err != nil {
 		log.Fatalf("Could not create pubsub Client: %v", err)
 	}

--- a/auth/accesstoken/accesstoken.go
+++ b/auth/accesstoken/accesstoken.go
@@ -43,7 +43,7 @@ func main() {
 		os.Exit(2)
 	}
 
-  // [START jwtaccesstoken_sample]
+	// [START jwtaccesstoken_sample]
 	// audience values for other services can be found in the repo here similar to
 	// PubSub
 	// https://github.com/googleapis/googleapis/blob/master/google/pubsub/pubsub.yaml

--- a/auth/accesstoken/accesstoken.go
+++ b/auth/accesstoken/accesstoken.go
@@ -4,9 +4,10 @@
 
 // This sample demonstrates AccessTokenCredentials:
 // https://godoc.org/golang.org/x/oauth2/google#JWTAccessTokenSourceFromJSON
+// https://developers.google.com/identity/protocols/OAuth2ServiceAccount#jwt-auth
 
-// To use, create a service accountJSON file and allow it atleast Pub/Sub Viewer IAM
-// permissions to list Topics on a project.
+// To use, create a service accountJSON file and allow it atleast
+// Cloud Datastore Viewer IAM on the project.
 package main
 
 import (
@@ -19,8 +20,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
 
-	"cloud.google.com/go/pubsub"
-	"google.golang.org/api/iterator"
+	"cloud.google.com/go/firestore"
 	"google.golang.org/api/option"
 )
 
@@ -45,9 +45,9 @@ func main() {
 
 	// [START jwtaccesstoken_sample]
 	// audience values for other services can be found in the repo here similar to
-	// PubSub
-	// https://github.com/googleapis/googleapis/blob/master/google/pubsub/pubsub.yaml
-	var aud string = "https://pubsub.googleapis.com/google.pubsub.v1.Publisher"
+	// FireStore
+	// https://github.com/googleapis/googleapis/blob/master/google/firestore/firestore.yaml
+	var aud string = "https://firestore.googleapis.com/google.firestore.v1beta1.Firestore"
 
 	ctx := context.Background()
 	keyBytes, err := ioutil.ReadFile(*keyfile)
@@ -64,20 +64,17 @@ func main() {
 	}
 	log.Println(jwt.AccessToken)
 
-	client, err := pubsub.NewClient(ctx, *projectID, option.WithTokenSource(tokenSource))
+	client, err := firestore.NewClient(ctx, *projectID, option.WithTokenSource(tokenSource))
 	if err != nil {
-		log.Fatalf("Could not create pubsub Client: %v", err)
+		log.Fatalf("Could not create FireStore Client: %v", err)
 	}
-	topics := client.Topics(ctx)
-	for {
-		topic, err := topics.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			log.Fatalf("Error listing topics %v", err)
-		}
-		log.Println(topic)
+
+	collections, err := client.Collections(ctx).GetAll()
+	if err != nil {
+		log.Fatalf("Unable to get Collections %v", err)
+	}
+	for _, col := range collections {
+		log.Printf("Collection ID:  %v", col.ID)
 	}
 	// [END jwtaccesstoken_sample]
 }


### PR DESCRIPTION
Add sample for `JWTAccessTokenSourceFromJSON`

- [https://godoc.org/golang.org/x/oauth2/google#JWTAccessTokenSourceFromJSON](https://godoc.org/golang.org/x/oauth2/google#JWTAccessTokenSourceFromJSON)

The token type can be used directly with GCP apis. 
If this repo isn't the correct place for this sample, LMK where.