### PR TITLE
testing: remove special case for mailgun

### DIFF
--- a/appengine_flexible/mailgun/mailgun.go
+++ b/appengine_flexible/mailgun/mailgun.go
@@ -56,7 +56,7 @@ func mustGetenv(k string) string {
 
 // [START gae_flex_mailgun_simple_message]
 func sendSimpleMessageHandler(w http.ResponseWriter, r *http.Request) {
-	msg, id, err := mailgunClient.Send(mailgunClient.NewMessage(
+	msg, id, err := mailgunClient.Send(r.Context(), mailgunClient.NewMessage(
 		/* From */ fmt.Sprintf("Excited User <mailgun@%s>", mailgunDomain),
 		/* Subject */ "Hello",
 		/* Body */ "Testing some Mailgun awesomness!",
@@ -87,7 +87,7 @@ func sendComplexMessageHandler(w http.ResponseWriter, r *http.Request) {
 	message.AddReaderAttachment("files/test.txt",
 		ioutil.NopCloser(strings.NewReader("foo")))
 
-	msg, id, err := mailgunClient.Send(message)
+	msg, id, err := mailgunClient.Send(r.Context(), message)
 	if err != nil {
 		msg := fmt.Sprintf("Could not send message: %v, ID %v, %+v", err, id, msg)
 		http.Error(w, msg, http.StatusInternalServerError)

--- a/docs/appengine/mail/mailgun/mailgun.go
+++ b/docs/appengine/mail/mailgun/mailgun.go
@@ -34,7 +34,7 @@ func SendSimpleMessageHandler(w http.ResponseWriter, r *http.Request) {
 	)
 	mg.SetClient(httpc)
 
-	msg, id, err := mg.Send(mg.NewMessage(
+	msg, id, err := mg.Send(appengine.NewContext(r), mg.NewMessage(
 		/* From */ "Excited User <mailgun@YOUR_DOMAIN_NAME>",
 		/* Subject */ "Hello",
 		/* Body */ "Testing some Mailgun awesomness!",
@@ -71,7 +71,7 @@ func SendComplexMessageHandler(w http.ResponseWriter, r *http.Request) {
 	message.AddAttachment("files/test.jpg")
 	message.AddAttachment("files/test.txt")
 
-	msg, id, err := mg.Send(message)
+	msg, id, err := mg.Send(appengine.NewContext(r), message)
 	if err != nil {
 		msg := fmt.Sprintf("Could not send message: %v, ID %v, %+v", err, id, msg)
 		http.Error(w, msg, http.StatusInternalServerError)

--- a/testing/kokoro/system_tests.sh
+++ b/testing/kokoro/system_tests.sh
@@ -80,20 +80,8 @@ fi
 # Download imports.
 GO_IMPORTS=$(go list -f '{{join .Imports "\n"}}{{"\n"}}{{join .TestImports "\n"}}' $TARGET | \
   sort | uniq | \
-  grep -v golang-samples | \
-  grep -v mailgun)
+  grep -v golang-samples)
 time go get -u -v -d $GO_IMPORTS
-
-# The latest version of mailgun-go uses a major module path (and imports),
-# which breaks on Go versions without module support (< 1.11).
-if [ -d $GOPATH/src/github.com/mailgun/mailgun-go ]; then
-  rm -rf $GOPATH/src/github.com/mailgun/mailgun-go
-fi
-git clone https://github.com/mailgun/mailgun-go.git $GOPATH/src/github.com/mailgun/mailgun-go
-pushd $GOPATH/src/github.com/mailgun/mailgun-go
-git checkout v2.0.0
-go get -v ./...
-popd
 
 # Always download top-level and internal dependencies.
 go get -t ./internal/...


### PR DESCRIPTION
Go 1.9.7 and 1.10.3 have minimal support for semantic import versioning.