### PR TITLE
stackdriver: update region tags

### DIFF
--- a/errorreporting/errorreporting_quickstart/main.go
+++ b/errorreporting/errorreporting_quickstart/main.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+// [START error_reporting_setup_go]
+// [START error_reporting_quickstart]
 // [START errorreporting_quickstart]
 
 // Sample errorreporting_quickstart contains is a quickstart
@@ -52,3 +54,5 @@ func logAndPrintError(err error) {
 }
 
 // [END errorreporting_quickstart]
+// [END error_reporting_quickstart]
+// [END error_reporting_setup_go]

--- a/profiler/snippets/snippets.go
+++ b/profiler/snippets/snippets.go
@@ -2,10 +2,12 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
+// [START profiler_setup_go_compute_engine]
+// [START profiler_start]
+
 // snippets is an example of starting cloud.google.com/go/profiler.
 package main
 
-// [START profiler_start]
 import (
 	"cloud.google.com/go/profiler"
 )
@@ -23,3 +25,4 @@ func main() {
 }
 
 // [END profiler_start]
+// [END profiler_setup_go_compute_engine]

--- a/trace/trace_quickstart/main.go
+++ b/trace/trace_quickstart/main.go
@@ -2,8 +2,7 @@
 // Use of this source code is governed by the Apache 2.0
 // license that can be found in the LICENSE file.
 
-// +build go1.8
-
+// [START trace_setup_go_quickstart]
 // [START trace_quickstart]
 
 // Sample trace_quickstart creates traces incoming and outgoing requests.
@@ -20,11 +19,8 @@ import (
 )
 
 func main() {
-	// Create an register a OpenCensus
-	// Stackdriver Trace exporter.
-	exporter, err := stackdriver.NewExporter(stackdriver.Options{
-		ProjectID: "YOUR_PROJECT_ID",
-	})
+	// Create and register a OpenCensus Stackdriver Trace exporter.
+	exporter, err := stackdriver.NewExporter(stackdriver.Options{})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -54,3 +50,4 @@ func main() {
 }
 
 // [END trace_quickstart]
+// [END trace_setup_go_quickstart]

--- a/trace/trace_quickstart/main.go
+++ b/trace/trace_quickstart/main.go
@@ -11,6 +11,7 @@ package main
 import (
 	"log"
 	"net/http"
+	"os"
 
 	"contrib.go.opencensus.io/exporter/stackdriver"
 	"contrib.go.opencensus.io/exporter/stackdriver/propagation"
@@ -20,7 +21,9 @@ import (
 
 func main() {
 	// Create and register a OpenCensus Stackdriver Trace exporter.
-	exporter, err := stackdriver.NewExporter(stackdriver.Options{})
+	exporter, err := stackdriver.NewExporter(stackdriver.Options{
+		ProjectID: os.Getenv("GOOGLE_CLOUD_PROJECT"),
+	})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/trace/trace_snippets/snippets.go
+++ b/trace/trace_snippets/snippets.go
@@ -9,6 +9,7 @@ package snippets
 
 import (
 	"log"
+	"os"
 
 	"contrib.go.opencensus.io/exporter/stackdriver"
 	"go.opencensus.io/trace"
@@ -16,7 +17,9 @@ import (
 
 func main() {
 	// Create and register a OpenCensus Stackdriver Trace exporter.
-	exporter, err := stackdriver.NewExporter(stackdriver.Options{})
+	exporter, err := stackdriver.NewExporter(stackdriver.Options{
+		ProjectID: os.Getenv("GOOGLE_CLOUD_PROJECT"),
+	})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/trace/trace_snippets/snippets.go
+++ b/trace/trace_snippets/snippets.go
@@ -1,0 +1,26 @@
+// Copyright 2018 Google Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+// Package snippets contains Stackdriver trace samples.
+package snippets
+
+// [START trace_setup_go_configure]
+
+import (
+	"log"
+
+	"contrib.go.opencensus.io/exporter/stackdriver"
+	"go.opencensus.io/trace"
+)
+
+func main() {
+	// Create and register a OpenCensus Stackdriver Trace exporter.
+	exporter, err := stackdriver.NewExporter(stackdriver.Options{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	trace.RegisterExporter(exporter)
+}
+
+// [END trace_setup_go_configure]


### PR DESCRIPTION
This also adds a new snippet that was previously inlined in docs.

~For posterity, the Stackdriver Exporter looks in application default credentials
for the project, so we don't need to specify the project manually.~ Uses `os.Getenv("GOOGLE_CLOUD_PROJECT")` to avoid auto-detection (makes it easier to test on multiple projects with a single service account, too).