### PR TITLE
spanner: check for database presence at test start

### DIFF
--- a/spanner/spanner_snippets/snippet_test.go
+++ b/spanner/spanner_snippets/snippet_test.go
@@ -45,9 +45,12 @@ func TestSample(t *testing.T) {
 	defer adminClient.Close()
 	defer dataClient.Close()
 
-	// Issue a pessimistic delete of the database before starting, as it's possible that resources have
-	// not been fully cleaned up from prior runs.
-	t.Logf("pessimistic spanner delete result: %v", adminClient.DropDatabase(ctx, &adminpb.DropDatabaseRequest{Database: dbName}))
+	// Check for database existance prior to test start and delete, as resources may not have
+	// been cleaned up from previous invocations.
+	if db, err := adminClient.GetDatabase(ctx, &adminpb.GetDatabaseRequest{Name: dbName}); err == nil {
+		t.Logf("database %s exists in state %s. delete result: %v", db.GetName(), db.GetState().String(),
+			adminClient.DropDatabase(ctx, &adminpb.DropDatabaseRequest{Database: dbName}))
+	}
 
 	assertContains := func(out string, sub string) {
 		if !strings.Contains(out, sub) {

--- a/spanner/spanner_snippets/snippet_test.go
+++ b/spanner/spanner_snippets/snippet_test.go
@@ -45,6 +45,10 @@ func TestSample(t *testing.T) {
 	defer adminClient.Close()
 	defer dataClient.Close()
 
+	// Issue a pessimistic delete of the database before starting, as it's possible that resources have
+	// not been fully cleaned up from prior runs.
+	t.Logf("pessimistic spanner delete result: %v", adminClient.DropDatabase(ctx, &adminpb.DropDatabaseRequest{Database: dbName}))
+
 	assertContains := func(out string, sub string) {
 		if !strings.Contains(out, sub) {
 			t.Errorf("got output %q; want it to contain %q", out, sub)


### PR DESCRIPTION
Spanner tests use stable names for testing, rather than generating
random names on each test invocation.  This change issues a single
pessimistic delete at the start of the snippet test and logs the
output, to reduce flakiness of this approach.