### PR TITLE
gettingstarted/bookshelf/app: don't rely on port 8080 being open in tests

### DIFF
--- a/getting-started/bookshelf/app/app_test.go
+++ b/getting-started/bookshelf/app/app_test.go
@@ -39,7 +39,7 @@ func TestMainFunc(t *testing.T) {
 	m := testutil.BuildMain(t)
 	defer m.Cleanup()
 	m.Run(env, func() {
-		appWt := webtest.New(nil, fmt.Sprintf(":%s", port))
+		appWt := webtest.New(nil, fmt.Sprintf("localhost:%s", port))
 		appWt.WaitForNet()
 		bodyContains(t, appWt, "/books", "No books found")
 	})

--- a/getting-started/bookshelf/app/app_test.go
+++ b/getting-started/bookshelf/app/app_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/golang-samples/getting-started/bookshelf"
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/webtest"
 )
 
@@ -25,6 +26,18 @@ func TestMain(m *testing.M) {
 	registerHandlers()
 
 	os.Exit(m.Run())
+}
+
+// This function verifies compilation occurs without error.
+// It may not be possible to run the application without
+// satisfying appengine environmental dependencies such as
+// the presence of a GCE metadata server.
+func TestBuildable(t *testing.T) {
+	m := testutil.BuildMain(t)
+	defer m.Cleanup()
+	if !m.Built() {
+		t.Fatal("failed to compile application.")
+	}
 }
 
 func TestNoBooks(t *testing.T) {

--- a/getting-started/bookshelf/app/app_test.go
+++ b/getting-started/bookshelf/app/app_test.go
@@ -7,11 +7,13 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"math/rand"
 	"mime/multipart"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/golang-samples/getting-started/bookshelf"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
@@ -29,12 +31,17 @@ func TestMain(m *testing.M) {
 }
 
 func TestMainFunc(t *testing.T) {
-	wt := webtest.New(t, "localhost:8080")
+	// randomize port selection to reduce liklihood of port collision
+	rand.Seed(time.Now().UnixNano())
+	port := fmt.Sprintf("%d", 8000+rand.Int31n(2000))
+	env := map[string]string{"PORT": port}
+	fmt.Printf("Using port: %s\n", port)
 	m := testutil.BuildMain(t)
 	defer m.Cleanup()
-	m.Run(nil, func() {
-		wt.WaitForNet()
-		bodyContains(t, wt, "/", "No books found")
+	m.Run(env, func() {
+		appWt := webtest.New(nil, fmt.Sprintf(":%s", port))
+		appWt.WaitForNet()
+		bodyContains(t, appWt, "/books", "No books found")
 	})
 }
 

--- a/getting-started/bookshelf/app/app_test.go
+++ b/getting-started/bookshelf/app/app_test.go
@@ -7,16 +7,13 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"math/rand"
 	"mime/multipart"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/GoogleCloudPlatform/golang-samples/getting-started/bookshelf"
-	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/webtest"
 )
 
@@ -28,21 +25,6 @@ func TestMain(m *testing.M) {
 	registerHandlers()
 
 	os.Exit(m.Run())
-}
-
-func TestMainFunc(t *testing.T) {
-	// randomize port selection to reduce liklihood of port collision
-	rand.Seed(time.Now().UnixNano())
-	port := fmt.Sprintf("%d", 8000+rand.Int31n(2000))
-	env := map[string]string{"PORT": port}
-	fmt.Printf("Using port: %s\n", port)
-	m := testutil.BuildMain(t)
-	defer m.Cleanup()
-	m.Run(env, func() {
-		appWt := webtest.New(nil, fmt.Sprintf("localhost:%s", port))
-		appWt.WaitForNet()
-		bodyContains(t, appWt, "/books", "No books found")
-	})
 }
 
 func TestNoBooks(t *testing.T) {

--- a/internal/webtest/webtest.go
+++ b/internal/webtest/webtest.go
@@ -23,7 +23,7 @@ type W struct {
 	Client *http.Client
 }
 
-// New creates a web test for a given a host tring (e.g. "localhost:8080")
+// New creates a web test for a given a host string (e.g. "localhost:8080")
 func New(t *testing.T, host string) *W {
 	return &W{
 		t:      t,


### PR DESCRIPTION
It appears there's test failures due to connection refused for
TestMainFunc, which invokes the application rather than the other
tests which render handlers.

On the suspicion something else is leaving the static port 8080 in
a temporarily unusuable state, this change picks a port randomly
and then passes it via the PORT environment variable which is used
by appengine.Main to override the serving port.

Also fixes a minor typo in internal/webtest.