### PR TITLE
dlp: use parallel subtests

### DIFF
--- a/dlp/dlp_snippets/deid_test.go
+++ b/dlp/dlp_snippets/deid_test.go
@@ -46,11 +46,14 @@ func TestMask(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		buf := new(bytes.Buffer)
-		mask(buf, client, projectID, test.input, []string{"US_SOCIAL_SECURITY_NUMBER"}, test.maskingCharacter, test.numberToMask)
-		if got := buf.String(); got != test.want {
-			t.Errorf("mask(%q, %s, %v) = %q, want %q", test.input, test.maskingCharacter, test.numberToMask, got, test.want)
-		}
+		t.Run(test.input, func(t *testing.T) {
+			t.Parallel()
+			buf := new(bytes.Buffer)
+			mask(buf, client, projectID, test.input, []string{"US_SOCIAL_SECURITY_NUMBER"}, test.maskingCharacter, test.numberToMask)
+			if got := buf.String(); got != test.want {
+				t.Errorf("mask(%q, %s, %v) = %q, want %q", test.input, test.maskingCharacter, test.numberToMask, got, test.want)
+			}
+		})
 	}
 }
 
@@ -76,10 +79,13 @@ func TestDeidentifyDateShift(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		buf := new(bytes.Buffer)
-		deidentifyDateShift(buf, client, projectID, test.lowerBound, test.upperBound, test.input)
-		if got := buf.String(); got != test.want {
-			t.Errorf("deidentifyDateShift(%v, %v, %q) = %q, want %q", test.lowerBound, test.upperBound, got, test.input, test.want)
-		}
+		t.Run(test.input, func(t *testing.T) {
+			// t.Parallel()
+			buf := new(bytes.Buffer)
+			deidentifyDateShift(buf, client, projectID, test.lowerBound, test.upperBound, test.input)
+			if got := buf.String(); got != test.want {
+				t.Errorf("deidentifyDateShift(%v, %v, %q) = %q, want %q", test.lowerBound, test.upperBound, got, test.input, test.want)
+			}
+		})
 	}
 }

