### PR TITLE
functions: correct project ID environment variable

### DIFF
--- a/functions/helloworld/hello_pubsub_system_test.go
+++ b/functions/helloworld/hello_pubsub_system_test.go
@@ -5,8 +5,6 @@
 // +build ignore
 // Disabled until system tests are working on Kokoro.
 
-// TODO: Use testutil.SystemTest and os.Setenv for GOOGLE_CLOUD_PROJECT.
-
 // [START functions_pubsub_system_test]
 
 package helloworld
@@ -28,7 +26,7 @@ func TestHelloPubSubSystem(t *testing.T) {
 	ctx := context.Background()
 
 	topicName := os.Getenv("FUNCTIONS_TOPIC")
-	projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
+	projectID := os.Getenv("GCP_PROJECT")
 
 	startTime := time.Now().UTC().Format(time.RFC3339)
 

--- a/functions/tips/contexttip/context_tip.go
+++ b/functions/tips/contexttip/context_tip.go
@@ -21,9 +21,9 @@ import (
 	"cloud.google.com/go/pubsub"
 )
 
-// projectID is set from the GOOGLE_CLOUD_PROJECT environment variable, which is
+// projectID is set from the GCP_PROJECT environment variable, which is
 // automatically set by the Cloud Functions runtime.
-var projectID = os.Getenv("GOOGLE_CLOUD_PROJECT")
+var projectID = os.Getenv("GCP_PROJECT")
 
 // client is a global Pub/Sub client, initialized once per instance.
 var client *pubsub.Client


### PR DESCRIPTION
GOOGLE_CLOUD_PROJECT is not set automatically for Cloud Functions. GCP_PROJECT is set automatically.