### PR TITLE
kms: don't say to base64 encode when decrypting

### DIFF
--- a/kms/asymmetric_test.go
+++ b/kms/asymmetric_test.go
@@ -59,22 +59,22 @@ func TestRSAEncryptDecrypt(t *testing.T) {
 	tc := testutil.SystemTest(t)
 	v := getTestVariables(tc.ProjectID)
 
-	cipherBytes, err := encryptRSA(v.rsaDecryptPath, []byte(v.message))
+	ciphertext, err := encryptRSA(v.rsaDecryptPath, []byte(v.message))
 	if err != nil {
 		t.Fatalf("encryptRSA(%s, %s): %v", v.rsaDecryptPath, []byte(v.message), err)
 	}
-	if len(cipherBytes) != 256 {
-		t.Fatalf("len(cipherBytes) = %d; want: %d", len(cipherBytes), 256)
+	if len(ciphertext) != 256 {
+		t.Fatalf("len(ciphertext) = %d; want: %d", len(ciphertext), 256)
 	}
-	plainBytes, err := decryptRSA(v.rsaDecryptPath, cipherBytes)
+	plainBytes, err := decryptRSA(v.rsaDecryptPath, ciphertext)
 	if err != nil {
-		t.Fatalf("decryptRSA(%s, %s): %v", cipherBytes, v.rsaDecryptPath, err)
+		t.Fatalf("decryptRSA(%s, %s): %v", ciphertext, v.rsaDecryptPath, err)
 	}
 	if !bytes.Equal(plainBytes, []byte(v.message)) {
 		t.Fatalf("decrypted plaintext does not match input message: want %s, got %s", []byte(v.message), plainBytes)
 	}
-	if bytes.Equal(cipherBytes, []byte(v.message)) {
-		t.Fatalf("ciphertext and plaintext bytes are identical: %s", cipherBytes)
+	if bytes.Equal(ciphertext, []byte(v.message)) {
+		t.Fatalf("ciphertext and plaintext bytes are identical: %s", ciphertext)
 	}
 	plaintext := string(plainBytes)
 	if plaintext != v.message {

--- a/kms/asymmetric_test.go
+++ b/kms/asymmetric_test.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	"crypto/rsa"
-	"encoding/base64"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
@@ -61,16 +60,15 @@ func TestRSAEncryptDecrypt(t *testing.T) {
 	v := getTestVariables(tc.ProjectID)
 
 	cipherBytes, err := encryptRSA(v.rsaDecryptPath, []byte(v.message))
-	ciphertext := base64.StdEncoding.EncodeToString(cipherBytes)
 	if err != nil {
 		t.Fatalf("encryptRSA(%s, %s): %v", v.rsaDecryptPath, []byte(v.message), err)
 	}
 	if len(cipherBytes) != 256 {
-		t.Fatalf("ciphertext length = %d; want: %d", len(ciphertext), 256)
+		t.Fatalf("len(cipherBytes) = %d; want: %d", len(cipherBytes), 256)
 	}
 	plainBytes, err := decryptRSA(v.rsaDecryptPath, cipherBytes)
 	if err != nil {
-		t.Fatalf("decryptRSA(%s, %s): %v", ciphertext, v.rsaDecryptPath, err)
+		t.Fatalf("decryptRSA(%s, %s): %v", cipherBytes, v.rsaDecryptPath, err)
 	}
 	if !bytes.Equal(plainBytes, []byte(v.message)) {
 		t.Fatalf("decrypted plaintext does not match input message: want %s, got %s", []byte(v.message), plainBytes)

--- a/kms/decrypt_rsa.go
+++ b/kms/decrypt_rsa.go
@@ -23,15 +23,14 @@ import (
 	kmspb "google.golang.org/genproto/googleapis/cloud/kms/v1"
 )
 
-// decryptRSA will attempt to decrypt a given ciphertext with an 'RSA_DECRYPT_OAEP_2048_SHA256'
-// private key stored on Cloud KMS.
-func decryptRSA(name string, ciphertext []byte) ([]byte, error) {
+// decryptRSA will attempt to decrypt a given cipherbytes with an
+// 'RSA_DECRYPT_OAEP_2048_SHA256' private key stored on Cloud KMS.
+func decryptRSA(name string, cipherbytes []byte) ([]byte, error) {
 	// name := "projects/PROJECT_ID/locations/global/keyRings/RING_ID/cryptoKeys/KEY_ID/cryptoKeyVersions/1"
-	// cipherBytes, err := encryptRSA(rsaDecryptPath, []byte("Sample message"))
+	// cipherbytes, err := encryptRSA(rsaDecryptPath, []byte("Sample message"))
 	// if err != nil {
 	//   return nil, fmt.Errorf("encryptRSA: %v", err)
 	// }
-	// ciphertext := base64.StdEncoding.EncodeToString(cipherBytes)
 	ctx := context.Background()
 	client, err := cloudkms.NewKeyManagementClient(ctx)
 	if err != nil {
@@ -41,7 +40,7 @@ func decryptRSA(name string, ciphertext []byte) ([]byte, error) {
 	// Build the request.
 	req := &kmspb.AsymmetricDecryptRequest{
 		Name:       name,
-		Ciphertext: ciphertext,
+		Ciphertext: cipherbytes,
 	}
 	// Call the API.
 	response, err := client.AsymmetricDecrypt(ctx, req)

--- a/kms/decrypt_rsa.go
+++ b/kms/decrypt_rsa.go
@@ -23,11 +23,11 @@ import (
 	kmspb "google.golang.org/genproto/googleapis/cloud/kms/v1"
 )
 
-// decryptRSA will attempt to decrypt a given cipherbytes with an
+// decryptRSA will attempt to decrypt a given ciphertext with an
 // 'RSA_DECRYPT_OAEP_2048_SHA256' private key stored on Cloud KMS.
-func decryptRSA(name string, cipherbytes []byte) ([]byte, error) {
+func decryptRSA(name string, ciphertext []byte) ([]byte, error) {
 	// name := "projects/PROJECT_ID/locations/global/keyRings/RING_ID/cryptoKeys/KEY_ID/cryptoKeyVersions/1"
-	// cipherbytes, err := encryptRSA(rsaDecryptPath, []byte("Sample message"))
+	// ciphertext, err := encryptRSA(rsaDecryptPath, []byte("Sample message"))
 	// if err != nil {
 	//   return nil, fmt.Errorf("encryptRSA: %v", err)
 	// }
@@ -40,7 +40,7 @@ func decryptRSA(name string, cipherbytes []byte) ([]byte, error) {
 	// Build the request.
 	req := &kmspb.AsymmetricDecryptRequest{
 		Name:       name,
-		Ciphertext: cipherbytes,
+		Ciphertext: ciphertext,
 	}
 	// Call the API.
 	response, err := client.AsymmetricDecrypt(ctx, req)

--- a/kms/snippets_test.go
+++ b/kms/snippets_test.go
@@ -19,6 +19,7 @@ package kms
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strconv"
@@ -103,7 +104,11 @@ func createKeyHelper(v TestVariables, keyID, keyPath, parent string,
 }
 
 func TestMain(m *testing.M) {
-	tc, _ := testutil.ContextMain(m)
+	tc, ok := testutil.ContextMain(m)
+	if !ok {
+		fmt.Println("Could not set up tests. Set GOLANG_SAMPLES_PROJECT_ID? Skipping.")
+		os.Exit(0)
+	}
 	v := getTestVariables(tc.ProjectID)
 	parent := "projects/" + v.projectID + "/locations/global"
 	// Create cryptokeys in the test project if needed.


### PR DESCRIPTION
Also updates `TestMain` to check if the test context was successfully retrieved.

Fixes #1037.