### PR TITLE
functions/tips: add run region tags

### DIFF
--- a/functions/tips/lazy.go
+++ b/functions/tips/lazy.go
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 // [START functions_tips_lazy_globals]
+// [START run_tips_global_lazy]
 
 // Package tips contains tips for writing Cloud Functions in Go.
 package tips
@@ -45,4 +46,5 @@ func LazyGlobal(w http.ResponseWriter, r *http.Request) {
 	// Use client.
 }
 
+// [END run_tips_global_lazy]
 // [END functions_tips_lazy_globals]

--- a/functions/tips/scope.go
+++ b/functions/tips/scope.go
@@ -21,6 +21,7 @@ import (
 )
 
 // [START functions_tips_scopes]
+// [START run_tips_global_scope]
 
 // h is in the global (instance-wide) scope.
 var h string
@@ -38,6 +39,7 @@ func ScopeDemo(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Global: %q, Local: %q", h, l)
 }
 
+// [END run_tips_global_scope]
 // [END functions_tips_scopes]
 
 func heavyComputation() string {


### PR DESCRIPTION
These two snippets are reused in the Cloud Run docs, wrapping in dedicated region tags to track usage/future evolution.

x-ref: https://github.com/GoogleCloudPlatform/nodejs-docs-samples/pull/1254