### PR TITLE
run: service-to-service auth snippet

### DIFF
--- a/run/authentication/auth.go
+++ b/run/authentication/auth.go
@@ -15,7 +15,7 @@
 // Package authentication contains the authentication samples for Cloud Run.
 package authentication
 
-// [START service_to_service_auth]
+// [START run_service_to_service_auth]
 import (
 	"fmt"
 	"net/http"
@@ -41,4 +41,4 @@ func makeGetRequest(serviceURL string) (*http.Response, error) {
 	return http.DefaultClient.Do(req)
 }
 
-// [END service_to_service_auth]
+// [END run_service_to_service_auth]

--- a/run/authentication/auth.go
+++ b/run/authentication/auth.go
@@ -1,0 +1,44 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package authentication contains the authentication samples for Cloud Run.
+package authentication
+
+// [START service_to_service_auth]
+import (
+	"fmt"
+	"net/http"
+
+	"cloud.google.com/go/compute/metadata"
+)
+
+// makeGetRequest makes a GET request to the specified Cloud Run endpoint in
+// serviceURL (must be a complete URL) by authenticating with the ID token
+// obtained from the Metadata API.
+func makeGetRequest(serviceURL string) (*http.Response, error) {
+	// query the id_token with ?audience as the serviceURL
+	tokenURL := fmt.Sprintf("/instance/service-accounts/default/identity?audience=%s", serviceURL)
+	idToken, err := metadata.Get(tokenURL)
+	if err != nil {
+		return nil, fmt.Errorf("metadata.Get: failed to query id_token: %+v", err)
+	}
+	req, err := http.NewRequest("GET", serviceURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", idToken))
+	return http.DefaultClient.Do(req)
+}
+
+// [END service_to_service_auth]

--- a/run/authentication/auth_test.go
+++ b/run/authentication/auth_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 )
 
-func Test_makeGetRequest(t *testing.T) {
+func TestMakeGetRequest(t *testing.T) {
 	metadata := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		v := r.URL.Query().Get("audience")
 		if v == "" {
@@ -35,7 +35,7 @@ func Test_makeGetRequest(t *testing.T) {
 
 	metadataURL, err := url.Parse(metadata.URL)
 	if err != nil {
-		t.Fatalf("failed to parse metadata URL (%s): %v", metadata.URL, err)
+		t.Fatalf("url.Parse(%s): %v", metadata.URL, err)
 	}
 	defer os.Unsetenv("GCE_METADATA_HOST")
 	os.Setenv("GCE_METADATA_HOST", metadataURL.Host)
@@ -55,13 +55,14 @@ func Test_makeGetRequest(t *testing.T) {
 
 	resp, err := makeGetRequest(url)
 	if err != nil {
-		t.Fatalf("makeGetRequest: ")
-	}
-	if expected := http.StatusOK; resp.StatusCode != expected {
-		t.Fatalf("unexpected response status: got=%d; expected=%d", resp.StatusCode, expected)
-	}
-	if gotHeader != expectedHeader {
-		t.Fatalf("unexpected Authorization header: expected=%q; got=%q", expectedHeader, gotHeader)
+		t.Fatalf("makeGetRequest: %v", err)
 	}
 	defer resp.Body.Close()
+
+	if expected := http.StatusOK; resp.StatusCode != expected {
+		t.Errorf("makeGetRequest got status code = %d; expected=%d", resp.StatusCode, expected)
+	}
+	if gotHeader != expectedHeader {
+		t.Errorf("makeGetRequest got Authorization header = %q; expected = %q", gotHeader, expectedHeader)
+	}
 }

--- a/run/authentication/auth_test.go
+++ b/run/authentication/auth_test.go
@@ -1,0 +1,67 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package authentication
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+)
+
+func Test_makeGetRequest(t *testing.T) {
+	metadata := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		v := r.URL.Query().Get("audience")
+		if v == "" {
+			http.Error(w, "audience is empty", http.StatusBadRequest)
+			return
+		}
+		fmt.Fprintf(w, "TOKEN_FOR_%s", v)
+	}))
+	defer metadata.Close()
+
+	metadataURL, err := url.Parse(metadata.URL)
+	if err != nil {
+		t.Fatalf("failed to parse metadata URL (%s): %v", metadata.URL, err)
+	}
+	defer os.Unsetenv("GCE_METADATA_HOST")
+	os.Setenv("GCE_METADATA_HOST", metadataURL.Host)
+
+	var gotHeader string
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("Authorization")
+		if gotHeader == "" {
+			http.Error(w, "Authorization header is empty", http.StatusBadRequest)
+			return
+		}
+	}))
+	defer target.Close()
+
+	url := fmt.Sprintf("%s/foo", target.URL)
+	expectedHeader := fmt.Sprintf("Bearer TOKEN_FOR_%s", url)
+
+	resp, err := makeGetRequest(url)
+	if err != nil {
+		t.Fatalf("makeGetRequest: ")
+	}
+	if expected := http.StatusOK; resp.StatusCode != expected {
+		t.Fatalf("unexpected response status: got=%d; expected=%d", resp.StatusCode, expected)
+	}
+	if gotHeader != expectedHeader {
+		t.Fatalf("unexpected Authorization header: expected=%q; got=%q", expectedHeader, gotHeader)
+	}
+	defer resp.Body.Close()
+}


### PR DESCRIPTION
Service to service authentication method sample for Cloud Run.