### PR TITLE
iot: use isNil to check error with reflection and add missing command

### DIFF
--- a/iot/manager/manager.go
+++ b/iot/manager/manager.go
@@ -176,7 +176,6 @@ func listRegistries(projectID string, region string) ([]*cloudiot.DeviceRegistry
 		fmt.Println("\t", registry.Name)
 	}
 	// [END iot_list_registries]
-
 	return response.DeviceRegistries, err
 }
 
@@ -488,7 +487,6 @@ func listDevices(projectID string, region string, registry string) ([]*cloudiot.
 		fmt.Println("\t", device.Id)
 	}
 	// [END iot_list_devices]
-
 	return response.Devices, err
 }
 
@@ -704,8 +702,8 @@ func main() {
 				fnArgs = append(fnArgs, reflect.ValueOf(arg))
 			}
 			retValues := reflect.ValueOf(cmd.fn).Call(fnArgs)
-			err := retValues[len(retValues)-1].Interface().(error)
-			if err != nil {
+			err := retValues[len(retValues)-1]
+			if !err.IsNil() {
 				fmt.Fprintf(os.Stderr, "%v\n", err)
 				os.Exit(1)
 			}

--- a/iot/manager/manager.go
+++ b/iot/manager/manager.go
@@ -176,6 +176,7 @@ func listRegistries(projectID string, region string) ([]*cloudiot.DeviceRegistry
 		fmt.Println("\t", registry.Name)
 	}
 	// [END iot_list_registries]
+
 	return response.DeviceRegistries, err
 }
 
@@ -487,6 +488,7 @@ func listDevices(projectID string, region string, registry string) ([]*cloudiot.
 		fmt.Println("\t", device.Id)
 	}
 	// [END iot_list_devices]
+
 	return response.Devices, err
 }
 
@@ -635,6 +637,7 @@ func main() {
 		{"createRegistry", createRegistry, []string{"cloud-region", "registry-id", "pubsub-topic"}},
 		{"deleteRegistry", deleteRegistry, []string{"cloud-region", "registry-id"}},
 		{"getRegistry", getRegistry, []string{"cloud-region", "registry-id"}},
+		{"listRegistries", listRegistries, []string{"cloud-region"}},
 		{"getRegistryIam", getRegistryIam, []string{"cloud-region", "registry-id"}},
 		{"setRegistryIam", setRegistryIam, []string{"cloud-region", "registry-id", "member", "role"}},
 	}


### PR DESCRIPTION
- listRegistries command was missing from available commands (function existed)
- Type checking with `.Interface().(error)` fails if `reflect.Value` is `nil`. Checking with `isNil()` instead