--- a/dlp/dlp_snippets/deid_test.go
+++ b/dlp/dlp_snippets/deid_test.go
@@ -80,7 +80,7 @@ func TestDeidentifyDateShift(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.input, func(t *testing.T) {
-			// t.Parallel()
+			t.Parallel()
 			buf := new(bytes.Buffer)
 			deidentifyDateShift(buf, client, projectID, test.lowerBound, test.upperBound, test.input)
 			if got := buf.String(); got != test.want {

--- a/dlp/dlp_snippets/inspect_test.go
+++ b/dlp/dlp_snippets/inspect_test.go
@@ -47,24 +47,27 @@ func TestInspectString(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		buf := new(bytes.Buffer)
-		inspectString(buf, client, projectID, dlppb.Likelihood_POSSIBLE, 0, true, []string{"US_SOCIAL_SECURITY_NUMBER"}, nil, nil, test.s)
-		if got := buf.String(); test.want != strings.Contains(got, "US_SOCIAL_SECURITY_NUMBER") {
-			if test.want {
-				t.Errorf("inspectString(%s) = %q, want 'US_SOCIAL_SECURITY_NUMBER' substring", test.s, got)
-			} else {
-				t.Errorf("inspectString(%s) = %q, want to not contain 'US_SOCIAL_SECURITY_NUMBER'", test.s, got)
+		t.Run(test.s, func(t *testing.T) {
+			t.Parallel()
+			buf := new(bytes.Buffer)
+			inspectString(buf, client, projectID, dlppb.Likelihood_POSSIBLE, 0, true, []string{"US_SOCIAL_SECURITY_NUMBER"}, nil, nil, test.s)
+			if got := buf.String(); test.want != strings.Contains(got, "US_SOCIAL_SECURITY_NUMBER") {
+				if test.want {
+					t.Errorf("inspectString(%s) = %q, want 'US_SOCIAL_SECURITY_NUMBER' substring", test.s, got)
+				} else {
+					t.Errorf("inspectString(%s) = %q, want to not contain 'US_SOCIAL_SECURITY_NUMBER'", test.s, got)
+				}
 			}
-		}
-		buf.Reset()
-		inspectString(buf, client, projectID, dlppb.Likelihood_POSSIBLE, 0, true, nil, []string{"SSN"}, []string{"\\d{9}"}, test.s)
-		if got := buf.String(); test.want != strings.Contains(got, "CUSTOM_DICTIONARY_0") && strings.Contains(got, "CUSTOM_REGEX_0") {
-			if test.want {
-				t.Errorf("inspectString(%s) = %q, want 'CUSTOM_DICTIONARY_0' and 'CUSTOM_REGEX_0' substring", test.s, got)
-			} else {
-				t.Errorf("inspectString(%s) = %q, want to not contain 'CUSTOM_DICTIONARY_0' and 'CUSTOM_REGEX_0'", test.s, got)
+			buf.Reset()
+			inspectString(buf, client, projectID, dlppb.Likelihood_POSSIBLE, 0, true, nil, []string{"SSN"}, []string{"\\d{9}"}, test.s)
+			if got := buf.String(); test.want != strings.Contains(got, "CUSTOM_DICTIONARY_0") && strings.Contains(got, "CUSTOM_REGEX_0") {
+				if test.want {
+					t.Errorf("inspectString(%s) = %q, want 'CUSTOM_DICTIONARY_0' and 'CUSTOM_REGEX_0' substring", test.s, got)
+				} else {
+					t.Errorf("inspectString(%s) = %q, want to not contain 'CUSTOM_DICTIONARY_0' and 'CUSTOM_REGEX_0'", test.s, got)
+				}
 			}
-		}
+		})
 	}
 }
 
@@ -83,24 +86,27 @@ func TestInspectFile(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		buf := new(bytes.Buffer)
-		inspectFile(buf, client, projectID, dlppb.Likelihood_POSSIBLE, 0, true, []string{"US_SOCIAL_SECURITY_NUMBER"}, nil, nil, dlppb.ByteContentItem_TEXT_UTF8, strings.NewReader(test.s))
-		if got := buf.String(); test.want != strings.Contains(got, "US_SOCIAL_SECURITY_NUMBER") {
-			if test.want {
-				t.Errorf("inspectString(%s) = %q, want 'US_SOCIAL_SECURITY_NUMBER' substring", test.s, got)
-			} else {
-				t.Errorf("inspectString(%s) = %q, want to not contain 'US_SOCIAL_SECURITY_NUMBER'", test.s, got)
+		t.Run(test.s, func(t *testing.T) {
+			t.Parallel()
+			buf := new(bytes.Buffer)
+			inspectFile(buf, client, projectID, dlppb.Likelihood_POSSIBLE, 0, true, []string{"US_SOCIAL_SECURITY_NUMBER"}, nil, nil, dlppb.ByteContentItem_TEXT_UTF8, strings.NewReader(test.s))
+			if got := buf.String(); test.want != strings.Contains(got, "US_SOCIAL_SECURITY_NUMBER") {
+				if test.want {
+					t.Errorf("inspectString(%s) = %q, want 'US_SOCIAL_SECURITY_NUMBER' substring", test.s, got)
+				} else {
+					t.Errorf("inspectString(%s) = %q, want to not contain 'US_SOCIAL_SECURITY_NUMBER'", test.s, got)
+				}
 			}
-		}
-		buf.Reset()
-		inspectFile(buf, client, projectID, dlppb.Likelihood_POSSIBLE, 0, true, nil, []string{"SSN"}, []string{"\\d{9}"}, dlppb.ByteContentItem_TEXT_UTF8, strings.NewReader(test.s))
-		if got := buf.String(); test.want != strings.Contains(got, "CUSTOM_DICTIONARY_0") && strings.Contains(got, "CUSTOM_REGEX_0") {
-			if test.want {
-				t.Errorf("inspectString(%s) = %q, want 'CUSTOM_DICTIONARY_0' and 'CUSTOM_REGEX_0' substring", test.s, got)
-			} else {
-				t.Errorf("inspectString(%s) = %q, want to not contain 'CUSTOM_DICTIONARY_0' and 'CUSTOM_REGEX_0'", test.s, got)
+			buf.Reset()
+			inspectFile(buf, client, projectID, dlppb.Likelihood_POSSIBLE, 0, true, nil, []string{"SSN"}, []string{"\\d{9}"}, dlppb.ByteContentItem_TEXT_UTF8, strings.NewReader(test.s))
+			if got := buf.String(); test.want != strings.Contains(got, "CUSTOM_DICTIONARY_0") && strings.Contains(got, "CUSTOM_REGEX_0") {
+				if test.want {
+					t.Errorf("inspectString(%s) = %q, want 'CUSTOM_DICTIONARY_0' and 'CUSTOM_REGEX_0' substring", test.s, got)
+				} else {
+					t.Errorf("inspectString(%s) = %q, want to not contain 'CUSTOM_DICTIONARY_0' and 'CUSTOM_REGEX_0'", test.s, got)
+				}
 			}
-		}
+		})
 	}
 }
 
@@ -171,11 +177,14 @@ func TestInspectGCS(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		buf := new(bytes.Buffer)
-		inspectGCSFile(buf, client, projectID, dlppb.Likelihood_POSSIBLE, 0, true, []string{"US_SOCIAL_SECURITY_NUMBER"}, []string{}, []string{}, inspectTopicName, inspectSubscriptionName, bucketName, test.fileName)
-		if got := buf.String(); !strings.Contains(got, test.want) {
-			t.Errorf("inspectString(%s) = %q, want %q substring", test.fileName, got, test.want)
-		}
+		t.Run(test.fileName, func(t *testing.T) {
+			t.Parallel()
+			buf := new(bytes.Buffer)
+			inspectGCSFile(buf, client, projectID, dlppb.Likelihood_POSSIBLE, 0, true, []string{"US_SOCIAL_SECURITY_NUMBER"}, []string{}, []string{}, inspectTopicName, inspectSubscriptionName, bucketName, test.fileName)
+			if got := buf.String(); !strings.Contains(got, test.want) {
+				t.Errorf("inspectString(%s) = %q, want %q substring", test.fileName, got, test.want)
+			}
+		})
 	}
 }
 
@@ -231,11 +240,14 @@ func TestInspectDatastore(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		buf := new(bytes.Buffer)
-		inspectDatastore(buf, client, projectID, dlppb.Likelihood_POSSIBLE, 0, true, []string{"US_SOCIAL_SECURITY_NUMBER"}, []string{}, []string{}, inspectTopicName, inspectSubscriptionName, projectID, "", test.kind)
-		if got := buf.String(); !strings.Contains(got, test.want) {
-			t.Errorf("inspectDatastore(%s) = %q, want %q substring", test.kind, got, test.want)
-		}
+		t.Run(test.kind, func(t *testing.T) {
+			t.Parallel()
+			buf := new(bytes.Buffer)
+			inspectDatastore(buf, client, projectID, dlppb.Likelihood_POSSIBLE, 0, true, []string{"US_SOCIAL_SECURITY_NUMBER"}, []string{}, []string{}, inspectTopicName, inspectSubscriptionName, projectID, "", test.kind)
+			if got := buf.String(); !strings.Contains(got, test.want) {
+				t.Errorf("inspectDatastore(%s) = %q, want %q substring", test.kind, got, test.want)
+			}
+		})
 	}
 }
 
@@ -312,10 +324,13 @@ func TestInspectBigquery(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		buf := new(bytes.Buffer)
-		inspectBigquery(buf, client, projectID, dlppb.Likelihood_POSSIBLE, 0, true, []string{"US_SOCIAL_SECURITY_NUMBER"}, []string{}, []string{}, inspectTopicName, inspectSubscriptionName, projectID, bqDatasetID, test.table)
-		if got := buf.String(); !strings.Contains(got, test.want) {
-			t.Errorf("inspectBigquery(%s) = %q, want %q substring", test.table, got, test.want)
-		}
+		t.Run(test.table, func(t *testing.T) {
+			t.Parallel()
+			buf := new(bytes.Buffer)
+			inspectBigquery(buf, client, projectID, dlppb.Likelihood_POSSIBLE, 0, true, []string{"US_SOCIAL_SECURITY_NUMBER"}, []string{}, []string{}, inspectTopicName, inspectSubscriptionName, projectID, bqDatasetID, test.table)
+			if got := buf.String(); !strings.Contains(got, test.want) {
+				t.Errorf("inspectBigquery(%s) = %q, want %q substring", test.table, got, test.want)
+			}
+		})
 	}
 }

--- a/dlp/dlp_snippets/metadata_test.go
+++ b/dlp/dlp_snippets/metadata_test.go
@@ -46,10 +46,13 @@ func TestInfoTypes(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		buf := new(bytes.Buffer)
-		infoTypes(buf, client, test.language, test.filter)
-		if got := buf.String(); !strings.Contains(got, test.want) {
-			t.Errorf("infoTypes(%s, %s) = %s, want substring %q", test.language, test.filter, got, test.want)
-		}
+		t.Run(test.language, func(t *testing.T) {
+			t.Parallel()
+			buf := new(bytes.Buffer)
+			infoTypes(buf, client, test.language, test.filter)
+			if got := buf.String(); !strings.Contains(got, test.want) {
+				t.Errorf("infoTypes(%s, %s) = %s, want substring %q", test.language, test.filter, got, test.want)
+			}
+		})
 	}
 }

--- a/dlp/dlp_snippets/redact_test.go
+++ b/dlp/dlp_snippets/redact_test.go
@@ -48,11 +48,14 @@ func TestRedactImage(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		buf := new(bytes.Buffer)
-		// TODO: output to a Writer or bytes rather than to a file on disk.
-		redactImage(buf, client, projectID, dlppb.Likelihood_POSSIBLE, test.infoTypes, test.bt, test.inputPath, "testdata/test_output.png")
-		if got := buf.String(); !strings.Contains(got, test.want) {
-			t.Errorf("redactImage(%s) got %q, want substring %q", test.name, got, test.want)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			buf := new(bytes.Buffer)
+			// TODO: output to a Writer or bytes rather than to a file on disk.
+			redactImage(buf, client, projectID, dlppb.Likelihood_POSSIBLE, test.infoTypes, test.bt, test.inputPath, "testdata/test_output.png")
+			if got := buf.String(); !strings.Contains(got, test.want) {
+				t.Errorf("redactImage(%s) got %q, want substring %q", test.name, got, test.want)
+			}
+		})
 	}
 }

