### PR TITLE
opencensus: use metric exporter interface

### DIFF
--- a/opencensus/metrics_quickstart/main.go
+++ b/opencensus/metrics_quickstart/main.go
@@ -66,7 +66,7 @@ func main() {
 	defer exporter.Flush()
 
 	if err := exporter.StartMetricsExporter(); err != nil {
-		log.Fatalf("error starting metric exporter. error=%v", err)
+		log.Fatalf("Error starting metric exporter: %v", err)
 	}
 	defer exporter.StopMetricsExporter()
 

--- a/opencensus/metrics_quickstart/main.go
+++ b/opencensus/metrics_quickstart/main.go
@@ -65,7 +65,9 @@ func main() {
 	// Flush must be called before main() exits to ensure metrics are recorded.
 	defer exporter.Flush()
 
-	exporter.StartMetricsExporter()
+	if err := exporter.StartMetricsExporter(); err != nil {
+		log.Fatalf("error starting metric exporter. error=%v", err)
+	}
 	defer exporter.StopMetricsExporter()
 
 	// Record 100 fake latency values between 0 and 5 seconds.

--- a/opencensus/metrics_quickstart/main.go
+++ b/opencensus/metrics_quickstart/main.go
@@ -65,10 +65,8 @@ func main() {
 	// Flush must be called before main() exits to ensure metrics are recorded.
 	defer exporter.Flush()
 
-	view.RegisterExporter(exporter)
-
-	// The minimum reporting period for Stackdriver is 1 minute.
-	view.SetReportingPeriod(60 * time.Second)
+	exporter.StartMetricsExporter()
+	defer exporter.StopMetricsExporter()
 
 	// Record 100 fake latency values between 0 and 5 seconds.
 	for i := 0; i < 100; i++ {


### PR DESCRIPTION
Modify quick_start  example to use new metric interface from opencensus. The new interface supports receiving gauges and derived gauges.
