### PR TITLE
profiler: do not collect allocation profiles in profiler quickstart.

### DIFF
--- a/profiler/profiler_quickstart/main.go
+++ b/profiler/profiler_quickstart/main.go
@@ -34,6 +34,7 @@ func main() {
 	err := profiler.Start(profiler.Config{
 		Service:              "hello-profiler",
 		NoHeapProfiling:      true,
+		NoAllocProfiling:     true,
 		NoGoroutineProfiling: true,
 		DebugLogging:         true,
 		// ProjectID must be set if not running on GCP.


### PR DESCRIPTION
This guarantees that the first profile collected is a CPU profile, since only CPU profiles will be collected. This is necessary for the profiler quickstart.