### PR TITLE
spanner: shorten leaderboard test and make it E2E

### DIFF
--- a/spanner/spanner_leaderboard/leaderboard_test.go
+++ b/spanner/spanner_leaderboard/leaderboard_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestSample(t *testing.T) {
-	tc := testutil.SystemTest(t)
+	tc := testutil.EndToEndTest(t)
 
 	instance := os.Getenv("GOLANG_SAMPLES_SPANNER")
 	if instance == "" {
@@ -87,14 +87,6 @@ func TestSample(t *testing.T) {
 	mustRunCommand(t, "createdatabase", dbName, 0)
 	assertContains(t, runCommand(t, "insertplayers", dbName, 0), "Inserted players")
 	assertContains(t, runCommand(t, "insertplayers", dbName, 0), "Inserted players")
-	assertContains(t, runCommand(t, "insertscores", dbName, 0), "Inserted scores")
-	assertContains(t, runCommand(t, "insertscores", dbName, 0), "Inserted scores")
-	assertContains(t, runCommand(t, "insertscores", dbName, 0), "Inserted scores")
-	assertContains(t, runCommand(t, "insertscores", dbName, 0), "Inserted scores")
-	assertContains(t, runCommand(t, "insertscores", dbName, 0), "Inserted scores")
-	assertContains(t, runCommand(t, "insertscores", dbName, 0), "Inserted scores")
-	assertContains(t, runCommand(t, "insertscores", dbName, 0), "Inserted scores")
-	assertContains(t, runCommand(t, "insertscores", dbName, 0), "Inserted scores")
 	assertContains(t, runCommand(t, "insertscores", dbName, 0), "Inserted scores")
 	assertContains(t, runCommand(t, "insertscores", dbName, 0), "Inserted scores")
 	assertContains(t, runCommand(t, "query", dbName, 0), "PlayerId: ")


### PR DESCRIPTION
This test takes 500-700 seconds. Removing some of the additional insertscores calls speeds it up ~300-400 seconds without sacrificing test quality.

I also switched this to be an E2E test, so it will run less often.