### PR TITLE
testing/docker: add Dockerfiles

### DIFF
--- a/testing/docker/README.md
+++ b/testing/docker/README.md
@@ -1,0 +1,21 @@
+# Docker Containers for golang-samples
+
+We run tests for all supported versions of Go in Docker containers. This
+directory contains `Dockerfile`s for each version of Go. You can run tests in
+these containers to make sure your setup is the same as the test environment.
+
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md),
+[`system_tests.sh`](/testing/kokoro/system_tests.sh), and the `.cfg` files in
+[`/testing/kokoro`](/testing/kokoro).
+
+When new minor versions are released, we should build and push new versions of
+these repos.
+
+```
+gcloud config set project golang-samples-tests
+for d in `find . -type d`; do
+  cd $d
+  gcloud builds submit gcr.io/golang-samples-tests/$d
+  cd -
+done
+```

--- a/testing/docker/go110/Dockerfile
+++ b/testing/docker/go110/Dockerfile
@@ -1,0 +1,3 @@
+FROM golang:1.10
+
+RUN apt-get update && apt-get install -y imagemagick

--- a/testing/docker/go111/Dockerfile
+++ b/testing/docker/go111/Dockerfile
@@ -1,0 +1,3 @@
+FROM golang:1.11
+
+RUN apt-get update && apt-get install -y imagemagick

--- a/testing/docker/go112/Dockerfile
+++ b/testing/docker/go112/Dockerfile
@@ -1,0 +1,3 @@
+FROM golang:1.12
+
+RUN apt-get update && apt-get install -y imagemagick

--- a/testing/docker/go19/Dockerfile
+++ b/testing/docker/go19/Dockerfile
@@ -1,0 +1,3 @@
+FROM golang:1.9
+
+RUN apt-get update && apt-get install -y imagemagick


### PR DESCRIPTION
Fixes #912.

I built and tagged these as the latest versions and tests pass (with no decline in speed due to not having any sort of dependency caching).