### PR TITLE
appengine: add static go.mod and test

### DIFF
--- a/appengine/go11x/static/go.mod
+++ b/appengine/go11x/static/go.mod
@@ -1,3 +1,3 @@
 module github.com/GoogleCloudPlatform/golang-samples/appengine/go11x/static
 
-go 1.13
+go 1.11

--- a/appengine/go11x/static/go.mod
+++ b/appengine/go11x/static/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleCloudPlatform/golang-samples/appengine/go11x/static
+
+go 1.13

--- a/internal/e2e/standard_test.go
+++ b/internal/e2e/standard_test.go
@@ -40,6 +40,19 @@ func TestHelloWorld(t *testing.T) {
 	bodyShouldContain(t, helloworld, "/", "Hello, World!")
 }
 
+func TestGo11xStatic(t *testing.T) {
+	tc := testutil.EndToEndTest(t)
+
+	helloworld := &aeintegrate.App{
+		Name:      "static",
+		Dir:       tc.Path("appengine", "go11x", "static"),
+		ProjectID: tc.ProjectID,
+	}
+	defer helloworld.Cleanup()
+
+	bodyShouldContain(t, helloworld, "/", "The Gopher Network")
+}
+
 func bodyShouldContain(t *testing.T, p *aeintegrate.App, path, shouldContain string) {
 	if p.Deployed() {
 		t.Fatalf("[%s] expected non-deployed app", p.Name)


### PR DESCRIPTION
Without the go.mod, App Engine can't find the templates.

Fixes #993.

cc @Deleplace.