### PR TITLE
appengine: change runtime to go112 and add comment for go111

### DIFF
--- a/appengine/go11x/helloworld/app.yaml
+++ b/appengine/go11x/helloworld/app.yaml
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: go111
+runtime: go112 # replace with go111 for Go 1.11


### PR DESCRIPTION
Changing go111->go112 and putting the go111 value in a comment.