### PR TITLE
appengine: add golang and alpine version to Dockerfile

### DIFF
--- a/appengine/go11x/tasks/handle_task/Dockerfile
+++ b/appengine/go11x/tasks/handle_task/Dockerfile
@@ -1,7 +1,7 @@
 # Use the offical Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang as builder
+FROM golang:1.12 as builder
 
 # Copy local code to the container image.
 RUN mkdir /app
@@ -15,7 +15,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -v -o handle_task
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine
+FROM alpine:3.9
 
 # Copy the binary to the production image from the builder stage.
 COPY --from=builder /app/handle_task /handle_task


### PR DESCRIPTION
Keeping builds reproducible but adaptive to bugfixes by specifying versions down to minor release.