### PR TITLE
texttospeech: quickstart include imports and package in region tag

### DIFF
--- a/texttospeech/quickstart/quickstart.go
+++ b/texttospeech/quickstart/quickstart.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// [START tts_quickstart]
+
 // Command quickstart generates an audio file with the content "Hello, World!".
 package main
 
@@ -24,8 +26,6 @@ import (
 	texttospeech "cloud.google.com/go/texttospeech/apiv1"
 	texttospeechpb "google.golang.org/genproto/googleapis/cloud/texttospeech/v1"
 )
-
-// [START tts_quickstart]
 
 func main() {
 	// Instantiates a client.


### PR DESCRIPTION
Move region tag to encompass package declaration and imports in response to developer feedback asking for library imports.