### PR TITLE
spanner: iterate in quickstart

### DIFF
--- a/spanner/spanner_quickstart/main.go
+++ b/spanner/spanner_quickstart/main.go
@@ -13,6 +13,7 @@ import (
 	"log"
 
 	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
 )
 
 func main() {
@@ -31,16 +32,22 @@ func main() {
 	iter := client.Single().Query(ctx, stmt)
 	defer iter.Stop()
 
-	row, err := iter.Next()
-	if err != nil {
-		log.Fatalf("Query failed with %v", err)
-	}
+	for {
+		row, err := iter.Next()
+		if err == iterator.Done {
+			fmt.Println("Done")
+			return
+		}
+		if err != nil {
+			log.Fatalf("Query failed with %v", err)
+		}
 
-	var i int64
-	if row.Columns(&i) != nil {
-		log.Fatalf("Failed to parse row %v", err)
+		var i int64
+		if row.Columns(&i) != nil {
+			log.Fatalf("Failed to parse row %v", err)
+		}
+		fmt.Printf("Got value %v\n", i)
 	}
-	fmt.Printf("Got value %v\n", i)
 }
 
 // [END spanner_quickstart]


### PR DESCRIPTION
There is only one row that gets returned. But, in practice, you almost
always want to iterate.

b/66986253