### PR TITLE
vision/product_search: make testing more hermetic.

### DIFF
--- a/vision/product_search/add_product_to_product_set_test.go
+++ b/vision/product_search/add_product_to_product_set_test.go
@@ -34,6 +34,14 @@ func TestAddProductToProductSet(t *testing.T) {
 
 	var buf bytes.Buffer
 
+	// Ensure re-used resource names don't exist prior to test start.
+	if err := getProductSet(&buf, tc.ProjectID, location, productSetID); err == nil {
+		deleteProductSet(&buf, tc.ProjectID, location, productSetID)
+	}
+	if err := getProduct(&buf, tc.ProjectID, location, productID); err == nil {
+		deleteProduct(&buf, tc.ProjectID, location, productID)
+	}
+
 	// Create fake product set and product.
 	if err := createProductSet(&buf, tc.ProjectID, location, productSetID, productSetDisplayName); err != nil {
 		t.Fatalf("createProductSet: %v", err)

--- a/vision/product_search/create_product_set_test.go
+++ b/vision/product_search/create_product_set_test.go
@@ -31,12 +31,9 @@ func TestCreateProductSet(t *testing.T) {
 
 	var buf bytes.Buffer
 
-	// Make sure the product set to be created does not already exist.
-	if err := listProductSets(&buf, tc.ProjectID, location); err != nil {
-		t.Fatalf("listProductSets: %v", err)
-	}
-	if got := buf.String(); strings.Contains(got, productSetID) {
-		t.Errorf("Product set ID %s already exists", productSetID)
+	// Ensure re-used resource names don't exist prior to test start.
+	if err := getProductSet(&buf, tc.ProjectID, location, productSetID); err == nil {
+		deleteProductSet(&buf, tc.ProjectID, location, productSetID)
 	}
 
 	// Create a fake product set.

--- a/vision/product_search/create_product_test.go
+++ b/vision/product_search/create_product_test.go
@@ -32,12 +32,9 @@ func TestCreateProduct(t *testing.T) {
 
 	var buf bytes.Buffer
 
-	// Make sure the product to be created does not already exist.
-	if err := listProducts(&buf, tc.ProjectID, location); err != nil {
-		t.Fatalf("listProducts: %v", err)
-	}
-	if got := buf.String(); strings.Contains(got, productID) {
-		t.Errorf("Product ID %s already exists", productID)
+	// Ensure re-used resource names don't exist prior to test start.
+	if err := getProduct(&buf, tc.ProjectID, location, productID); err == nil {
+		deleteProduct(&buf, tc.ProjectID, location, productID)
 	}
 
 	// Create a fake product.

--- a/vision/product_search/create_reference_image_test.go
+++ b/vision/product_search/create_reference_image_test.go
@@ -34,17 +34,18 @@ func TestCreateReferenceImage(t *testing.T) {
 
 	var buf bytes.Buffer
 
+	// Ensure re-used resource names don't exist prior to test start.
+	if err := getReferenceImage(&buf, tc.ProjectID, location, productID, referenceImageID); err == nil {
+		deleteReferenceImage(&buf, tc.ProjectID, location, productID, referenceImageID)
+	}
+	if err := getProduct(&buf, tc.ProjectID, location, productID); err == nil {
+		deleteProduct(&buf, tc.ProjectID, location, productID)
+	}
+	buf.Reset()
+
 	// Create a fake product.
 	if err := createProduct(&buf, tc.ProjectID, location, productID, productDisplayName, productCategory); err != nil {
 		t.Fatalf("createProduct: %v", err)
-	}
-
-	// Make sure the reference image to be created does not already exist.
-	if err := listReferenceImages(&buf, tc.ProjectID, location, productID); err != nil {
-		t.Fatalf("listReferenceImages: %v", err)
-	}
-	if got := buf.String(); strings.Contains(got, referenceImageID) {
-		t.Errorf("Reference image ID %s already exists", referenceImageID)
 	}
 
 	// Create reference image.

--- a/vision/product_search/delete_product_set_test.go
+++ b/vision/product_search/delete_product_set_test.go
@@ -31,6 +31,12 @@ func TestDeleteProductSet(t *testing.T) {
 
 	var buf bytes.Buffer
 
+	// Ensure re-used resource names don't exist prior to test start.
+	if err := getProductSet(&buf, tc.ProjectID, location, productSetID); err == nil {
+		deleteProductSet(&buf, tc.ProjectID, location, productSetID)
+	}
+	buf.Reset()
+
 	// Create a fake product set.
 	if err := createProductSet(&buf, tc.ProjectID, location, productSetID, productSetDisplayName); err != nil {
 		t.Fatalf("createProductSet: %v", err)

--- a/vision/product_search/delete_product_test.go
+++ b/vision/product_search/delete_product_test.go
@@ -32,6 +32,12 @@ func TestDeleteProduct(t *testing.T) {
 
 	var buf bytes.Buffer
 
+	// Ensure re-used resource names don't exist prior to test start.
+	if err := getProduct(&buf, tc.ProjectID, location, productID); err == nil {
+		deleteProduct(&buf, tc.ProjectID, location, productID)
+	}
+	buf.Reset()
+
 	// Create a fake product.
 	if err := createProduct(&buf, tc.ProjectID, location, productID, productDisplayName, productCategory); err != nil {
 		t.Fatalf("createProduct: %v", err)

--- a/vision/product_search/delete_reference_image_test.go
+++ b/vision/product_search/delete_reference_image_test.go
@@ -34,6 +34,15 @@ func TestDeleteReferenceImage(t *testing.T) {
 
 	var buf bytes.Buffer
 
+	// Ensure re-used resource names don't exist prior to test start.
+	if err := getReferenceImage(&buf, tc.ProjectID, location, productID, referenceImageID); err == nil {
+		deleteReferenceImage(&buf, tc.ProjectID, location, productID, referenceImageID)
+	}
+	if err := getProduct(&buf, tc.ProjectID, location, productID); err == nil {
+		deleteProduct(&buf, tc.ProjectID, location, productID)
+	}
+	buf.Reset()
+
 	// Create a fake product.
 	if err := createProduct(&buf, tc.ProjectID, location, productID, productDisplayName, productCategory); err != nil {
 		t.Fatalf("createProduct: %v", err)

--- a/vision/product_search/import_product_sets_test.go
+++ b/vision/product_search/import_product_sets_test.go
@@ -39,6 +39,13 @@ func TestImportProductSets(t *testing.T) {
 	if err := getProductSet(&buf, tc.ProjectID, location, productSetID); err == nil {
 		deleteProductSet(&buf, tc.ProjectID, location, productSetID)
 	}
+	if err := getProduct(&buf, tc.ProjectID, location, productID1); err == nil {
+		deleteProduct(&buf, tc.ProjectID, location, productID1)
+	}
+	if err := getProduct(&buf, tc.ProjectID, location, productID2); err == nil {
+		deleteProduct(&buf, tc.ProjectID, location, productID2)
+	}
+
 	buf.Reset()
 
 	// Import product set.

--- a/vision/product_search/import_product_sets_test.go
+++ b/vision/product_search/import_product_sets_test.go
@@ -35,21 +35,11 @@ func TestImportProductSets(t *testing.T) {
 
 	var buf bytes.Buffer
 
-	// Make sure the product set to be created does not already exist.
-	if err := listProductSets(&buf, tc.ProjectID, location); err != nil {
-		t.Fatalf("listProductSets: %v", err)
+	// Ensure re-used resource names don't exist prior to test start.
+	if err := getProductSet(&buf, tc.ProjectID, location, productSetID); err == nil {
+		deleteProductSet(&buf, tc.ProjectID, location, productSetID)
 	}
-	if got := buf.String(); strings.Contains(got, productSetID) {
-		t.Errorf("Product set ID %s already exists", productSetID)
-	}
-
-	// Make sure the products to be created do not already exist.
-	if err := listProducts(&buf, tc.ProjectID, location); err != nil {
-		t.Fatalf("listProducts: %v", err)
-	}
-	if got := buf.String(); strings.Contains(got, productID1) || strings.Contains(got, productID2) {
-		t.Errorf("Product IDs %s %s already exist", productID1, productID2)
-	}
+	buf.Reset()
 
 	// Import product set.
 	if err := importProductSets(&buf, tc.ProjectID, location, gcsURI); err != nil {

--- a/vision/product_search/remove_product_from_product_set_test.go
+++ b/vision/product_search/remove_product_from_product_set_test.go
@@ -34,6 +34,15 @@ func TestRemoveProductFromProductSet(t *testing.T) {
 
 	var buf bytes.Buffer
 
+	// Ensure re-used resource names don't exist prior to test start.
+	if err := getProductSet(&buf, tc.ProjectID, location, productSetID); err == nil {
+		deleteProductSet(&buf, tc.ProjectID, location, productSetID)
+	}
+	if err := getProduct(&buf, tc.ProjectID, location, productID); err == nil {
+		deleteProduct(&buf, tc.ProjectID, location, productID)
+	}
+	buf.Reset()
+
 	// Create fake product set and product.
 	if err := createProductSet(&buf, tc.ProjectID, location, productSetID, productSetDisplayName); err != nil {
 		t.Fatalf("createProductSet: %v", err)

--- a/vision/product_search/update_product_labels_test.go
+++ b/vision/product_search/update_product_labels_test.go
@@ -34,6 +34,12 @@ func TestUpdateProductLabels(t *testing.T) {
 
 	var buf bytes.Buffer
 
+	// Ensure re-used resource names don't exist prior to test start.
+	if err := getProduct(&buf, tc.ProjectID, location, productID); err == nil {
+		deleteProduct(&buf, tc.ProjectID, location, productID)
+	}
+	buf.Reset()
+
 	// Create a fake product.
 	if err := createProduct(&buf, tc.ProjectID, location, productID, productDisplayName, productCategory); err != nil {
 		t.Fatalf("createProduct: %v", err)


### PR DESCRIPTION
Another instance where many tests have implicit expectations on test
start dependent on cleanup from previous runs due to static identifiers.

This test adds explicit probe-and-delete behavior to the start of all
tests that want to create resources (products, product sets, reference
images).