### PR TITLE
DLP: Reduce use of repeated literal identifiers.

### DIFF
--- a/dlp/dlp_snippets/inspect_test.go
+++ b/dlp/dlp_snippets/inspect_test.go
@@ -17,6 +17,9 @@ import (
 	dlppb "google.golang.org/genproto/googleapis/privacy/dlp/v2"
 )
 
+var inspectTopicName = "dlp-inspect-test-topic"
+var inspectSubscriptionName = "dlp-inspect-test-sub"
+
 func TestInspectString(t *testing.T) {
 	testutil.SystemTest(t)
 	tests := []struct {
@@ -157,7 +160,7 @@ func TestInspectGCS(t *testing.T) {
 	}
 	for _, test := range tests {
 		buf := new(bytes.Buffer)
-		inspectGCSFile(buf, client, projectID, dlppb.Likelihood_POSSIBLE, 0, true, []string{"US_SOCIAL_SECURITY_NUMBER"}, []string{}, []string{}, "test-topic", "test-sub", bucketName, test.fileName)
+		inspectGCSFile(buf, client, projectID, dlppb.Likelihood_POSSIBLE, 0, true, []string{"US_SOCIAL_SECURITY_NUMBER"}, []string{}, []string{}, inspectTopicName, inspectSubscriptionName, bucketName, test.fileName)
 		if got := buf.String(); !strings.Contains(got, test.want) {
 			t.Errorf("inspectString(%s) = %q, want %q substring", test.fileName, got, test.want)
 		}
@@ -217,7 +220,7 @@ func TestInspectDatastore(t *testing.T) {
 	}
 	for _, test := range tests {
 		buf := new(bytes.Buffer)
-		inspectDatastore(buf, client, projectID, dlppb.Likelihood_POSSIBLE, 0, true, []string{"US_SOCIAL_SECURITY_NUMBER"}, []string{}, []string{}, "test-topic", "test-sub", projectID, "", test.kind)
+		inspectDatastore(buf, client, projectID, dlppb.Likelihood_POSSIBLE, 0, true, []string{"US_SOCIAL_SECURITY_NUMBER"}, []string{}, []string{}, inspectTopicName, inspectSubscriptionName, projectID, "", test.kind)
 		if got := buf.String(); !strings.Contains(got, test.want) {
 			t.Errorf("inspectDatastore(%s) = %q, want %q substring", test.kind, got, test.want)
 		}
@@ -298,7 +301,7 @@ func TestInspectBigquery(t *testing.T) {
 	}
 	for _, test := range tests {
 		buf := new(bytes.Buffer)
-		inspectBigquery(buf, client, projectID, dlppb.Likelihood_POSSIBLE, 0, true, []string{"US_SOCIAL_SECURITY_NUMBER"}, []string{}, []string{}, "test-topic", "test-sub", projectID, bqDatasetID, test.table)
+		inspectBigquery(buf, client, projectID, dlppb.Likelihood_POSSIBLE, 0, true, []string{"US_SOCIAL_SECURITY_NUMBER"}, []string{}, []string{}, inspectTopicName, inspectSubscriptionName, projectID, bqDatasetID, test.table)
 		if got := buf.String(); !strings.Contains(got, test.want) {
 			t.Errorf("inspectBigquery(%s) = %q, want %q substring", test.table, got, test.want)
 		}

--- a/dlp/dlp_snippets/inspect_test.go
+++ b/dlp/dlp_snippets/inspect_test.go
@@ -17,8 +17,10 @@ import (
 	dlppb "google.golang.org/genproto/googleapis/privacy/dlp/v2"
 )
 
-var inspectTopicName = "dlp-inspect-test-topic"
-var inspectSubscriptionName = "dlp-inspect-test-sub"
+const (
+	inspectTopicName        = "dlp-inspect-test-topic"
+	inspectSubscriptionName = "dlp-inspect-test-sub"
+)
 
 func TestInspectString(t *testing.T) {
 	testutil.SystemTest(t)

--- a/dlp/dlp_snippets/risk_test.go
+++ b/dlp/dlp_snippets/risk_test.go
@@ -13,11 +13,14 @@ import (
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 )
 
+var riskTopicName = "dlp-risk-test-topic"
+var riskSubscriptionName = "dlp-risk-test-sub"
+
 func TestRiskNumerical(t *testing.T) {
 	testutil.SystemTest(t)
 	testutil.Retry(t, 20, 2*time.Second, func(r *testutil.R) {
 		buf := new(bytes.Buffer)
-		riskNumerical(buf, client, projectID, "bigquery-public-data", "dlp-test-topic", "dlp-test-sub", "nhtsa_traffic_fatalities", "accident_2015", "state_number")
+		riskNumerical(buf, client, projectID, "bigquery-public-data", riskTopicName, riskSubscriptionName, "nhtsa_traffic_fatalities", "accident_2015", "state_number")
 		wants := []string{"Created job", "Value range", "Value at"}
 		got := buf.String()
 		for _, want := range wants {
@@ -32,7 +35,7 @@ func TestRiskCategorical(t *testing.T) {
 	testutil.SystemTest(t)
 	testutil.Retry(t, 20, 2*time.Second, func(r *testutil.R) {
 		buf := new(bytes.Buffer)
-		riskCategorical(buf, client, projectID, "bigquery-public-data", "dlp-test-topic", "dlp-test-sub", "nhtsa_traffic_fatalities", "accident_2015", "state_number")
+		riskCategorical(buf, client, projectID, "bigquery-public-data", riskTopicName, riskSubscriptionName, "nhtsa_traffic_fatalities", "accident_2015", "state_number")
 		wants := []string{"Created job", "Histogram bucket", "Most common value occurs"}
 		got := buf.String()
 		for _, want := range wants {
@@ -47,7 +50,7 @@ func TestRiskKAnonymity(t *testing.T) {
 	testutil.SystemTest(t)
 	testutil.Retry(t, 20, 2*time.Second, func(r *testutil.R) {
 		buf := new(bytes.Buffer)
-		riskKAnonymity(buf, client, projectID, "bigquery-public-data", "dlp-test-topic", "dlp-test-sub", "nhtsa_traffic_fatalities", "accident_2015", "state_number", "county")
+		riskKAnonymity(buf, client, projectID, "bigquery-public-data", riskTopicName, riskSubscriptionName, "nhtsa_traffic_fatalities", "accident_2015", "state_number", "county")
 		wants := []string{"Created job", "Histogram bucket", "Size range"}
 		got := buf.String()
 		for _, want := range wants {
@@ -62,7 +65,7 @@ func TestRiskLDiversity(t *testing.T) {
 	testutil.SystemTest(t)
 	testutil.Retry(t, 20, 2*time.Second, func(r *testutil.R) {
 		buf := new(bytes.Buffer)
-		riskLDiversity(buf, client, projectID, "bigquery-public-data", "dlp-test-topic", "dlp-test-sub", "nhtsa_traffic_fatalities", "accident_2015", "city", "state_number", "county")
+		riskLDiversity(buf, client, projectID, "bigquery-public-data", riskTopicName, riskSubscriptionName, "nhtsa_traffic_fatalities", "accident_2015", "city", "state_number", "county")
 		wants := []string{"Created job", "Histogram bucket", "Size range"}
 		got := buf.String()
 		for _, want := range wants {
@@ -77,7 +80,7 @@ func TestRiskKMap(t *testing.T) {
 	testutil.SystemTest(t)
 	testutil.Retry(t, 20, 2*time.Second, func(r *testutil.R) {
 		buf := new(bytes.Buffer)
-		riskKMap(buf, client, projectID, "bigquery-public-data", "dlp-test-topic", "dlp-test-sub", "san_francisco", "bikeshare_trips", "US", "zip_code")
+		riskKMap(buf, client, projectID, "bigquery-public-data", riskTopicName, riskSubscriptionName, "san_francisco", "bikeshare_trips", "US", "zip_code")
 		wants := []string{"Created job", "Histogram bucket", "Anonymity range"}
 		got := buf.String()
 		for _, want := range wants {

--- a/dlp/dlp_snippets/risk_test.go
+++ b/dlp/dlp_snippets/risk_test.go
@@ -13,8 +13,10 @@ import (
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 )
 
-var riskTopicName = "dlp-risk-test-topic"
-var riskSubscriptionName = "dlp-risk-test-sub"
+const (
+	riskTopicName        = "dlp-risk-test-topic"
+	riskSubscriptionName = "dlp-risk-test-sub"
+)
 
 func TestRiskNumerical(t *testing.T) {
 	testutil.SystemTest(t)


### PR DESCRIPTION
DLP risk and inspect tests communicate changes via pubsub, and
specifying the topic and subscription names as literal strings.