### PR TITLE
profiler: add function to hotapp which repeatedly allocates memory

### DIFF
--- a/profiler/hotapp/main.go
+++ b/profiler/hotapp/main.go
@@ -83,7 +83,7 @@ func allocMany() {
 		for i := 0; i < 16; i++ {
 			_ = make([]byte, 64*1024)
 		}
-		time.Sleep(time.Second)
+		time.Sleep(100 * time.Millisecond)
 	}
 }
 

--- a/profiler/hotapp/main.go
+++ b/profiler/hotapp/main.go
@@ -75,6 +75,18 @@ func allocImpl() {
 	}
 }
 
+// Simulates a function which allocates a lot of memory, but does not hold on
+// to that memory.
+func allocMany() {
+	// Allocate 1 MiB of 64 KiB chunks repeatedly.
+	for {
+		for i := 0; i < 16; i++ {
+			_ = make([]byte, 64*1024)
+		}
+		time.Sleep(time.Second)
+	}
+}
+
 // Simulates a CPU-intensive computation.
 func busyloop() {
 	for {
@@ -134,6 +146,9 @@ func main() {
 
 	// Simulate some memory allocation.
 	alloc()
+
+	// Simulate repeated memory allocations.
+	go allocMany()
 
 	// Simulate CPU load.
 	busyloop()

--- a/profiler/hotapp/main.go
+++ b/profiler/hotapp/main.go
@@ -75,8 +75,8 @@ func allocImpl() {
 	}
 }
 
-// Simulates a function which allocates a lot of memory, but does not hold on
-// to that memory.
+// allocMany simulates a function which allocates a lot of memory, but does not
+// hold on to that memory.
 func allocMany() {
 	// Allocate 1 MiB of 64 KiB chunks repeatedly.
 	for {

--- a/profiler/hotapp/main.go
+++ b/profiler/hotapp/main.go
@@ -64,7 +64,7 @@ func waitImpl() {
 // Simulates a memory-hungry function. It calls an "impl" function to produce
 // a bit deeper stacks in the profiler visualization, merely for illustration
 // purpose.
-func alloc() {
+func allocOnce() {
 	allocImpl()
 }
 
@@ -145,7 +145,7 @@ func main() {
 	}
 
 	// Simulate some memory allocation.
-	alloc()
+	allocOnce()
 
 	// Simulate repeated memory allocations.
 	go allocMany()


### PR DESCRIPTION
This will allow non-empty Heap Alloc profiles to be collected on this app.