### PR TITLE
pubsub: set PublishSettings individually

### DIFF
--- a/pubsub/subscriptions/main.go
+++ b/pubsub/subscriptions/main.go
@@ -154,6 +154,7 @@ func pullMsgsSettings(client *pubsub.Client, subName string) error {
 	ctx := context.Background()
 	// [START pubsub_subscriber_flow_settings]
 	sub := client.Subscription(subName)
+	sub.ReceiveSettings.Synchronous = true
 	sub.ReceiveSettings.MaxOutstandingMessages = 10
 	err := sub.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
 		fmt.Printf("Got message: %q\n", string(msg.Data))

--- a/pubsub/topics/main.go
+++ b/pubsub/topics/main.go
@@ -228,11 +228,10 @@ func publishWithSettings(client *pubsub.Client, topic string, msg []byte) error 
 	ctx := context.Background()
 	// [START pubsub_publisher_batch_settings]
 	t := client.Topic(topic)
-	t.PublishSettings = pubsub.PublishSettings{
-		ByteThreshold:  5000,
-		CountThreshold: 10,
-		DelayThreshold: 100 * time.Millisecond,
-	}
+	t.PublishSettings.ByteThreshold = 5000
+	t.PublishSettings.CountThreshold = 10
+	t.PublishSettings.DelayThreshold = 100 * time.Millisecond
+
 	result := t.Publish(ctx, &pubsub.Message{Data: msg})
 	// Block until the result is returned and a server-generated
 	// ID is returned for the published message.
@@ -249,9 +248,8 @@ func publishSingleGoroutine(client *pubsub.Client, topic string, msg []byte) err
 	ctx := context.Background()
 	// [START pubsub_publisher_concurrency_control]
 	t := client.Topic(topic)
-	t.PublishSettings = pubsub.PublishSettings{
-		NumGoroutines: 1,
-	}
+	t.PublishSettings.NumGoroutines = 1
+
 	result := t.Publish(ctx, &pubsub.Message{Data: msg})
 	// Block until the result is returned and a server-generated
 	// ID is returned for the published message.


### PR DESCRIPTION
Setting PublishSettings individually is recommended over composite literal method. This is because forgetting to set values will default them to the zero value in scenarios where one might not necessarily want to override them.

Additionally, including `ReceiveSettings.Synchronous = true` to make `MaxOutstandingMessages` work. This has been confusing for users before based on current documentation:
```	
// If Synchronous is true, then no more than MaxOutstandingMessages will be in
// memory at one time. (In contrast, when Synchronous is false, more than
// MaxOutstandingMessages may have been received from the service and in memory
// before being processed.) MaxOutstandingBytes still refers to the total bytes
// processed, rather than in memory. NumGoroutines is ignored.
```