### PR TITLE
Asset: update construction of ExportAssetsRequest.

### DIFF
--- a/asset/quickstart/export-assets/main.go
+++ b/asset/quickstart/export-assets/main.go
@@ -31,7 +31,9 @@ func main() {
 		OutputConfig: &assetpb.OutputConfig{
 			Destination: &assetpb.OutputConfig_GcsDestination{
 				GcsDestination: &assetpb.GcsDestination{
-					Uri: string(assetDumpFile),
+					ObjectUri: &assetpb.GcsDestination_Uri{
+						Uri: string(assetDumpFile),
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Structure of the v1beta1 assets API proto changed to accomodate additional export
functionality.  This updates the asset sample to demonstrate the
newer semantics.

More internal background: CL 219683080.