### PR TITLE
appengine_flexible: websockets sample

### DIFF
--- a/appengine_flexible/websockets/app.yaml
+++ b/appengine_flexible/websockets/app.yaml
@@ -1,0 +1,15 @@
+runtime: go1.11
+env: flex
+
+# Use only a single instance, so that this local-memory-only chat app will work
+# consistently with multiple users. To work across multiple instances, an
+# extra-instance messaging system or data store would be needed.
+manual_scaling:
+  instances: 1
+
+# For applications which can take advantage of session affinity
+# (where the load balancer will attempt to route multiple connections from
+# the same user to the same App Engine instance), uncomment the folowing:
+
+# network:
+#   session_affinity: true

--- a/appengine_flexible/websockets/main.go
+++ b/appengine_flexible/websockets/main.go
@@ -25,7 +25,7 @@ import (
 
 func main() {
 	http.Handle("/", http.FileServer(http.Dir("static")))
-	http.HandleFunc("/ws", websocketHandler)
+	http.HandleFunc("/ws", socketHandler)
 	http.HandleFunc("/_ah/health", healthCheckHandler)
 	log.Print("Listening on port 8080")
 	log.Fatal(http.ListenAndServe(":8080", nil))
@@ -37,8 +37,8 @@ var upgrader = websocket.Upgrader{
 	WriteBufferSize: 1024,
 }
 
-// wsHandler addresses inbound websocket connection requests.
-func websocketHandler(w http.ResponseWriter, r *http.Request) {
+// socketHandler echos websocket messages back to the client.
+func socketHandler(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/ws" {
 		http.NotFound(w, r)
 		return
@@ -49,19 +49,19 @@ func websocketHandler(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	if err != nil {
-			log.Printf("upgrader.Upgrade: %v", err)
-			return
+		log.Printf("upgrader.Upgrade: %v", err)
+		return
 	}
 
 	for {
-    messageType, p, err := conn.ReadMessage()
-    if err != nil {
-				log.Printf("conn.ReadMessage: %v", err)
-        return
-    }
-    if err := conn.WriteMessage(messageType, p); err != nil {
-        log.Printf("conn.WriteMessage: %v", err)
-        return
+		messageType, p, err := conn.ReadMessage()
+		if err != nil {
+			log.Printf("conn.ReadMessage: %v", err)
+			return
+		}
+		if err := conn.WriteMessage(messageType, p); err != nil {
+			log.Printf("conn.WriteMessage: %v", err)
+			return
 		}
 	}
 }

--- a/appengine_flexible/websockets/main.go
+++ b/appengine_flexible/websockets/main.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// [START gae_flex_websockets_app]
+
 // Sample websockets demonstrates an App Engine Flexible app.
 package main
 
@@ -39,14 +41,8 @@ var upgrader = websocket.Upgrader{
 
 // socketHandler echos websocket messages back to the client.
 func socketHandler(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path != "/ws" {
-		http.NotFound(w, r)
-		return
-	}
 	conn, err := upgrader.Upgrade(w, r, nil)
-	defer func() {
-		conn.Close()
-	}()
+	defer conn.Close()
 
 	if err != nil {
 		log.Printf("upgrader.Upgrade: %v", err)
@@ -70,3 +66,5 @@ func socketHandler(w http.ResponseWriter, r *http.Request) {
 func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, "ok")
 }
+
+// [END gae_flex_websockets_app]

--- a/appengine_flexible/websockets/main.go
+++ b/appengine_flexible/websockets/main.go
@@ -1,0 +1,72 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Sample websockets demonstrates an App Engine Flexible app.
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/gorilla/websocket"
+)
+
+func main() {
+	http.Handle("/", http.FileServer(http.Dir("static")))
+	http.HandleFunc("/ws", websocketHandler)
+	http.HandleFunc("/_ah/health", healthCheckHandler)
+	log.Print("Listening on port 8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+// upgrader holds the websocket connection.
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+}
+
+// wsHandler addresses inbound websocket connection requests.
+func websocketHandler(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/ws" {
+		http.NotFound(w, r)
+		return
+	}
+	conn, err := upgrader.Upgrade(w, r, nil)
+	defer func() {
+		conn.Close()
+	}()
+
+	if err != nil {
+			log.Printf("upgrader.Upgrade: %v", err)
+			return
+	}
+
+	for {
+    messageType, p, err := conn.ReadMessage()
+    if err != nil {
+				log.Printf("conn.ReadMessage: %v", err)
+        return
+    }
+    if err := conn.WriteMessage(messageType, p); err != nil {
+        log.Printf("conn.WriteMessage: %v", err)
+        return
+		}
+	}
+}
+
+// healthCheckHandler is used by App Engine Flex to check instance health.
+func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, "ok")
+}

--- a/appengine_flexible/websockets/main_test.go
+++ b/appengine_flexible/websockets/main_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestSocketHandler(t *testing.T) {
+	var err error
+
+	server := httptest.NewServer(http.HandlerFunc(socketHandler))
+	defer server.Close()
+	dialer := websocket.Dialer{}
+
+	conn, resp, err := dialer.Dial("ws://"+server.Listener.Addr().String()+"/ws", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := resp.StatusCode
+	want := http.StatusSwitchingProtocols
+	if got != want {
+		t.Errorf("resp.StatusCode = %q, want %q", got, want)
+	}
+
+	err = conn.WriteMessage(websocket.TextMessage, []byte("echo test"))
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHealthCheckHandler(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", strings.NewReader(""))
+
+	rr := httptest.NewRecorder()
+	healthCheckHandler(rr, req)
+
+	out, err := ioutil.ReadAll(rr.Result().Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+
+	want := "ok"
+	if got := string(out); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/appengine_flexible/websockets/main_test.go
+++ b/appengine_flexible/websockets/main_test.go
@@ -1,6 +1,21 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (
+	"bytes"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -11,8 +26,6 @@ import (
 )
 
 func TestSocketHandler(t *testing.T) {
-	var err error
-
 	server := httptest.NewServer(http.HandlerFunc(socketHandler))
 	defer server.Close()
 	dialer := websocket.Dialer{}
@@ -22,15 +35,22 @@ func TestSocketHandler(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := resp.StatusCode
 	want := http.StatusSwitchingProtocols
-	if got != want {
+	if got := resp.StatusCode; got != want {
 		t.Errorf("resp.StatusCode = %q, want %q", got, want)
 	}
 
-	err = conn.WriteMessage(websocket.TextMessage, []byte("echo test"))
+	message := []byte("echo test")
+	if err = conn.WriteMessage(websocket.TextMessage, message); err != nil {
+		t.Fatal(err)
+	}
+
+	_, got, err := conn.ReadMessage()
 	if err != nil {
 		t.Fatal(err)
+	}
+	if !bytes.Equal(got, message) {
+		t.Errorf("got %q, want %q", got, message)
 	}
 }
 

--- a/appengine_flexible/websockets/static/index.html
+++ b/appengine_flexible/websockets/static/index.html
@@ -1,0 +1,105 @@
+<!--
+Copyright 2019 Google LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+[START appengine_websockets_index]
+-->
+<!doctype html>
+<html>
+  <head>
+    <title>Google App Engine Flexible Environment - Golang Websockets Chat</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta charset="utf-8">
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      body { font: 13px Helvetica, Arial; }
+      form { background: #000; padding: 3px; position: fixed; bottom: 0; width: 100%; }
+      form input { border: 0; padding: 10px; width: 90%; margin-right: .5%; }
+      form button { width: 9%; background: rgb(130, 224, 255); border: none; padding: 10px; }
+      #messages { list-style-type: none; margin: 0; padding: 0; }
+      #messages li { padding: 5px 10px; }
+      #messages li:nth-child(odd) { background: #dedede; }
+      #messages li:last-child { background: #aea; }
+      section {
+        background-color: #eee;
+        border: 3px dashed #888; border-radius: 10px;
+        margin: 30px; margin-bottom: 80px;
+        padding: 5px;
+      }
+    </style>
+  </head>
+  <body>
+
+    <!-- [START gae_flex_websockets_form] -->
+    <h1>Websockets Chat Demo</h1>
+    
+    <form id="chat-form">
+      <input type="text" id="chat-text" autocomplete="off" placeholder="Enter some text...">
+      <button type="submit">Send</button>
+    </form>
+
+    <section>
+
+      <ul id="messages"></ul>
+    </section>
+
+    <!-- [END gae_flex_websockets_form] -->
+
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
+    <script>
+    // [START gae_flex_websockets_js]
+    $(function() {
+      /* If the main page is served via https, the WebSocket must be served via
+         "wss" (WebSocket Secure) */
+      var scheme = window.location.protocol == "https:" ? 'wss://' : 'ws://';
+      var webSocketUri =  scheme
+                          + window.location.hostname
+                          + (location.port ? ':'+location.port: '')
+                          + '/ws';
+
+      /* Helper to keep an activity log on the page. */
+      function log(text, label) {
+        label = label || 'Status';
+        $('#messages').append(`<li> <strong>${label}</strong>: ${text}`);
+      }
+
+      /* Establish the WebSocket connection and register event handlers. */
+      var websocket = new WebSocket(webSocketUri);
+      websocket.onopen = function() {
+        log('Connected');
+      };
+      websocket.onclose = function() {
+        log('Closed');
+      };
+      websocket.onmessage = function(e) {
+        log(e.data, 'Message received')
+      };
+      websocket.onerror = function(e) {
+        log('Error (see console)');
+        console.log(e);
+      };
+      /* Handle form submission and send a message to the websocket. */
+      $('#chat-form').submit(function(e) {
+        e.preventDefault();
+        var data = $('#chat-text').val();
+        if (data) {
+          websocket.send(data);
+          window.scrollTo(0, document.body.scrollHeight)
+          $('#chat-text').val('');
+        }
+      });
+    });
+    // [END gae_flex_websockets_js]
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
New sample to demonstrate GAE Flex Websockets support.

This is based on a [Python canonical sample](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/appengine/flexible/websockets/main_test.py)

## Screenshot of Frontend

![Screen Shot 2019-04-26 at 3 11 37 PM](https://user-images.githubusercontent.com/283489/56869138-7126b200-69b1-11e9-8c6f-fc9d4b4bbe01.png)
