### PR TITLE
Publish that scales with asynchronous error handling

### DIFF
--- a/pubsub/topics/main.go
+++ b/pubsub/topics/main.go
@@ -157,7 +157,7 @@ func publish(client *pubsub.Client, topic, msg string) error {
 func publishThatScales(client *pubsub.Client, topic string, n uint64) error {
 	ctx := context.Background()
 	var wg sync.WaitGroup
-	var ops uint64
+	var n_err uint64
 	// [START pubsub_publish_with_error_handling_that_scales]
 	t := client.Topic(topic)
 
@@ -175,16 +175,16 @@ func publishThatScales(client *pubsub.Client, topic string, n uint64) error {
 			if err != nil {
 				// Error handling code can be here.
 				log.Output(1, fmt.Sprintf("Failed to publish: %v", err))
+				atomic.AddUint64(&n_err, 1)
 			} else {
 				fmt.Printf("Published message No. %d; msg ID: %v\n", i, id)
 			}
-			atomic.AddUint64(&ops, 1)
 		}(i)
 
 		wg.Wait()
 	}
 
-	if n != ops {
+	if n_err > 0 {
 		return errors.New("some messages did not publish successfully")
 	}
 	return nil

--- a/pubsub/topics/main.go
+++ b/pubsub/topics/main.go
@@ -154,14 +154,14 @@ func publish(client *pubsub.Client, topic, msg string) error {
 	return nil
 }
 
-func publishThatScales(client *pubsub.Client, topic string, n uint64) error {
+func publishThatScales(client *pubsub.Client, topic string, n int) error {
 	ctx := context.Background()
 	// [START pubsub_publish_with_error_handling_that_scales]
 	var wg sync.WaitGroup
 	var totalErrors uint64
 	t := client.Topic(topic)
 
-	for i := 0; i < int(n); i++ {
+	for i := 0; i < n; i++ {
 		result := t.Publish(ctx, &pubsub.Message{
 			// data must be a ByteString
 			Data: []byte("Message " + strconv.Itoa(i)),
@@ -177,9 +177,9 @@ func publishThatScales(client *pubsub.Client, topic string, n uint64) error {
 				// Error handling code can be added here.
 				log.Output(1, fmt.Sprintf("Failed to publish: %v", err))
 				atomic.AddUint64(&totalErrors, 1)
-			} else {
-				fmt.Printf("Published message %d; msg ID: %v\n", i, id)
+				return
 			}
+			fmt.Printf("Published message %d; msg ID: %v\n", i, id)
 		}(i, result)
 	}
 

--- a/pubsub/topics/main_test.go
+++ b/pubsub/topics/main_test.go
@@ -94,6 +94,13 @@ func TestPublish(t *testing.T) {
 	}
 }
 
+func TestPublishThatScales(t *testing.T) {
+	c := setup(t)
+	if err := publishThatScales(c, topicID, 10); err != nil {
+		t.Errorf("failed to publish message: %v", err)
+	}
+}
+
 func TestIAM(t *testing.T) {
 	c := setup(t)
 


### PR DESCRIPTION
The original publish example shows publishing a single message. 

The added function shows publishing multiple messages with error handling. 