### PR TITLE
Pubsub: Correct subscription reference

### DIFF
--- a/pubsub/pubsub_quickstart/main.go
+++ b/pubsub/pubsub_quickstart/main.go
@@ -37,11 +37,11 @@ func main() {
 		log.Fatalf("Failed to create client: %v", err)
 	}
 
-	// Sets the name for the new topic.
-	topicName := "my-topic"
+	// Sets the id for the new topic.
+	topicID := "my-topic"
 
 	// Creates the new topic.
-	topic, err := client.CreateTopic(ctx, topicName)
+	topic, err := client.CreateTopic(ctx, topicID)
 	if err != nil {
 		log.Fatalf("Failed to create topic: %v", err)
 	}

--- a/pubsub/subscriptions/add_users.go
+++ b/pubsub/subscriptions/add_users.go
@@ -24,16 +24,16 @@ import (
 )
 
 // addUsers adds all IAM users to a subscription.
-func addUsers(projectID, subName string) error {
+func addUsers(projectID, subID string) error {
 	// projectID := "my-project-id"
-	// subName := "my-sub" // subscription id
+	// subID := "my-sub"
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)
 	if err != nil {
 		return fmt.Errorf("pubsub.NewClient: %v", err)
 	}
 
-	sub := client.Subscription(subName)
+	sub := client.Subscription(subID)
 	policy, err := sub.IAM().Policy(ctx)
 	if err != nil {
 		return fmt.Errorf("Policy: %v", err)

--- a/pubsub/subscriptions/add_users.go
+++ b/pubsub/subscriptions/add_users.go
@@ -26,7 +26,7 @@ import (
 // addUsers adds all IAM users to a subscription.
 func addUsers(projectID, subName string) error {
 	// projectID := "my-project-id"
-	// subName := projectID + "-example-sub"
+	// subName := "my-sub" // subscription id
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)
 	if err != nil {

--- a/pubsub/subscriptions/async_pull.go
+++ b/pubsub/subscriptions/async_pull.go
@@ -25,9 +25,9 @@ import (
 	"cloud.google.com/go/pubsub"
 )
 
-func pullMsgs(w io.Writer, projectID, subName string, topic *pubsub.Topic) error {
+func pullMsgs(w io.Writer, projectID, subID string, topic *pubsub.Topic) error {
 	// projectID := "my-project-id"
-	// subName := "my-sub" // subscription id
+	// subID := "my-sub"
 	// topic of type https://godoc.org/cloud.google.com/go/pubsub#Topic
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)
@@ -54,7 +54,7 @@ func pullMsgs(w io.Writer, projectID, subName string, topic *pubsub.Topic) error
 	// Consume 10 messages.
 	var mu sync.Mutex
 	received := 0
-	sub := client.Subscription(subName)
+	sub := client.Subscription(subID)
 	cctx, cancel := context.WithCancel(ctx)
 	err = sub.Receive(cctx, func(ctx context.Context, msg *pubsub.Message) {
 		msg.Ack()

--- a/pubsub/subscriptions/async_pull.go
+++ b/pubsub/subscriptions/async_pull.go
@@ -27,7 +27,7 @@ import (
 
 func pullMsgs(w io.Writer, projectID, subName string, topic *pubsub.Topic) error {
 	// projectID := "my-project-id"
-	// subName := projectID + "-example-sub"
+	// subName := "my-sub" // subscription id
 	// topic of type https://godoc.org/cloud.google.com/go/pubsub#Topic
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)

--- a/pubsub/subscriptions/create.go
+++ b/pubsub/subscriptions/create.go
@@ -26,7 +26,7 @@ import (
 
 func create(w io.Writer, projectID, subName string, topic *pubsub.Topic) error {
 	// projectID := "my-project-id"
-	// subName := projectID + "-example-sub"
+	// subName := "my-sub" // subscription id
 	// topic of type https://godoc.org/cloud.google.com/go/pubsub#Topic
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)

--- a/pubsub/subscriptions/create.go
+++ b/pubsub/subscriptions/create.go
@@ -24,9 +24,9 @@ import (
 	"cloud.google.com/go/pubsub"
 )
 
-func create(w io.Writer, projectID, subName string, topic *pubsub.Topic) error {
+func create(w io.Writer, projectID, subID string, topic *pubsub.Topic) error {
 	// projectID := "my-project-id"
-	// subName := "my-sub" // subscription id
+	// subID := "my-sub"
 	// topic of type https://godoc.org/cloud.google.com/go/pubsub#Topic
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)
@@ -34,7 +34,7 @@ func create(w io.Writer, projectID, subName string, topic *pubsub.Topic) error {
 		return fmt.Errorf("pubsub.NewClient: %v", err)
 	}
 
-	sub, err := client.CreateSubscription(ctx, subName, pubsub.SubscriptionConfig{
+	sub, err := client.CreateSubscription(ctx, subID, pubsub.SubscriptionConfig{
 		Topic:       topic,
 		AckDeadline: 20 * time.Second,
 	})

--- a/pubsub/subscriptions/create_endpoint.go
+++ b/pubsub/subscriptions/create_endpoint.go
@@ -26,7 +26,7 @@ import (
 
 func createWithEndpoint(w io.Writer, projectID, subName string, topic *pubsub.Topic, endpoint string) error {
 	// projectID := "my-project-id"
-	// subName := projectID + "-example-sub"
+	// subName := "my-sub" // subscription id
 	// topic of type https://godoc.org/cloud.google.com/go/pubsub#Topic
 	// endpoint := "https://my-test-project.appspot.com/push"
 	ctx := context.Background()

--- a/pubsub/subscriptions/create_endpoint.go
+++ b/pubsub/subscriptions/create_endpoint.go
@@ -24,9 +24,9 @@ import (
 	"cloud.google.com/go/pubsub"
 )
 
-func createWithEndpoint(w io.Writer, projectID, subName string, topic *pubsub.Topic, endpoint string) error {
+func createWithEndpoint(w io.Writer, projectID, subID string, topic *pubsub.Topic, endpoint string) error {
 	// projectID := "my-project-id"
-	// subName := "my-sub" // subscription id
+	// subID := "my-sub"
 	// topic of type https://godoc.org/cloud.google.com/go/pubsub#Topic
 	// endpoint := "https://my-test-project.appspot.com/push"
 	ctx := context.Background()
@@ -35,7 +35,7 @@ func createWithEndpoint(w io.Writer, projectID, subName string, topic *pubsub.To
 		return fmt.Errorf("pubsub.NewClient: %v", err)
 	}
 
-	sub, err := client.CreateSubscription(ctx, subName, pubsub.SubscriptionConfig{
+	sub, err := client.CreateSubscription(ctx, subID, pubsub.SubscriptionConfig{
 		Topic:       topic,
 		AckDeadline: 10 * time.Second,
 		PushConfig:  pubsub.PushConfig{Endpoint: endpoint},

--- a/pubsub/subscriptions/delete.go
+++ b/pubsub/subscriptions/delete.go
@@ -23,20 +23,20 @@ import (
 	"cloud.google.com/go/pubsub"
 )
 
-func delete(w io.Writer, projectID, subName string) error {
+func delete(w io.Writer, projectID, subID string) error {
 	// projectID := "my-project-id"
-	// subName := "my-sub" // subscription id
+	// subID := "my-sub"
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)
 	if err != nil {
 		return fmt.Errorf("pubsub.NewClient: %v", err)
 	}
 
-	sub := client.Subscription(subName)
+	sub := client.Subscription(subID)
 	if err := sub.Delete(ctx); err != nil {
 		return fmt.Errorf("Delete: %v", err)
 	}
-	fmt.Fprintf(w, "Subscription %q deleted.", subName)
+	fmt.Fprintf(w, "Subscription %q deleted.", subID)
 	return nil
 }
 

--- a/pubsub/subscriptions/delete.go
+++ b/pubsub/subscriptions/delete.go
@@ -25,7 +25,7 @@ import (
 
 func delete(w io.Writer, projectID, subName string) error {
 	// projectID := "my-project-id"
-	// subName := projectID + "-example-sub"
+	// subName := "my-sub" // subscription id
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)
 	if err != nil {

--- a/pubsub/subscriptions/policy.go
+++ b/pubsub/subscriptions/policy.go
@@ -24,16 +24,16 @@ import (
 	"cloud.google.com/go/pubsub"
 )
 
-func policy(w io.Writer, projectID, subName string) (*iam.Policy, error) {
+func policy(w io.Writer, projectID, subID string) (*iam.Policy, error) {
 	// projectID := "my-project-id"
-	// subName := "my-sub" // subscription id
+	// subID := "my-sub"
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)
 	if err != nil {
 		return nil, fmt.Errorf("pubsub.NewClient: %v", err)
 	}
 
-	policy, err := client.Subscription(subName).IAM().Policy(ctx)
+	policy, err := client.Subscription(subID).IAM().Policy(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("Subscription: %v", err)
 	}

--- a/pubsub/subscriptions/policy.go
+++ b/pubsub/subscriptions/policy.go
@@ -26,7 +26,7 @@ import (
 
 func policy(w io.Writer, projectID, subName string) (*iam.Policy, error) {
 	// projectID := "my-project-id"
-	// subName := projectID + "-example-sub"
+	// subName := "my-sub" // subscription id
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)
 	if err != nil {

--- a/pubsub/subscriptions/pull_error.go
+++ b/pubsub/subscriptions/pull_error.go
@@ -23,9 +23,9 @@ import (
 	"cloud.google.com/go/pubsub"
 )
 
-func pullMsgsError(w io.Writer, projectID, subName string) error {
+func pullMsgsError(w io.Writer, projectID, subID string) error {
 	// projectID := "my-project-id"
-	// subName := "my-sub" // subscription id
+	// subID := "my-sub"
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)
 	if err != nil {
@@ -34,7 +34,7 @@ func pullMsgsError(w io.Writer, projectID, subName string) error {
 
 	// If the service returns a non-retryable error, Receive returns that error after
 	// all of the outstanding calls to the handler have returned.
-	err = client.Subscription(subName).Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
+	err = client.Subscription(subID).Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
 		fmt.Fprintf(w, "Got message: %q\n", string(msg.Data))
 		msg.Ack()
 	})

--- a/pubsub/subscriptions/pull_error.go
+++ b/pubsub/subscriptions/pull_error.go
@@ -25,7 +25,7 @@ import (
 
 func pullMsgsError(w io.Writer, projectID, subName string) error {
 	// projectID := "my-project-id"
-	// subName := projectID + "-example-sub"
+	// subName := "my-sub" // subscription id
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)
 	if err != nil {

--- a/pubsub/subscriptions/pull_settings.go
+++ b/pubsub/subscriptions/pull_settings.go
@@ -23,16 +23,16 @@ import (
 	"cloud.google.com/go/pubsub"
 )
 
-func pullMsgsSettings(w io.Writer, projectID, subName string) error {
+func pullMsgsSettings(w io.Writer, projectID, subID string) error {
 	// projectID := "my-project-id"
-	// subName := "my-sub" // subscription id
+	// subID := "my-sub"
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)
 	if err != nil {
 		return fmt.Errorf("pubsub.NewClient: %v", err)
 	}
 
-	sub := client.Subscription(subName)
+	sub := client.Subscription(subID)
 	sub.ReceiveSettings.Synchronous = true
 	sub.ReceiveSettings.MaxOutstandingMessages = 10
 	err = sub.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {

--- a/pubsub/subscriptions/pull_settings.go
+++ b/pubsub/subscriptions/pull_settings.go
@@ -25,7 +25,7 @@ import (
 
 func pullMsgsSettings(w io.Writer, projectID, subName string) error {
 	// projectID := "my-project-id"
-	// subName := projectID + "-example-sub"
+	// subName := "my-sub" // subscription id
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)
 	if err != nil {

--- a/pubsub/subscriptions/subscription_test.go
+++ b/pubsub/subscriptions/subscription_test.go
@@ -29,8 +29,8 @@ import (
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 )
 
-var topicName string
-var subName string
+var topicID string
+var subID string
 
 // once guards cleanup related operations in setup. No need to set up and tear
 // down every time, so this speeds things up.
@@ -40,8 +40,8 @@ func setup(t *testing.T) *pubsub.Client {
 	ctx := context.Background()
 	tc := testutil.SystemTest(t)
 
-	topicName = "test-sub-topic"
-	subName = "test-sub"
+	topicID = "test-sub-topic"
+	subID = "test-sub"
 	var err error
 	client, err := pubsub.NewClient(ctx, tc.ProjectID)
 	if err != nil {
@@ -50,24 +50,24 @@ func setup(t *testing.T) *pubsub.Client {
 
 	// Cleanup resources from the previous tests.
 	once.Do(func() {
-		topic := client.Topic(topicName)
+		topic := client.Topic(topicID)
 		ok, err := topic.Exists(ctx)
 		if err != nil {
 			t.Fatalf("failed to check if topic exists: %v", err)
 		}
 		if ok {
 			if err := topic.Delete(ctx); err != nil {
-				t.Fatalf("failed to cleanup the topic (%q): %v", topicName, err)
+				t.Fatalf("failed to cleanup the topic (%q): %v", topicID, err)
 			}
 		}
-		sub := client.Subscription(subName)
+		sub := client.Subscription(subID)
 		ok, err = sub.Exists(ctx)
 		if err != nil {
 			t.Fatalf("failed to check if subscription exists: %v", err)
 		}
 		if ok {
 			if err := sub.Delete(ctx); err != nil {
-				t.Fatalf("failed to cleanup the subscription (%q): %v", subName, err)
+				t.Fatalf("failed to cleanup the subscription (%q): %v", subID, err)
 			}
 		}
 	})
@@ -79,20 +79,20 @@ func TestCreate(t *testing.T) {
 	ctx := context.Background()
 	tc := testutil.SystemTest(t)
 	client := setup(t)
-	topic, err := client.CreateTopic(ctx, topicName)
+	topic, err := client.CreateTopic(ctx, topicID)
 	if err != nil {
 		t.Fatalf("CreateTopic: %v", err)
 	}
 	buf := new(bytes.Buffer)
-	if err := create(buf, tc.ProjectID, subName, topic); err != nil {
+	if err := create(buf, tc.ProjectID, subID, topic); err != nil {
 		t.Fatalf("failed to create a subscription: %v", err)
 	}
-	ok, err := client.Subscription(subName).Exists(context.Background())
+	ok, err := client.Subscription(subID).Exists(context.Background())
 	if err != nil {
 		t.Fatalf("failed to check if sub exists: %v", err)
 	}
 	if !ok {
-		t.Fatalf("got none; want sub = %q", subName)
+		t.Fatalf("got none; want sub = %q", subID)
 	}
 }
 
@@ -107,16 +107,16 @@ func TestList(t *testing.T) {
 		}
 
 		for _, sub := range subs {
-			if sub.ID() == subName {
+			if sub.ID() == subID {
 				return // PASS
 			}
 		}
 
-		subNames := make([]string, len(subs))
+		subIDs := make([]string, len(subs))
 		for i, sub := range subs {
-			subNames[i] = sub.ID()
+			subIDs[i] = sub.ID()
 		}
-		r.Errorf("got %+v; want a list with subscription %q", subNames, subName)
+		r.Errorf("got %+v; want a list with subscription %q", subIDs, subID)
 	})
 }
 
@@ -125,7 +125,7 @@ func TestIAM(t *testing.T) {
 
 	testutil.Retry(t, 10, time.Second, func(r *testutil.R) {
 		buf := new(bytes.Buffer)
-		perms, err := testPermissions(buf, tc.ProjectID, subName)
+		perms, err := testPermissions(buf, tc.ProjectID, subID)
 		if err != nil {
 			r.Errorf("testPermissions: %v", err)
 		}
@@ -135,14 +135,14 @@ func TestIAM(t *testing.T) {
 	})
 
 	testutil.Retry(t, 10, time.Second, func(r *testutil.R) {
-		if err := addUsers(tc.ProjectID, subName); err != nil {
+		if err := addUsers(tc.ProjectID, subID); err != nil {
 			r.Errorf("addUsers: %v", err)
 		}
 	})
 
 	testutil.Retry(t, 10, time.Second, func(r *testutil.R) {
 		buf := new(bytes.Buffer)
-		policy, err := policy(buf, tc.ProjectID, subName)
+		policy, err := policy(buf, tc.ProjectID, subID)
 		if err != nil {
 			r.Errorf("policy: %v", err)
 		}
@@ -160,17 +160,17 @@ func TestDelete(t *testing.T) {
 	tc := testutil.SystemTest(t)
 	client := setup(t)
 
-	topic := client.Topic(topicName)
+	topic := client.Topic(topicID)
 	ok, err := topic.Exists(ctx)
 	if err != nil {
 		t.Fatalf("failed to check if topic exists: %v", err)
 	}
 	if !ok {
-		topic, err := client.CreateTopic(ctx, topicName)
+		topic, err := client.CreateTopic(ctx, topicID)
 		if err != nil {
 			t.Fatalf("CreateTopic: %v", err)
 		}
-		_, err = client.CreateSubscription(ctx, subName, pubsub.SubscriptionConfig{
+		_, err = client.CreateSubscription(ctx, subID, pubsub.SubscriptionConfig{
 			Topic:       topic,
 			AckDeadline: 20 * time.Second,
 		})
@@ -180,14 +180,14 @@ func TestDelete(t *testing.T) {
 	}
 
 	buf := new(bytes.Buffer)
-	if err := delete(buf, tc.ProjectID, subName); err != nil {
-		t.Fatalf("failed to delete subscription (%q): %v", subName, err)
+	if err := delete(buf, tc.ProjectID, subID); err != nil {
+		t.Fatalf("failed to delete subscription (%q): %v", subID, err)
 	}
-	ok, err = client.Subscription(subName).Exists(context.Background())
+	ok, err = client.Subscription(subID).Exists(context.Background())
 	if err != nil {
 		t.Fatalf("failed to check if sub exists: %v", err)
 	}
 	if ok {
-		t.Fatalf("got sub = %q; want none", subName)
+		t.Fatalf("got sub = %q; want none", subID)
 	}
 }

--- a/pubsub/subscriptions/subscription_test.go
+++ b/pubsub/subscriptions/subscription_test.go
@@ -40,8 +40,8 @@ func setup(t *testing.T) *pubsub.Client {
 	ctx := context.Background()
 	tc := testutil.SystemTest(t)
 
-	topicName = tc.ProjectID + "-test-sub-topic"
-	subName = tc.ProjectID + "-test-sub"
+	topicName = "test-sub-topic"
+	subName = "test-sub"
 	var err error
 	client, err := pubsub.NewClient(ctx, tc.ProjectID)
 	if err != nil {

--- a/pubsub/subscriptions/test_permissions.go
+++ b/pubsub/subscriptions/test_permissions.go
@@ -25,7 +25,7 @@ import (
 
 func testPermissions(w io.Writer, projectID, subName string) ([]string, error) {
 	// projectID := "my-project-id"
-	// subName := projectID + "-example-sub"
+	// subName := "my-sub" // subscription id
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)
 	if err != nil {

--- a/pubsub/subscriptions/test_permissions.go
+++ b/pubsub/subscriptions/test_permissions.go
@@ -23,16 +23,16 @@ import (
 	"cloud.google.com/go/pubsub"
 )
 
-func testPermissions(w io.Writer, projectID, subName string) ([]string, error) {
+func testPermissions(w io.Writer, projectID, subID string) ([]string, error) {
 	// projectID := "my-project-id"
-	// subName := "my-sub" // subscription id
+	// subID := "my-sub"
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)
 	if err != nil {
 		return nil, fmt.Errorf("pubsub.NewClient: %v", err)
 	}
 
-	sub := client.Subscription(subName)
+	sub := client.Subscription(subID)
 	perms, err := sub.IAM().TestPermissions(ctx, []string{
 		"pubsub.subscriptions.consume",
 		"pubsub.subscriptions.update",

--- a/pubsub/subscriptions/update.go
+++ b/pubsub/subscriptions/update.go
@@ -25,7 +25,7 @@ import (
 
 func updateEndpoint(w io.Writer, projectID, subName string, endpoint string) error {
 	// projectID := "my-project-id"
-	// subName := projectID + "-example-sub"
+	// subName := "my-sub" // subscription id
 	// endpoint := "https://my-test-project.appspot.com/push"
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)

--- a/pubsub/subscriptions/update.go
+++ b/pubsub/subscriptions/update.go
@@ -23,9 +23,9 @@ import (
 	"cloud.google.com/go/pubsub"
 )
 
-func updateEndpoint(w io.Writer, projectID, subName string, endpoint string) error {
+func updateEndpoint(w io.Writer, projectID, subID string, endpoint string) error {
 	// projectID := "my-project-id"
-	// subName := "my-sub" // subscription id
+	// subID := "my-sub"
 	// endpoint := "https://my-test-project.appspot.com/push"
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)
@@ -33,7 +33,7 @@ func updateEndpoint(w io.Writer, projectID, subName string, endpoint string) err
 		return fmt.Errorf("pubsub.NewClient: %v", err)
 	}
 
-	subConfig, err := client.Subscription(subName).Update(ctx, pubsub.SubscriptionConfigToUpdate{
+	subConfig, err := client.Subscription(subID).Update(ctx, pubsub.SubscriptionConfigToUpdate{
 		PushConfig: &pubsub.PushConfig{Endpoint: endpoint},
 	})
 	if err != nil {


### PR DESCRIPTION
The current code sample references a Subscription by concatenating the project id with the subscription identifier:
```go
func pullMsgs(w io.Writer, projectID, subName string, topic *pubsub.Topic) error {
	// projectID := "my-project-id"
	// subName := projectID + "-example-sub"
        ...
```  

However, only the subscription `id` is needed, so that it can be used to form the fully qualified name. The following is from the pubsub [source code](https://github.com/googleapis/google-cloud-go/blob/master/pubsub/subscription.go#L61):
```go
// SubscriptionInProject creates a reference to a subscription in a given project.
func (c *Client) SubscriptionInProject(id, projectID string) *Subscription {
	return &Subscription{
		c:    c,
		name: fmt.Sprintf("projects/%s/subscriptions/%s", projectID, id),
	}
}
```

This PR changes the subscription identifier to `my-sub`, to be consistent with the [PubSub docs](https://cloud.google.com/pubsub/docs/quickstart-client-libraries). All relevant files were updated too.