### PR TITLE
kms: samples should not be a main package

### DIFF
--- a/kms/asymmetric/samples.go
+++ b/kms/asymmetric/samples.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // Samples for asymmetric keys feature of Cloud Key Management Service: https://cloud.google.com/kms/
-package main
+package samples
 
 import (
 	"crypto"

--- a/kms/asymmetric/samples_test.go
+++ b/kms/asymmetric/samples_test.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // Tests for asymmetric keys feature of Cloud Key Management Service: https://cloud.google.com/kms/
-package main
+package samples
 
 import (
 	"crypto/ecdsa"


### PR DESCRIPTION
```
Step 3/4 : RUN go get -u github.com/GoogleCloudPlatform/golang-samples/...
 ---> Running in 145483839d84
# github.com/GoogleCloudPlatform/golang-samples/container_registry/container_analysis/src/sample
runtime.main_main·f: function main is undeclared in the main package
# github.com/GoogleCloudPlatform/golang-samples/kms/asymmetric
runtime.main_main·f: function main is undeclared in the main package
```