### PR TITLE
memorystore/redis: fix redigo path to resolve docker build failure

### DIFF
--- a/memorystore/redis/gke_deployment/Dockerfile
+++ b/memorystore/redis/gke_deployment/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.8-alpine
 
 RUN apk update && apk add git
 
-RUN go get github.com/garyburd/redigo/redis
+RUN go get github.com/gomodule/redigo/redis
 
 ADD . /go/src/visit-counter
 RUN go install visit-counter


### PR DESCRIPTION
redigo package path in Dockerfile is github.com/garyburd/redigo, while
in main.go, the path is github.com/gomodule/redigo.

docker build image fails because of gomodule/redigo can not be found.