### PR TITLE
memorystore/redis: update REDISHOST with user replaced variable

### DIFF
--- a/memorystore/redis/app.yaml
+++ b/memorystore/redis/app.yaml
@@ -3,7 +3,7 @@ env: flex
 
 # Update with Redis instance details
 env_variables:
-  REDISHOST: '127.0.0.1'
+  REDISHOST: '<REDIS_IP>'
   REDISPORT: '6379'
 
 # Update with Redis instance network name


### PR DESCRIPTION
Replaced "127.0.0.1" with a variable to match other samples and make it more clear the user needs to replace that value in the docs. 