### PR TITLE
appengine/mailjet: remove unused region tag

### DIFF
--- a/docs/appengine/mail/mailjet/app.yaml
+++ b/docs/appengine/mail/mailjet/app.yaml
@@ -5,9 +5,7 @@ handlers:
 - url: /.*
   script: _go_app
 
-# [START env_variables]
 env_variables:
   MJ_FROM_EMAIL: your-mailjet-sender-address
   MJ_APIKEY_PUBLIC: your-mailjet-api-key
   MJ_APIKEY_PRIVATE: your-mailjet-secret-key
-# [END env_variables]


### PR DESCRIPTION
The app.yaml is not used in the documentation and the code snippet itself makes sufficient point about the environment variables.