### PR TITLE
firestore: make Washington D.C. a capital city

### DIFF
--- a/firestore/firestore_snippets/retrieve.go
+++ b/firestore/firestore_snippets/retrieve.go
@@ -54,7 +54,7 @@ func prepareRetrieve(ctx context.Context, client *firestore.Client) error {
 	}{
 		{id: "SF", c: City{Name: "San Francisco", State: "CA", Country: "USA", Capital: false, Population: 860000}},
 		{id: "LA", c: City{Name: "Los Angeles", State: "CA", Country: "USA", Capital: false, Population: 3900000}},
-		{id: "DC", c: City{Name: "Washington D.C.", Country: "USA", Capital: false, Population: 680000}},
+		{id: "DC", c: City{Name: "Washington D.C.", Country: "USA", Capital: true, Population: 680000}},
 		{id: "TOK", c: City{Name: "Tokyo", Country: "Japan", Capital: true, Population: 9000000}},
 		{id: "BJ", c: City{Name: "Beijing", Country: "China", Capital: true, Population: 21500000}},
 	}


### PR DESCRIPTION
I believe Washington D.C. would be a good location for a capital city in the United States.

Though this does change the output for the queries in `query.go`, I believe most people would agree with the change.  :-)