### PR TITLE
vision: add product_search purge_orphan_products sample

### DIFF
--- a/vision/product_search/purge_orphan_products.go
+++ b/vision/product_search/purge_orphan_products.go
@@ -1,0 +1,62 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package productsearch contains samples for Google Cloud Vision API Product Search.
+package productsearch
+
+// [START vision_product_search_purge_orphan_products]
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	vision "cloud.google.com/go/vision/apiv1"
+	visionpb "google.golang.org/genproto/googleapis/cloud/vision/v1"
+)
+
+// purgeOrphanProducts deletes all products not in any product sets.
+func purgeOrphanProducts(w io.Writer, projectID string, location string, force bool) error {
+	ctx := context.Background()
+	c, err := vision.NewProductSearchClient(ctx)
+	if err != nil {
+		return fmt.Errorf("NewProductSearchClient: %v", err)
+	}
+	defer c.Close()
+
+	req := &visionpb.PurgeProductsRequest{
+		Parent: fmt.Sprintf("projects/%s/locations/%s", projectID, location),
+		Target: &visionpb.PurgeProductsRequest_DeleteOrphanProducts{
+			DeleteOrphanProducts: true,
+		},
+		Force: force,
+	}
+
+	// The purge operation is async.
+	op, err := c.PurgeProducts(ctx, req)
+	if err != nil {
+		return fmt.Errorf("NewProductSearchClient: %v", err)
+	}
+	fmt.Fprintf(w, "Processing operation name: %s\n", op.Name())
+
+	if err := op.Wait(ctx); err != nil {
+		return fmt.Errorf("Wait: %v", err)
+	}
+
+	fmt.Fprintf(w, "Orphan products deleted.\n")
+
+	return nil
+}
+
+// [END vision_product_search_purge_orphan_products]

--- a/vision/product_search/purge_orphan_products_test.go
+++ b/vision/product_search/purge_orphan_products_test.go
@@ -1,0 +1,67 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package productsearch
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+)
+
+func TestPurgeOrphanProducts(t *testing.T) {
+	tc := testutil.SystemTest(t)
+
+	const location = "us-west1"
+	const productDisplayName = "fake_product_display_name_for_testing"
+	const productCategory = "homegoods"
+	const productID = "fake_product_id_for_testing"
+
+	var buf bytes.Buffer
+
+	// Ensure re-used resource names don't exist prior to test start.
+	if err := getProduct(&buf, tc.ProjectID, location, productID); err == nil {
+		deleteProduct(&buf, tc.ProjectID, location, productID)
+	}
+
+	// Create fake product set and product.
+	if err := createProduct(&buf, tc.ProjectID, location, productID, productDisplayName, productCategory); err != nil {
+		t.Fatalf("createProduct: %v", err)
+	}
+
+	// Make sure the product exists.
+	buf.Reset()
+	if err := listProducts(&buf, tc.ProjectID, location); err != nil {
+		t.Fatalf("listProducts: %v", err)
+	}
+	if got := buf.String(); !strings.Contains(got, productID) {
+		t.Errorf("Product ID %s doesn't exist", productID)
+	}
+
+	// Purge the products in the product set.
+	if err := purgeOrphanProducts(&buf, tc.ProjectID, location, true); err != nil {
+		t.Fatalf("purgeOrphanProducts: %v", err)
+	}
+
+	// Check if the orphan product was deleted.
+	buf.Reset()
+	if err := listProducts(&buf, tc.ProjectID, location); err != nil {
+		t.Fatalf("listProducts: %v", err)
+	}
+	if got := buf.String(); !strings.Contains(got, productID) {
+		t.Errorf("Product ID %s still exists", productID)
+	}
+}


### PR DESCRIPTION
Adding `product_search` sample for `purge_orphan_products`.