### PR TITLE
docs/appengine: move defer sample to another file

### DIFF
--- a/docs/appengine/taskqueue/push/defer.go
+++ b/docs/appengine/taskqueue/push/defer.go
@@ -11,7 +11,7 @@ import (
 )
 
 func example() {
-	var ctx context.Context
+	ctx := context.Background()
 
 	// [START deferred_tasks]
 	var expensiveFunc = delay.Func("some-arbitrary-key", func(ctx context.Context, a string, b int) {

--- a/docs/appengine/taskqueue/push/defer.go
+++ b/docs/appengine/taskqueue/push/defer.go
@@ -1,0 +1,24 @@
+// Copyright 2018 Google Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+package counter
+
+import (
+	"context"
+
+	"google.golang.org/appengine/delay"
+)
+
+func example() {
+	var ctx context.Context
+
+	// [START deferred_tasks]
+	var expensiveFunc = delay.Func("some-arbitrary-key", func(ctx context.Context, a string, b int) {
+		// Do something expensive!
+	})
+
+	// Somewhere else.
+	expensiveFunc.Call(ctx, "Hello, world!", 42)
+	// [END deferred_tasks]
+}

--- a/docs/appengine/taskqueue/push/taskqueue_push.go
+++ b/docs/appengine/taskqueue/push/taskqueue_push.go
@@ -7,13 +7,11 @@
 package counter
 
 import (
-	"context"
 	"html/template"
 	"net/http"
 
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
-	"google.golang.org/appengine/delay"
 	"google.golang.org/appengine/log"
 	"google.golang.org/appengine/taskqueue"
 )
@@ -81,23 +79,3 @@ const handlerHTML = `
 `
 
 // [END intro]
-
-func example() {
-	var ctx context.Context
-	var t *taskqueue.Task
-	_ = t
-
-	// [START deferred_tasks]
-	var expensiveFunc = delay.Func("some-arbitrary-key", func(ctx context.Context, a string, b int) {
-		// do something expensive!
-	})
-
-	// Somewhere else
-	expensiveFunc.Call(ctx, "Hello, world!", 42)
-	// [END deferred_tasks]
-
-	// [START URL_endpoints]
-	t = &taskqueue.Task{Path: "/path/to/my/worker"}
-	t = &taskqueue.Task{Path: "/path?a=b&c=d", Method: "GET"}
-	// [END URL_endpoints]
-}


### PR DESCRIPTION
This also deletes the URL_endpoints sample since it's not used.