### PR TITLE
endpoints: fix sample when both api-key and token are specified

### DIFF
--- a/endpoints/getting-started-grpc/client/main.go
+++ b/endpoints/getting-started-grpc/client/main.go
@@ -95,12 +95,12 @@ func main() {
 	}
 	if *token != "" {
 		log.Printf("Using authentication token: %s", *token)
-                _, ok := metadata.FromOutgoingContext(ctx)
+		_, ok := metadata.FromOutgoingContext(ctx)
 		if ok {
-                  ctx = metadata.AppendToOutgoingContext(ctx, "Authorization", fmt.Sprintf("Bearer %s", *token))
-                } else {
-                  ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", *token)))
-                }
+			ctx = metadata.AppendToOutgoingContext(ctx, "Authorization", fmt.Sprintf("Bearer %s", *token))
+		} else {
+			ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", *token)))
+		}
 	}
 
 	// Contact the server and print out its response.

--- a/endpoints/getting-started-grpc/client/main.go
+++ b/endpoints/getting-started-grpc/client/main.go
@@ -91,16 +91,11 @@ func main() {
 	ctx := context.Background()
 	if *key != "" {
 		log.Printf("Using API key: %s", *key)
-		ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("x-api-key", *key))
+		ctx = metadata.AppendToOutgoingContext(ctx, "x-api-key", *key)
 	}
 	if *token != "" {
 		log.Printf("Using authentication token: %s", *token)
-		_, ok := metadata.FromOutgoingContext(ctx)
-		if ok {
-			ctx = metadata.AppendToOutgoingContext(ctx, "Authorization", fmt.Sprintf("Bearer %s", *token))
-		} else {
-			ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", *token)))
-		}
+		ctx = metadata.AppendToOutgoingContext(ctx, "Authorization", fmt.Sprintf("Bearer %s", *token))
 	}
 
 	// Contact the server and print out its response.

--- a/endpoints/getting-started-grpc/client/main.go
+++ b/endpoints/getting-started-grpc/client/main.go
@@ -95,7 +95,12 @@ func main() {
 	}
 	if *token != "" {
 		log.Printf("Using authentication token: %s", *token)
-		ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", *token)))
+                _, ok := metadata.FromOutgoingContext(ctx)
+		if ok {
+                  ctx = metadata.AppendToOutgoingContext(ctx, "Authorization", fmt.Sprintf("Bearer %s", *token))
+                } else {
+                  ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("Authorization", fmt.Sprintf("Bearer %s", *token)))
+                }
 	}
 
 	// Contact the server and print out its response.


### PR DESCRIPTION
Existing code is broken where it would attempt to create a context
inside a context as opposed to appending both keys to the context.
Therefore, when both api-key and token are specified, only token
would take effect and not api-key.