--- a/dlp/dlp_snippets/risk_test.go
+++ b/dlp/dlp_snippets/risk_test.go
@@ -28,77 +28,88 @@ const (
 	riskSubscriptionName = "dlp-risk-test-sub"
 )
 
-func TestRiskNumerical(t *testing.T) {
+func TestRisk(t *testing.T) {
 	testutil.SystemTest(t)
-	testutil.Retry(t, 20, 2*time.Second, func(r *testutil.R) {
-		buf := new(bytes.Buffer)
-		riskNumerical(buf, client, projectID, "bigquery-public-data", riskTopicName, riskSubscriptionName, "nhtsa_traffic_fatalities", "accident_2015", "state_number")
-		wants := []string{"Created job", "Value range", "Value at"}
-		got := buf.String()
-		for _, want := range wants {
-			if !strings.Contains(got, want) {
-				r.Errorf("riskNumerical got %s, want substring %q", got, want)
-			}
-		}
-	})
-}
+	tests := []struct {
+		name string
+		fn   func(r *testutil.R)
+	}{
+		{
+			name: "Numerical",
+			fn: func(r *testutil.R) {
+				buf := new(bytes.Buffer)
+				riskNumerical(buf, client, projectID, "bigquery-public-data", riskTopicName, riskSubscriptionName, "nhtsa_traffic_fatalities", "accident_2015", "state_number")
+				wants := []string{"Created job", "Value range", "Value at"}
+				got := buf.String()
+				for _, want := range wants {
+					if !strings.Contains(got, want) {
+						r.Errorf("riskNumerical got %s, want substring %q", got, want)
+					}
+				}
+			},
+		},
+		{
+			name: "Categorical",
+			fn: func(r *testutil.R) {
+				buf := new(bytes.Buffer)
+				riskCategorical(buf, client, projectID, "bigquery-public-data", riskTopicName, riskSubscriptionName, "nhtsa_traffic_fatalities", "accident_2015", "state_number")
+				wants := []string{"Created job", "Histogram bucket", "Most common value occurs"}
+				got := buf.String()
+				for _, want := range wants {
+					if !strings.Contains(got, want) {
+						r.Errorf("riskCategorical got %s, want substring %q", got, want)
+					}
+				}
+			},
+		},
+		{
+			name: "K Anonymity",
+			fn: func(r *testutil.R) {
+				buf := new(bytes.Buffer)
+				riskKAnonymity(buf, client, projectID, "bigquery-public-data", riskTopicName, riskSubscriptionName, "nhtsa_traffic_fatalities", "accident_2015", "state_number", "county")
+				wants := []string{"Created job", "Histogram bucket", "Size range"}
+				got := buf.String()
+				for _, want := range wants {
+					if !strings.Contains(got, want) {
+						r.Errorf("riskKAnonymity got %s, want substring %q", got, want)
+					}
+				}
+			},
+		},
+		{
+			name: "L Diversity",
+			fn: func(r *testutil.R) {
+				buf := new(bytes.Buffer)
+				riskLDiversity(buf, client, projectID, "bigquery-public-data", riskTopicName, riskSubscriptionName, "nhtsa_traffic_fatalities", "accident_2015", "city", "state_number", "county")
+				wants := []string{"Created job", "Histogram bucket", "Size range"}
+				got := buf.String()
+				for _, want := range wants {
+					if !strings.Contains(got, want) {
+						r.Errorf("riskLDiversity got %s, want substring %q", got, want)
+					}
+				}
+			},
+		},
+		{
+			name: "K Map",
+			fn: func(r *testutil.R) {
+				buf := new(bytes.Buffer)
+				riskKMap(buf, client, projectID, "bigquery-public-data", riskTopicName, riskSubscriptionName, "san_francisco", "bikeshare_trips", "US", "zip_code")
+				wants := []string{"Created job", "Histogram bucket", "Anonymity range"}
+				got := buf.String()
+				for _, want := range wants {
+					if !strings.Contains(got, want) {
+						r.Errorf("riskKMap got %s, want substring %q", got, want)
+					}
+				}
+			},
+		},
+	}
 
-func TestRiskCategorical(t *testing.T) {
-	testutil.SystemTest(t)
-	testutil.Retry(t, 20, 2*time.Second, func(r *testutil.R) {
-		buf := new(bytes.Buffer)
-		riskCategorical(buf, client, projectID, "bigquery-public-data", riskTopicName, riskSubscriptionName, "nhtsa_traffic_fatalities", "accident_2015", "state_number")
-		wants := []string{"Created job", "Histogram bucket", "Most common value occurs"}
-		got := buf.String()
-		for _, want := range wants {
-			if !strings.Contains(got, want) {
-				r.Errorf("riskCategorical got %s, want substring %q", got, want)
-			}
-		}
-	})
-}
-
-func TestRiskKAnonymity(t *testing.T) {
-	testutil.SystemTest(t)
-	testutil.Retry(t, 20, 2*time.Second, func(r *testutil.R) {
-		buf := new(bytes.Buffer)
-		riskKAnonymity(buf, client, projectID, "bigquery-public-data", riskTopicName, riskSubscriptionName, "nhtsa_traffic_fatalities", "accident_2015", "state_number", "county")
-		wants := []string{"Created job", "Histogram bucket", "Size range"}
-		got := buf.String()
-		for _, want := range wants {
-			if !strings.Contains(got, want) {
-				r.Errorf("riskKAnonymity got %s, want substring %q", got, want)
-			}
-		}
-	})
-}
-
-func TestRiskLDiversity(t *testing.T) {
-	testutil.SystemTest(t)
-	testutil.Retry(t, 20, 2*time.Second, func(r *testutil.R) {
-		buf := new(bytes.Buffer)
-		riskLDiversity(buf, client, projectID, "bigquery-public-data", riskTopicName, riskSubscriptionName, "nhtsa_traffic_fatalities", "accident_2015", "city", "state_number", "county")
-		wants := []string{"Created job", "Histogram bucket", "Size range"}
-		got := buf.String()
-		for _, want := range wants {
-			if !strings.Contains(got, want) {
-				r.Errorf("riskLDiversity got %s, want substring %q", got, want)
-			}
-		}
-	})
-}
-
-func TestRiskKMap(t *testing.T) {
-	testutil.SystemTest(t)
-	testutil.Retry(t, 20, 2*time.Second, func(r *testutil.R) {
-		buf := new(bytes.Buffer)
-		riskKMap(buf, client, projectID, "bigquery-public-data", riskTopicName, riskSubscriptionName, "san_francisco", "bikeshare_trips", "US", "zip_code")
-		wants := []string{"Created job", "Histogram bucket", "Anonymity range"}
-		got := buf.String()
-		for _, want := range wants {
-			if !strings.Contains(got, want) {
-				r.Errorf("riskKMap got %s, want substring %q", got, want)
-			}
-		}
-	})
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			testutil.Retry(t, 20, 2*time.Second, test.fn)
+		})
+	}
 }


### PR DESCRIPTION
Running tests in parallel reduces test time by ~100 seconds.