### PR TITLE
kms: asymmetric - return value is base64 commented

### DIFF
--- a/kms/asymmetric.go
+++ b/kms/asymmetric.go
@@ -191,6 +191,7 @@ func signAsymmetric(keyName string, message []byte) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("asymmetric sign request failed: %+v", err)
 	}
+	// Signature is base64 encoded.
 	return response.Signature, nil
 }
 


### PR DESCRIPTION
Responding to user feedback, clarify that the returned signature value of kms_sign_asymmetric is base64 encoded.