### PR TITLE
bigquery: re-enable CMEK snippet test

### DIFF
--- a/bigquery/snippets/snippet_test.go
+++ b/bigquery/snippets/snippet_test.go
@@ -227,12 +227,10 @@ func TestAll(t *testing.T) {
 	if err := copyMultiTable(client, datasetID, dstTableID); err != nil {
 		t.Errorf("copyMultiTable(dataset:%q table:%q): %v", datasetID, dstTableID, err)
 	}
-	/* skipped due to b/140294699
 	dstTableID = uniqueBQName("golang_example_copycmek")
 	if err := copyTableWithCMEK(client, datasetID, dstTableID); err != nil {
 		t.Errorf("copyTableWithCMEK(dataset:%q table:%q): %v", datasetID, dstTableID, err)
 	}
-	*/
 
 	if err := listJobs(client, ioutil.Discard); err != nil {
 		t.Errorf("listJobs: %v", err)


### PR DESCRIPTION
Fixes: https://github.com/GoogleCloudPlatform/golang-samples/issues/967
(internal issue 140294699)