### PR TITLE
Containeranalysis main

### DIFF
--- a/container_registry/container_analysis/src/sample/samples.go
+++ b/container_registry/container_analysis/src/sample/samples.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // Samples for the Container Analysis golang libraries: https://cloud.google.com/container-registry/docs/container-analysis
-package main
+package sample
 
 import (
 	"fmt"

--- a/container_registry/container_analysis/src/sample/samples_test.go
+++ b/container_registry/container_analysis/src/sample/samples_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
-package main
+package sample
 
 import (
 	"math/rand"


### PR DESCRIPTION
Otherwise I get:

```
Step 3/4 : RUN go get -u github.com/GoogleCloudPlatform/golang-samples/...
 ---> Running in 145483839d84
# github.com/GoogleCloudPlatform/golang-samples/container_registry/container_analysis/src/sample
runtime.main_main·f: function main is undeclared in the main package
# github.com/GoogleCloudPlatform/golang-samples/kms/asymmetric
runtime.main_main·f: function main is undeclared in the main package
```