### PR TITLE
all: swap satori's uuid package to gofrs

### DIFF
--- a/appengine/gophers/gophers-6/main.go
+++ b/appengine/gophers/gophers-6/main.go
@@ -23,7 +23,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	vision "cloud.google.com/go/vision/apiv1"
-	uuid "github.com/satori/go.uuid"
+	uuid "github.com/gofrs/uuid"
 	"google.golang.org/appengine/delay"
 	// [END new_imports]
 )

--- a/appengine_flexible/analytics/analytics.go
+++ b/appengine_flexible/analytics/analytics.go
@@ -16,7 +16,7 @@ import (
 	"net/url"
 	"os"
 
-	uuid "github.com/satori/go.uuid"
+	uuid "github.com/gofrs/uuid"
 
 	"google.golang.org/appengine"
 )

--- a/getting-started/bookshelf/app/app.go
+++ b/getting-started/bookshelf/app/app.go
@@ -21,9 +21,9 @@ import (
 	"cloud.google.com/go/pubsub"
 	"cloud.google.com/go/storage"
 
+	uuid "github.com/gofrs/uuid"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
-	uuid "github.com/gofrs/uuid"
 
 	"github.com/GoogleCloudPlatform/golang-samples/getting-started/bookshelf"
 )

--- a/getting-started/bookshelf/app/app.go
+++ b/getting-started/bookshelf/app/app.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
-	uuid "github.com/satori/go.uuid"
+	uuid "github.com/gofrs/uuid"
 
 	"github.com/GoogleCloudPlatform/golang-samples/getting-started/bookshelf"
 )

--- a/getting-started/bookshelf/app/auth.go
+++ b/getting-started/bookshelf/app/auth.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/GoogleCloudPlatform/golang-samples/getting-started/bookshelf"
-	uuid "github.com/satori/go.uuid"
+	uuid "github.com/gofrs/uuid"
 )
 
 const (

--- a/jobs/v3/howto/howto_test.go
+++ b/jobs/v3/howto/howto_test.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 	talent "google.golang.org/api/jobs/v3"


### PR DESCRIPTION
This updates the sample bookshelf app to use the community recommended gofrs uuid package.

go.uuid is effectively unmaintained and contained at least one critical security flaw which took half a year to be merged as the owner isn't active. See https://github.com/satori/go.uuid/pull/75

 