### PR TITLE
storage/gcsupload: public flag does not work

### DIFF
--- a/storage/gcsupload/gcsupload.go
+++ b/storage/gcsupload/gcsupload.go
@@ -87,7 +87,7 @@ func main() {
 	}
 
 	ctx := context.Background()
-	_, objAttrs, err := upload(ctx, r, projectID, bucket, name, true)
+	_, objAttrs, err := upload(ctx, r, projectID, bucket, name, public)
 	if err != nil {
 		switch err {
 		case storage.ErrBucketNotExist:


### PR DESCRIPTION
The public flag in storage/gcsupload.go does not work due to using the fixed value.
So, the uploaded object can always be accessed from public.