### PR TITLE
appengine_flexible: mask IPs and don't use appengine package for Cloud SQL

### DIFF
--- a/appengine_flexible/cloudsql_postgres/README.md
+++ b/appengine_flexible/cloudsql_postgres/README.md
@@ -2,4 +2,4 @@
 
 Follow the [instructions][1] in the documentation to run this code.
 
-[1]: https://cloud.google.com/appengine/docs/flexible/go/using-cloud-sql
+[1]: https://cloud.google.com/appengine/docs/flexible/go/using-cloud-sql-postgres


### PR DESCRIPTION
Fixes #9.