### PR TITLE
translate/v3: add samples for translate v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,13 +22,16 @@ require (
 	github.com/fluent/fluent-logger-golang v1.4.0
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/gofrs/uuid v3.2.0+incompatible
+	github.com/golang/groupcache v0.0.0-20191002201903-404acd9df4cc // indirect
 	github.com/golang/protobuf v1.3.2
 	github.com/gomodule/redigo v2.0.0+incompatible
+	github.com/google/pprof v0.0.0-20191022163618-5260658b92d7 // indirect
 	github.com/google/uuid v1.1.1
 	github.com/googleapis/gax-go/v2 v2.0.5
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/websocket v1.4.1
 	github.com/h2non/filetype v1.0.10
+	github.com/jstemmer/go-junit-report v0.9.1 // indirect
 	github.com/lib/pq v1.2.0
 	github.com/linkedin/goavro/v2 v2.9.7
 	github.com/mailgun/mailgun-go/v3 v3.6.1
@@ -40,7 +43,11 @@ require (
 	golang.org/x/exp v0.0.0-20191024150812-c286b889502e
 	golang.org/x/net v0.0.0-20191021144547-ec77196f6094
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
+	golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7 // indirect
 	golang.org/x/text v0.3.2
+	golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0 // indirect
+	golang.org/x/tools v0.0.0-20191022210528-83d82311fd1f // indirect
 	google.golang.org/api v0.11.0
 	google.golang.org/appengine v1.6.5
 	google.golang.org/genproto v0.0.0-20191009194640-548a555dbc03

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekf
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 h1:ZgQEtGgCBiWRM39fZuwSd1LwSqqSW0hOdXCYYDX0R3I=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20191002201903-404acd9df4cc h1:55rEp52jU6bkyslZ1+C/7NGfpQsEc6pxGLAGDOctqbw=
+github.com/golang/groupcache v0.0.0-20191002201903-404acd9df4cc/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.3.1 h1:qGJ6qTW+x6xX/my+8YUVl4WNpX9B7+/l2tRsHGZ7f2s=
@@ -103,6 +105,8 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f h1:Jnx61latede7zDD3DiiP4gmNz33uK0U5HDUaF0a/HVQ=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
+github.com/google/pprof v0.0.0-20191022163618-5260658b92d7 h1:hJW3WlOf9bP3XY5Qboc90mr+iCaSKdrOX4Oa60eB5FQ=
+github.com/google/pprof v0.0.0-20191022163618-5260658b92d7/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -122,6 +126,8 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5i
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024 h1:rBMNdlhTLzJjJSDIjNEXX1Pz3Hmwmz91v+zycvx9PJc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
+github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
+github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -206,6 +212,8 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -216,12 +224,17 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa h1:KIDDMLT1O0Nr7TSxp8xM5tJcdn8tgyAONntO829og1M=
 golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7 h1:HmbHVPwrPEKPGLAcHSrMe6+hqSUlvZU0rab6x5EXfGU=
+golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0 h1:xQwXv67TxFo9nC1GJFyab5eq/5B590r6RlnL/G8Sz7w=
+golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -243,6 +256,8 @@ golang.org/x/tools v0.0.0-20190927191325-030b2cf1153e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191010171213-8abd42400456/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a h1:TwMENskLwU2NnWBzrJGEWHqSiGUkO/B4rfyhwqDxDYQ=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191022210528-83d82311fd1f h1:X4UYO3m0+b0v4ctMUiMVB/vdVP5v25QRYMtH88N+Ne8=
+golang.org/x/tools v0.0.0-20191022210528-83d82311fd1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=

--- a/translate/v3/README.md
+++ b/translate/v3/README.md
@@ -1,0 +1,3 @@
+# Google Cloud Translation API v3 Go example
+
+Samples for [Cloud Translation API v3](https://cloud.google.com/translate/docs/intro-to-v3).

--- a/translate/v3/batch_translate_text.go
+++ b/translate/v3/batch_translate_text.go
@@ -35,7 +35,7 @@ func batchTranslateText(
 	sourceLang string,
 	targetLang string,
 ) error {
-	// projectID := "your-google-cloud-project-id"
+	// projectID := "my-project-id"
 	// location := "us-central1"
 	// inputURI := "gs://cloud-samples-data/text.txt"
 	// outputURI := "gs://YOUR_BUCKET_ID/path_to_store_results/"

--- a/translate/v3/batch_translate_text.go
+++ b/translate/v3/batch_translate_text.go
@@ -26,15 +26,7 @@ import (
 )
 
 // batchTranslateText translates a large volume of text in asynchronous batch mode.
-func batchTranslateText(
-	w io.Writer,
-	projectID string,
-	location string,
-	inputURI string,
-	outputURI string,
-	sourceLang string,
-	targetLang string,
-) error {
+func batchTranslateText(w io.Writer, projectID string, location string, inputURI string, outputURI string, sourceLang string, targetLang string) error {
 	// projectID := "my-project-id"
 	// location := "us-central1"
 	// inputURI := "gs://cloud-samples-data/text.txt"
@@ -47,7 +39,7 @@ func batchTranslateText(
 	if err != nil {
 		return fmt.Errorf("NewTranslationClient: %v", err)
 	}
-	defer c.Close()
+	defer client.Close()
 
 	req := &translatepb.BatchTranslateTextRequest{
 		Parent:              fmt.Sprintf("projects/%s/locations/%s", projectID, location),
@@ -72,7 +64,7 @@ func batchTranslateText(
 	}
 
 	// The BatchTranslateText operation is async.
-	op, err := c.BatchTranslateText(ctx, req)
+	op, err := client.BatchTranslateText(ctx, req)
 	if err != nil {
 		return fmt.Errorf("BatchTranslateText: %v", err)
 	}

--- a/translate/v3/batch_translate_text.go
+++ b/translate/v3/batch_translate_text.go
@@ -43,7 +43,7 @@ func batchTranslateText(
 	// targetLang := "ja"
 
 	ctx := context.Background()
-	c, err := translate.NewTranslationClient(ctx)
+	client, err := translate.NewTranslationClient(ctx)
 	if err != nil {
 		return fmt.Errorf("NewTranslationClient: %v", err)
 	}

--- a/translate/v3/batch_translate_text.go
+++ b/translate/v3/batch_translate_text.go
@@ -1,0 +1,92 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package v3 contains samples for Google Cloud Translation API v3.
+package v3
+
+// [START translate_v3_batch_translate_text]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	translate "cloud.google.com/go/translate/apiv3"
+	translatepb "google.golang.org/genproto/googleapis/cloud/translate/v3"
+)
+
+// batchTranslateText translates a large volume of text in asynchronous batch mode.
+func batchTranslateText(
+	w io.Writer,
+	projectID string,
+	location string,
+	inputURI string,
+	outputURI string,
+	sourceLang string,
+	targetLang string,
+) error {
+	// projectID := "your-google-cloud-project-id"
+	// location := "us-central1"
+	// inputURI := "gs://cloud-samples-data/text.txt"
+	// outputURI := "gs://YOUR_BUCKET_ID/path_to_store_results/"
+	// sourceLang := "en"
+	// targetLang := "ja"
+
+	ctx := context.Background()
+	c, err := translate.NewTranslationClient(ctx)
+	if err != nil {
+		return fmt.Errorf("NewTranslationClient: %v", err)
+	}
+	defer c.Close()
+
+	req := &translatepb.BatchTranslateTextRequest{
+		Parent:              fmt.Sprintf("projects/%s/locations/%s", projectID, location),
+		SourceLanguageCode:  sourceLang,
+		TargetLanguageCodes: []string{targetLang},
+		InputConfigs: []*translatepb.InputConfig{
+			{
+				Source: &translatepb.InputConfig_GcsSource{
+					GcsSource: &translatepb.GcsSource{InputUri: inputURI},
+				},
+				// Optional. Can be "text/plain" or "text/html".
+				MimeType: "text/plain",
+			},
+		},
+		OutputConfig: &translatepb.OutputConfig{
+			Destination: &translatepb.OutputConfig_GcsDestination{
+				GcsDestination: &translatepb.GcsDestination{
+					OutputUriPrefix: outputURI,
+				},
+			},
+		},
+	}
+
+	// The BatchTranslateText operation is async.
+	op, err := c.BatchTranslateText(ctx, req)
+	if err != nil {
+		return fmt.Errorf("BatchTranslateText: %v", err)
+	}
+	fmt.Fprintf(w, "Processing operation name: %q\n", op.Name())
+
+	resp, err := op.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("Wait: %v", err)
+	}
+
+	fmt.Fprintf(w, "Total characters: %v\n", resp.GetTotalCharacters())
+	fmt.Fprintf(w, "Translated characters: %v\n", resp.GetTranslatedCharacters())
+
+	return nil
+}
+
+// [END translate_v3_batch_translate_text]

--- a/translate/v3/batch_translate_text_test.go
+++ b/translate/v3/batch_translate_text_test.go
@@ -29,8 +29,6 @@ import (
 func TestBatchTranslateText(t *testing.T) {
 	tc := testutil.SystemTest(t)
 
-	var buf bytes.Buffer
-
 	bucketName := fmt.Sprintf("%s-batch_translate_text-%v", tc.ProjectID, uuid.New().ID())
 	location := "us-central1"
 	inputURI := "gs://cloud-samples-data/translation/text.txt"
@@ -50,13 +48,14 @@ func TestBatchTranslateText(t *testing.T) {
 	if err := bucket.Create(ctx, tc.ProjectID, nil); err != nil {
 		t.Fatalf("bucket.Create: %v", err)
 	}
-	defer bucket.Delete(ctx)
+	defer deleteBucket(ctx, t, bucket)
 
 	// Translate a sample text and check the number of translated characters.
+	var buf bytes.Buffer
 	if err := batchTranslateText(&buf, tc.ProjectID, location, inputURI, outputURI, sourceLang, targetLang); err != nil {
 		t.Fatalf("batchTranslateText: %v", err)
 	}
-	if got := buf.String(); !strings.Contains(got, "Total characters: 13") {
-		t.Fatalf("Got '%s', expected to contain 'Total characters: 13'", got)
+	if got, want := buf.String(), "Total characters"; !strings.Contains(got, want) {
+		t.Fatalf("batchTranslateText got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 }

--- a/translate/v3/batch_translate_text_test.go
+++ b/translate/v3/batch_translate_text_test.go
@@ -40,28 +40,20 @@ func TestBatchTranslateText(t *testing.T) {
 
 	// Create a temporary bucket to store annotation output.
 	ctx := context.Background()
-	c, err := storage.NewClient(ctx)
+	client, err := storage.NewClient(ctx)
 	if err != nil {
 		t.Fatalf("storage.NewClient: %v", err)
 	}
-	defer c.Close()
+	defer client.Close()
 
-	bucket := c.Bucket(bucketName)
+	bucket := client.Bucket(bucketName)
 	if err := bucket.Create(ctx, tc.ProjectID, nil); err != nil {
 		t.Fatalf("bucket.Create: %v", err)
 	}
 	defer bucket.Delete(ctx)
 
 	// Translate a sample text and check the number of translated characters.
-	if err := batchTranslateText(
-		&buf,
-		tc.ProjectID,
-		location,
-		inputURI,
-		outputURI,
-		sourceLang,
-		targetLang,
-	); err != nil {
+	if err := batchTranslateText(&buf, tc.ProjectID, location, inputURI, outputURI, sourceLang, targetLang); err != nil {
 		t.Fatalf("batchTranslateText: %v", err)
 	}
 	if got := buf.String(); !strings.Contains(got, "Total characters: 13") {

--- a/translate/v3/batch_translate_text_test.go
+++ b/translate/v3/batch_translate_text_test.go
@@ -1,0 +1,70 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+	"github.com/google/uuid"
+)
+
+func TestBatchTranslateText(t *testing.T) {
+	tc := testutil.SystemTest(t)
+
+	var buf bytes.Buffer
+
+	bucketName := fmt.Sprintf("%s-batch_translate_text-%v", tc.ProjectID, uuid.New().ID())
+	location := "us-central1"
+	inputURI := "gs://cloud-samples-data/translation/text.txt"
+	outputURI := fmt.Sprintf("gs://%s/translation/output/", bucketName)
+	sourceLang := "en"
+	targetLang := "es"
+
+	// Create a temporary bucket to store annotation output.
+	ctx := context.Background()
+	c, err := storage.NewClient(ctx)
+	if err != nil {
+		t.Fatalf("storage.NewClient: %v", err)
+	}
+	defer c.Close()
+
+	bucket := c.Bucket(bucketName)
+	if err := bucket.Create(ctx, tc.ProjectID, nil); err != nil {
+		t.Fatalf("bucket.Create: %v", err)
+	}
+	defer bucket.Delete(ctx)
+
+	// Translate a sample text and check the number of translated characters.
+	if err := batchTranslateText(
+		&buf,
+		tc.ProjectID,
+		location,
+		inputURI,
+		outputURI,
+		sourceLang,
+		targetLang,
+	); err != nil {
+		t.Fatalf("batchTranslateText: %v", err)
+	}
+	if got := buf.String(); !strings.Contains(got, "Total characters: 13") {
+		t.Fatalf("Got '%s', expected to contain 'Total characters: 13'", got)
+	}
+}

--- a/translate/v3/batch_translate_text_test.go
+++ b/translate/v3/batch_translate_text_test.go
@@ -56,6 +56,6 @@ func TestBatchTranslateText(t *testing.T) {
 		t.Fatalf("batchTranslateText: %v", err)
 	}
 	if got, want := buf.String(), "Total characters"; !strings.Contains(got, want) {
-		t.Fatalf("batchTranslateText got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
+		t.Errorf("batchTranslateText got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 }

--- a/translate/v3/batch_translate_text_with_glossary.go
+++ b/translate/v3/batch_translate_text_with_glossary.go
@@ -1,0 +1,99 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package v3 contains samples for Google Cloud Translation API v3.
+package v3
+
+// [START translate_v3_batch_translate_text_with_glossary]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	translate "cloud.google.com/go/translate/apiv3"
+	translatepb "google.golang.org/genproto/googleapis/cloud/translate/v3"
+)
+
+// batchTranslateTextWithGlossary translates a large volume of text in asynchronous batch mode.
+func batchTranslateTextWithGlossary(
+	w io.Writer,
+	projectID string,
+	location string,
+	inputURI string,
+	outputURI string,
+	sourceLang string,
+	targetLang string,
+	glossaryID string,
+) error {
+	// projectID := "your-google-cloud-project-id"
+	// location := "us-central1"
+	// inputURI := "gs://cloud-samples-data/text.txt"
+	// outputURI := "gs://YOUR_BUCKET_ID/path_to_store_results/"
+	// sourceLang := "en"
+	// targetLang := "ja"
+	// glossaryID := "your-glossary-id"
+
+	ctx := context.Background()
+	c, err := translate.NewTranslationClient(ctx)
+	if err != nil {
+		return fmt.Errorf("NewTranslationClient: %v", err)
+	}
+	defer c.Close()
+
+	req := &translatepb.BatchTranslateTextRequest{
+		Parent:              fmt.Sprintf("projects/%s/locations/%s", projectID, location),
+		SourceLanguageCode:  sourceLang,
+		TargetLanguageCodes: []string{targetLang},
+		InputConfigs: []*translatepb.InputConfig{
+			{
+				Source: &translatepb.InputConfig_GcsSource{
+					GcsSource: &translatepb.GcsSource{InputUri: inputURI},
+				},
+				// Optional. Can be "text/plain" or "text/html".
+				MimeType: "text/plain",
+			},
+		},
+		Glossaries: map[string]*translatepb.TranslateTextGlossaryConfig{
+			targetLang: {
+				Glossary: fmt.Sprintf("projects/%s/locations/%s/glossaries/%s", projectID, location, glossaryID),
+			},
+		},
+		OutputConfig: &translatepb.OutputConfig{
+			Destination: &translatepb.OutputConfig_GcsDestination{
+				GcsDestination: &translatepb.GcsDestination{
+					OutputUriPrefix: outputURI,
+				},
+			},
+		},
+	}
+
+	// The BatchTranslateText operation is async.
+	op, err := c.BatchTranslateText(ctx, req)
+	if err != nil {
+		return fmt.Errorf("BatchTranslateText: %v", err)
+	}
+	fmt.Fprintf(w, "Processing operation name: %q\n", op.Name())
+
+	resp, err := op.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("Wait: %v", err)
+	}
+
+	fmt.Fprintf(w, "Total characters: %v\n", resp.GetTotalCharacters())
+	fmt.Fprintf(w, "Translated characters: %v\n", resp.GetTranslatedCharacters())
+
+	return nil
+}
+
+// [END translate_v3_batch_translate_text_with_glossary]

--- a/translate/v3/batch_translate_text_with_glossary.go
+++ b/translate/v3/batch_translate_text_with_glossary.go
@@ -26,17 +26,8 @@ import (
 )
 
 // batchTranslateTextWithGlossary translates a large volume of text in asynchronous batch mode.
-func batchTranslateTextWithGlossary(
-	w io.Writer,
-	projectID string,
-	location string,
-	inputURI string,
-	outputURI string,
-	sourceLang string,
-	targetLang string,
-	glossaryID string,
-) error {
-	// projectID := "your-google-cloud-project-id"
+func batchTranslateTextWithGlossary(w io.Writer, projectID string, location string, inputURI string, outputURI string, sourceLang string, targetLang string, glossaryID string) error {
+	// projectID := "my-project-id"
 	// location := "us-central1"
 	// inputURI := "gs://cloud-samples-data/text.txt"
 	// outputURI := "gs://YOUR_BUCKET_ID/path_to_store_results/"
@@ -45,11 +36,11 @@ func batchTranslateTextWithGlossary(
 	// glossaryID := "your-glossary-id"
 
 	ctx := context.Background()
-	c, err := translate.NewTranslationClient(ctx)
+	client, err := translate.NewTranslationClient(ctx)
 	if err != nil {
 		return fmt.Errorf("NewTranslationClient: %v", err)
 	}
-	defer c.Close()
+	defer client.Close()
 
 	req := &translatepb.BatchTranslateTextRequest{
 		Parent:              fmt.Sprintf("projects/%s/locations/%s", projectID, location),
@@ -79,7 +70,7 @@ func batchTranslateTextWithGlossary(
 	}
 
 	// The BatchTranslateText operation is async.
-	op, err := c.BatchTranslateText(ctx, req)
+	op, err := client.BatchTranslateText(ctx, req)
 	if err != nil {
 		return fmt.Errorf("BatchTranslateText: %v", err)
 	}

--- a/translate/v3/batch_translate_text_with_glossary_and_model.go
+++ b/translate/v3/batch_translate_text_with_glossary_and_model.go
@@ -1,0 +1,104 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package v3 contains samples for Google Cloud Translation API v3.
+package v3
+
+// [START translate_v3_batch_translate_text_with_glossary_and_model]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	translate "cloud.google.com/go/translate/apiv3"
+	translatepb "google.golang.org/genproto/googleapis/cloud/translate/v3"
+)
+
+// batchTranslateTextWithGlossaryAndModel translates a large volume of text in asynchronous batch mode.
+func batchTranslateTextWithGlossaryAndModel(
+	w io.Writer,
+	projectID string,
+	location string,
+	inputURI string,
+	outputURI string,
+	sourceLang string,
+	targetLang string,
+	glossaryID string,
+	modelID string,
+) error {
+	// projectID := "your-google-cloud-project-id"
+	// location := "us-central1"
+	// inputURI := "gs://cloud-samples-data/text.txt"
+	// outputURI := "gs://YOUR_BUCKET_ID/path_to_store_results/"
+	// sourceLang := "en"
+	// targetLang := "ja"
+	// glossaryID := "your-glossary-id"
+	// modelID := "your-model-id"
+
+	ctx := context.Background()
+	c, err := translate.NewTranslationClient(ctx)
+	if err != nil {
+		return fmt.Errorf("NewTranslationClient: %v", err)
+	}
+	defer c.Close()
+
+	req := &translatepb.BatchTranslateTextRequest{
+		Parent:              fmt.Sprintf("projects/%s/locations/%s", projectID, location),
+		SourceLanguageCode:  sourceLang,
+		TargetLanguageCodes: []string{targetLang},
+		InputConfigs: []*translatepb.InputConfig{
+			{
+				Source: &translatepb.InputConfig_GcsSource{
+					GcsSource: &translatepb.GcsSource{InputUri: inputURI},
+				},
+				// Optional. Can be "text/plain" or "text/html".
+				MimeType: "text/plain",
+			},
+		},
+		Glossaries: map[string]*translatepb.TranslateTextGlossaryConfig{
+			targetLang: {
+				Glossary: fmt.Sprintf("projects/%s/locations/%s/glossaries/%s", projectID, location, glossaryID),
+			},
+		},
+		OutputConfig: &translatepb.OutputConfig{
+			Destination: &translatepb.OutputConfig_GcsDestination{
+				GcsDestination: &translatepb.GcsDestination{
+					OutputUriPrefix: outputURI,
+				},
+			},
+		},
+		Models: map[string]string{
+			targetLang: fmt.Sprintf("projects/%s/locations/%s/models/%s", projectID, location, modelID),
+		},
+	}
+
+	// The BatchTranslateText operation is async.
+	op, err := c.BatchTranslateText(ctx, req)
+	if err != nil {
+		return fmt.Errorf("BatchTranslateText: %v", err)
+	}
+	fmt.Fprintf(w, "Processing operation name: %q\n", op.Name())
+
+	resp, err := op.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("Wait: %v", err)
+	}
+
+	fmt.Fprintf(w, "Total characters: %v\n", resp.GetTotalCharacters())
+	fmt.Fprintf(w, "Translated characters: %v\n", resp.GetTranslatedCharacters())
+
+	return nil
+}
+
+// [END translate_v3_batch_translate_text_with_glossary_and_model]

--- a/translate/v3/batch_translate_text_with_glossary_and_model.go
+++ b/translate/v3/batch_translate_text_with_glossary_and_model.go
@@ -26,18 +26,8 @@ import (
 )
 
 // batchTranslateTextWithGlossaryAndModel translates a large volume of text in asynchronous batch mode.
-func batchTranslateTextWithGlossaryAndModel(
-	w io.Writer,
-	projectID string,
-	location string,
-	inputURI string,
-	outputURI string,
-	sourceLang string,
-	targetLang string,
-	glossaryID string,
-	modelID string,
-) error {
-	// projectID := "your-google-cloud-project-id"
+func batchTranslateTextWithGlossaryAndModel(w io.Writer, projectID string, location string, inputURI string, outputURI string, sourceLang string, targetLang string, glossaryID string, modelID string) error {
+	// projectID := "my-project-id"
 	// location := "us-central1"
 	// inputURI := "gs://cloud-samples-data/text.txt"
 	// outputURI := "gs://YOUR_BUCKET_ID/path_to_store_results/"
@@ -47,11 +37,11 @@ func batchTranslateTextWithGlossaryAndModel(
 	// modelID := "your-model-id"
 
 	ctx := context.Background()
-	c, err := translate.NewTranslationClient(ctx)
+	client, err := translate.NewTranslationClient(ctx)
 	if err != nil {
 		return fmt.Errorf("NewTranslationClient: %v", err)
 	}
-	defer c.Close()
+	defer client.Close()
 
 	req := &translatepb.BatchTranslateTextRequest{
 		Parent:              fmt.Sprintf("projects/%s/locations/%s", projectID, location),
@@ -84,7 +74,7 @@ func batchTranslateTextWithGlossaryAndModel(
 	}
 
 	// The BatchTranslateText operation is async.
-	op, err := c.BatchTranslateText(ctx, req)
+	op, err := client.BatchTranslateText(ctx, req)
 	if err != nil {
 		return fmt.Errorf("BatchTranslateText: %v", err)
 	}

--- a/translate/v3/batch_translate_text_with_glossary_and_model_test.go
+++ b/translate/v3/batch_translate_text_with_glossary_and_model_test.go
@@ -14,58 +14,60 @@
 
 package v3
 
-import (
-	"bytes"
-	"context"
-	"fmt"
-	"strings"
-	"testing"
+// TODO: uncomment this test once the AutoML model is set in the testing projects.
 
-	"cloud.google.com/go/storage"
-	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-	"github.com/google/uuid"
-)
+// import (
+// 	"bytes"
+// 	"context"
+// 	"fmt"
+// 	"strings"
+// 	"testing"
 
-func TestBatchTranslateTextWithGlossaryAndModel(t *testing.T) {
-	tc := testutil.SystemTest(t)
+// 	"cloud.google.com/go/storage"
+// 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+// 	"github.com/google/uuid"
+// )
 
-	bucketName := fmt.Sprintf("%s-translate_glossary_model-%v", tc.ProjectID, uuid.New().ID())
-	location := "us-central1"
-	inputURI := "gs://cloud-samples-data/translation/text_with_glossary.txt"
-	outputURI := fmt.Sprintf("gs://%s/translation/output/", bucketName)
-	sourceLang := "en"
-	targetLang := "ja"
-	glossaryID := fmt.Sprintf("create_and_delete_glossary-%v", uuid.New().ID())
-	glossaryInputURI := "gs://cloud-samples-data/translation/glossary_ja.csv"
-	modelID := "TRL3128559826197068699"
+// func TestBatchTranslateTextWithGlossaryAndModel(t *testing.T) {
+// 	tc := testutil.SystemTest(t)
 
-	// Create a glossary.
-	var buf bytes.Buffer
-	if err := createGlossary(&buf, tc.ProjectID, location, glossaryID, glossaryInputURI); err != nil {
-		t.Fatalf("createGlossary: %v", err)
-	}
-	defer deleteGlossary(&buf, tc.ProjectID, location, glossaryID)
+// 	bucketName := fmt.Sprintf("%s-translate_glossary_model-%v", tc.ProjectID, uuid.New().ID())
+// 	location := "us-central1"
+// 	inputURI := "gs://cloud-samples-data/translation/text_with_glossary.txt"
+// 	outputURI := fmt.Sprintf("gs://%s/translation/output/", bucketName)
+// 	sourceLang := "en"
+// 	targetLang := "ja"
+// 	glossaryID := fmt.Sprintf("create_and_delete_glossary-%v", uuid.New().ID())
+// 	glossaryInputURI := "gs://cloud-samples-data/translation/glossary_ja.csv"
+// 	modelID := "TRL3128559826197068699"
 
-	// Create a temporary bucket to store annotation output.
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		t.Fatalf("storage.NewClient: %v", err)
-	}
-	defer client.Close()
+// 	// Create a glossary.
+// 	var buf bytes.Buffer
+// 	if err := createGlossary(&buf, tc.ProjectID, location, glossaryID, glossaryInputURI); err != nil {
+// 		t.Fatalf("createGlossary: %v", err)
+// 	}
+// 	defer deleteGlossary(&buf, tc.ProjectID, location, glossaryID)
 
-	bucket := client.Bucket(bucketName)
-	if err := bucket.Create(ctx, tc.ProjectID, nil); err != nil {
-		t.Fatalf("bucket.Create: %v", err)
-	}
-	defer deleteBucket(ctx, t, bucket)
+// 	// Create a temporary bucket to store annotation output.
+// 	ctx := context.Background()
+// 	client, err := storage.NewClient(ctx)
+// 	if err != nil {
+// 		t.Fatalf("storage.NewClient: %v", err)
+// 	}
+// 	defer client.Close()
 
-	// Translate a sample text and check the number of translated characters.
-	buf.Reset()
-	if err := batchTranslateTextWithGlossaryAndModel(&buf, tc.ProjectID, location, inputURI, outputURI, sourceLang, targetLang, glossaryID, modelID); err != nil {
-		t.Fatalf("batchTranslateTextWithGlossaryAndModel: %v", err)
-	}
-	if got, want := buf.String(), "Total characters"; !strings.Contains(got, want) {
-		t.Fatalf("batchTranslateTextWithGlossaryAndModel got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
-	}
-}
+// 	bucket := client.Bucket(bucketName)
+// 	if err := bucket.Create(ctx, tc.ProjectID, nil); err != nil {
+// 		t.Fatalf("bucket.Create: %v", err)
+// 	}
+// 	defer deleteBucket(ctx, t, bucket)
+
+// 	// Translate a sample text and check the number of translated characters.
+// 	buf.Reset()
+// 	if err := batchTranslateTextWithGlossaryAndModel(&buf, tc.ProjectID, location, inputURI, outputURI, sourceLang, targetLang, glossaryID, modelID); err != nil {
+// 		t.Fatalf("batchTranslateTextWithGlossaryAndModel: %v", err)
+// 	}
+// 	if got, want := buf.String(), "Total characters"; !strings.Contains(got, want) {
+// 		t.Fatalf("batchTranslateTextWithGlossaryAndModel got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
+// 	}
+// }

--- a/translate/v3/batch_translate_text_with_glossary_and_model_test.go
+++ b/translate/v3/batch_translate_text_with_glossary_and_model_test.go
@@ -1,0 +1,82 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+	"github.com/google/uuid"
+)
+
+func TestBatchTranslateTextWithGlossaryAndModel(t *testing.T) {
+	tc := testutil.SystemTest(t)
+
+	var buf bytes.Buffer
+
+	bucketName := fmt.Sprintf("%s-translate_glossary_model-%v", tc.ProjectID, uuid.New().ID())
+	location := "us-central1"
+	inputURI := "gs://cloud-samples-data/translation/text_with_glossary.txt"
+	outputURI := fmt.Sprintf("gs://%s/translation/output/", bucketName)
+	sourceLang := "en"
+	targetLang := "ja"
+	glossaryID := fmt.Sprintf("create_and_delete_glossary-%v", uuid.New().ID())
+	glossaryInputURI := "gs://cloud-samples-data/translation/glossary_ja.csv"
+	modelID := "TRL3128559826197068699"
+
+	// Create a glossary.
+	if err := createGlossary(&buf, tc.ProjectID, location, glossaryID, glossaryInputURI); err != nil {
+		t.Fatalf("createGlossary: %v", err)
+	}
+	defer deleteGlossary(&buf, tc.ProjectID, location, glossaryID)
+
+	// Create a temporary bucket to store annotation output.
+	ctx := context.Background()
+	c, err := storage.NewClient(ctx)
+	if err != nil {
+		t.Fatalf("storage.NewClient: %v", err)
+	}
+	defer c.Close()
+
+	bucket := c.Bucket(bucketName)
+	if err := bucket.Create(ctx, tc.ProjectID, nil); err != nil {
+		t.Fatalf("bucket.Create: %v", err)
+	}
+	defer bucket.Delete(ctx)
+
+	// Translate a sample text and check the number of translated characters.
+	buf.Reset()
+	if err := batchTranslateTextWithGlossaryAndModel(
+		&buf,
+		tc.ProjectID,
+		location,
+		inputURI,
+		outputURI,
+		sourceLang,
+		targetLang,
+		glossaryID,
+		modelID,
+	); err != nil {
+		t.Fatalf("batchTranslateTextWithGlossary: %v", err)
+	}
+	if got := buf.String(); !strings.Contains(got, "Total characters: 25") {
+		t.Fatalf("Got '%s', expected to contain 'Total characters: 25'", got)
+	}
+}

--- a/translate/v3/batch_translate_text_with_glossary_and_model_test.go
+++ b/translate/v3/batch_translate_text_with_glossary_and_model_test.go
@@ -68,6 +68,6 @@ package v3
 // 		t.Fatalf("batchTranslateTextWithGlossaryAndModel: %v", err)
 // 	}
 // 	if got, want := buf.String(), "Total characters"; !strings.Contains(got, want) {
-// 		t.Fatalf("batchTranslateTextWithGlossaryAndModel got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
+// 		t.Errorf("batchTranslateTextWithGlossaryAndModel got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 // 	}
 // }

--- a/translate/v3/batch_translate_text_with_glossary_and_model_test.go
+++ b/translate/v3/batch_translate_text_with_glossary_and_model_test.go
@@ -29,8 +29,6 @@ import (
 func TestBatchTranslateTextWithGlossaryAndModel(t *testing.T) {
 	tc := testutil.SystemTest(t)
 
-	var buf bytes.Buffer
-
 	bucketName := fmt.Sprintf("%s-translate_glossary_model-%v", tc.ProjectID, uuid.New().ID())
 	location := "us-central1"
 	inputURI := "gs://cloud-samples-data/translation/text_with_glossary.txt"
@@ -42,6 +40,7 @@ func TestBatchTranslateTextWithGlossaryAndModel(t *testing.T) {
 	modelID := "TRL3128559826197068699"
 
 	// Create a glossary.
+	var buf bytes.Buffer
 	if err := createGlossary(&buf, tc.ProjectID, location, glossaryID, glossaryInputURI); err != nil {
 		t.Fatalf("createGlossary: %v", err)
 	}
@@ -59,14 +58,14 @@ func TestBatchTranslateTextWithGlossaryAndModel(t *testing.T) {
 	if err := bucket.Create(ctx, tc.ProjectID, nil); err != nil {
 		t.Fatalf("bucket.Create: %v", err)
 	}
-	defer bucket.Delete(ctx)
+	defer deleteBucket(ctx, t, bucket)
 
 	// Translate a sample text and check the number of translated characters.
 	buf.Reset()
 	if err := batchTranslateTextWithGlossaryAndModel(&buf, tc.ProjectID, location, inputURI, outputURI, sourceLang, targetLang, glossaryID, modelID); err != nil {
-		t.Fatalf("batchTranslateTextWithGlossary: %v", err)
+		t.Fatalf("batchTranslateTextWithGlossaryAndModel: %v", err)
 	}
-	if got := buf.String(); !strings.Contains(got, "Total characters: 25") {
-		t.Fatalf("Got '%s', expected to contain 'Total characters: 25'", got)
+	if got, want := buf.String(), "Total characters"; !strings.Contains(got, want) {
+		t.Fatalf("batchTranslateTextWithGlossaryAndModel got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 }

--- a/translate/v3/batch_translate_text_with_glossary_and_model_test.go
+++ b/translate/v3/batch_translate_text_with_glossary_and_model_test.go
@@ -49,13 +49,13 @@ func TestBatchTranslateTextWithGlossaryAndModel(t *testing.T) {
 
 	// Create a temporary bucket to store annotation output.
 	ctx := context.Background()
-	c, err := storage.NewClient(ctx)
+	client, err := storage.NewClient(ctx)
 	if err != nil {
 		t.Fatalf("storage.NewClient: %v", err)
 	}
-	defer c.Close()
+	defer client.Close()
 
-	bucket := c.Bucket(bucketName)
+	bucket := client.Bucket(bucketName)
 	if err := bucket.Create(ctx, tc.ProjectID, nil); err != nil {
 		t.Fatalf("bucket.Create: %v", err)
 	}
@@ -63,17 +63,7 @@ func TestBatchTranslateTextWithGlossaryAndModel(t *testing.T) {
 
 	// Translate a sample text and check the number of translated characters.
 	buf.Reset()
-	if err := batchTranslateTextWithGlossaryAndModel(
-		&buf,
-		tc.ProjectID,
-		location,
-		inputURI,
-		outputURI,
-		sourceLang,
-		targetLang,
-		glossaryID,
-		modelID,
-	); err != nil {
+	if err := batchTranslateTextWithGlossaryAndModel(&buf, tc.ProjectID, location, inputURI, outputURI, sourceLang, targetLang, glossaryID, modelID); err != nil {
 		t.Fatalf("batchTranslateTextWithGlossary: %v", err)
 	}
 	if got := buf.String(); !strings.Contains(got, "Total characters: 25") {

--- a/translate/v3/batch_translate_text_with_glossary_test.go
+++ b/translate/v3/batch_translate_text_with_glossary_test.go
@@ -48,13 +48,13 @@ func TestBatchTranslateTextWithGlossary(t *testing.T) {
 
 	// Create a temporary bucket to store annotation output.
 	ctx := context.Background()
-	c, err := storage.NewClient(ctx)
+	client, err := storage.NewClient(ctx)
 	if err != nil {
 		t.Fatalf("storage.NewClient: %v", err)
 	}
-	defer c.Close()
+	defer client.Close()
 
-	bucket := c.Bucket(bucketName)
+	bucket := client.Bucket(bucketName)
 	if err := bucket.Create(ctx, tc.ProjectID, nil); err != nil {
 		t.Fatalf("bucket.Create: %v", err)
 	}
@@ -62,16 +62,7 @@ func TestBatchTranslateTextWithGlossary(t *testing.T) {
 
 	// Translate a sample text and check the number of translated characters.
 	buf.Reset()
-	if err := batchTranslateTextWithGlossary(
-		&buf,
-		tc.ProjectID,
-		location,
-		inputURI,
-		outputURI,
-		sourceLang,
-		targetLang,
-		glossaryID,
-	); err != nil {
+	if err := batchTranslateTextWithGlossary(&buf, tc.ProjectID, location, inputURI, outputURI, sourceLang, targetLang, glossaryID); err != nil {
 		t.Fatalf("batchTranslateTextWithGlossary: %v", err)
 	}
 	if got := buf.String(); !strings.Contains(got, "Total characters: 9") {

--- a/translate/v3/batch_translate_text_with_glossary_test.go
+++ b/translate/v3/batch_translate_text_with_glossary_test.go
@@ -29,8 +29,6 @@ import (
 func TestBatchTranslateTextWithGlossary(t *testing.T) {
 	tc := testutil.SystemTest(t)
 
-	var buf bytes.Buffer
-
 	bucketName := fmt.Sprintf("%s-translate_glossary-%v", tc.ProjectID, uuid.New().ID())
 	location := "us-central1"
 	inputURI := "gs://cloud-samples-data/translation/text_with_glossary.txt"
@@ -41,6 +39,7 @@ func TestBatchTranslateTextWithGlossary(t *testing.T) {
 	glossaryInputURI := "gs://cloud-samples-data/translation/glossary_ja.csv"
 
 	// Create a glossary.
+	var buf bytes.Buffer
 	if err := createGlossary(&buf, tc.ProjectID, location, glossaryID, glossaryInputURI); err != nil {
 		t.Fatalf("createGlossary: %v", err)
 	}
@@ -58,14 +57,14 @@ func TestBatchTranslateTextWithGlossary(t *testing.T) {
 	if err := bucket.Create(ctx, tc.ProjectID, nil); err != nil {
 		t.Fatalf("bucket.Create: %v", err)
 	}
-	defer bucket.Delete(ctx)
+	defer deleteBucket(ctx, t, bucket)
 
 	// Translate a sample text and check the number of translated characters.
 	buf.Reset()
 	if err := batchTranslateTextWithGlossary(&buf, tc.ProjectID, location, inputURI, outputURI, sourceLang, targetLang, glossaryID); err != nil {
 		t.Fatalf("batchTranslateTextWithGlossary: %v", err)
 	}
-	if got := buf.String(); !strings.Contains(got, "Total characters: 9") {
-		t.Fatalf("Got '%s', expected to contain 'Total characters: 9'", got)
+	if got, want := buf.String(), "Total characters"; !strings.Contains(got, want) {
+		t.Fatalf("batchTranslateTextWithGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 }

--- a/translate/v3/batch_translate_text_with_glossary_test.go
+++ b/translate/v3/batch_translate_text_with_glossary_test.go
@@ -1,0 +1,80 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+	"github.com/google/uuid"
+)
+
+func TestBatchTranslateTextWithGlossary(t *testing.T) {
+	tc := testutil.SystemTest(t)
+
+	var buf bytes.Buffer
+
+	bucketName := fmt.Sprintf("%s-translate_glossary-%v", tc.ProjectID, uuid.New().ID())
+	location := "us-central1"
+	inputURI := "gs://cloud-samples-data/translation/text_with_glossary.txt"
+	outputURI := fmt.Sprintf("gs://%s/translation/output/", bucketName)
+	sourceLang := "en"
+	targetLang := "ja"
+	glossaryID := fmt.Sprintf("create_and_delete_glossary-%v", uuid.New().ID())
+	glossaryInputURI := "gs://cloud-samples-data/translation/glossary_ja.csv"
+
+	// Create a glossary.
+	if err := createGlossary(&buf, tc.ProjectID, location, glossaryID, glossaryInputURI); err != nil {
+		t.Fatalf("createGlossary: %v", err)
+	}
+	defer deleteGlossary(&buf, tc.ProjectID, location, glossaryID)
+
+	// Create a temporary bucket to store annotation output.
+	ctx := context.Background()
+	c, err := storage.NewClient(ctx)
+	if err != nil {
+		t.Fatalf("storage.NewClient: %v", err)
+	}
+	defer c.Close()
+
+	bucket := c.Bucket(bucketName)
+	if err := bucket.Create(ctx, tc.ProjectID, nil); err != nil {
+		t.Fatalf("bucket.Create: %v", err)
+	}
+	defer bucket.Delete(ctx)
+
+	// Translate a sample text and check the number of translated characters.
+	buf.Reset()
+	if err := batchTranslateTextWithGlossary(
+		&buf,
+		tc.ProjectID,
+		location,
+		inputURI,
+		outputURI,
+		sourceLang,
+		targetLang,
+		glossaryID,
+	); err != nil {
+		t.Fatalf("batchTranslateTextWithGlossary: %v", err)
+	}
+	if got := buf.String(); !strings.Contains(got, "Total characters: 9") {
+		t.Fatalf("Got '%s', expected to contain 'Total characters: 9'", got)
+	}
+}

--- a/translate/v3/batch_translate_text_with_glossary_test.go
+++ b/translate/v3/batch_translate_text_with_glossary_test.go
@@ -65,6 +65,6 @@ func TestBatchTranslateTextWithGlossary(t *testing.T) {
 		t.Fatalf("batchTranslateTextWithGlossary: %v", err)
 	}
 	if got, want := buf.String(), "Total characters"; !strings.Contains(got, want) {
-		t.Fatalf("batchTranslateTextWithGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
+		t.Errorf("batchTranslateTextWithGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 }

--- a/translate/v3/batch_translate_text_with_model.go
+++ b/translate/v3/batch_translate_text_with_model.go
@@ -1,0 +1,97 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package v3 contains samples for Google Cloud Translation API v3.
+package v3
+
+// [START translate_v3_batch_translate_text_with_model]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	translate "cloud.google.com/go/translate/apiv3"
+	translatepb "google.golang.org/genproto/googleapis/cloud/translate/v3"
+)
+
+// batchTranslateTextWithModel translates a large volume of text in asynchronous batch mode.
+func batchTranslateTextWithModel(
+	w io.Writer,
+	projectID string,
+	location string,
+	inputURI string,
+	outputURI string,
+	sourceLang string,
+	targetLang string,
+	modelID string,
+) error {
+	// projectID := "your-google-cloud-project-id"
+	// location := "us-central1"
+	// inputURI := "gs://cloud-samples-data/text.txt"
+	// outputURI := "gs://YOUR_BUCKET_ID/path_to_store_results/"
+	// sourceLang := "en"
+	// targetLang := "de"
+	// modelID := "your-model-id"
+
+	ctx := context.Background()
+	c, err := translate.NewTranslationClient(ctx)
+	if err != nil {
+		return fmt.Errorf("NewTranslationClient: %v", err)
+	}
+	defer c.Close()
+
+	req := &translatepb.BatchTranslateTextRequest{
+		Parent:              fmt.Sprintf("projects/%s/locations/%s", projectID, location),
+		SourceLanguageCode:  sourceLang,
+		TargetLanguageCodes: []string{targetLang},
+		InputConfigs: []*translatepb.InputConfig{
+			{
+				Source: &translatepb.InputConfig_GcsSource{
+					GcsSource: &translatepb.GcsSource{InputUri: inputURI},
+				},
+				// Optional. Can be "text/plain" or "text/html".
+				MimeType: "text/plain",
+			},
+		},
+		OutputConfig: &translatepb.OutputConfig{
+			Destination: &translatepb.OutputConfig_GcsDestination{
+				GcsDestination: &translatepb.GcsDestination{
+					OutputUriPrefix: outputURI,
+				},
+			},
+		},
+		Models: map[string]string{
+			targetLang: fmt.Sprintf("projects/%s/locations/%s/models/%s", projectID, location, modelID),
+		},
+	}
+
+	// The BatchTranslateText operation is async.
+	op, err := c.BatchTranslateText(ctx, req)
+	if err != nil {
+		return fmt.Errorf("BatchTranslateText: %v", err)
+	}
+	fmt.Fprintf(w, "Processing operation name: %q\n", op.Name())
+
+	resp, err := op.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("Wait: %v", err)
+	}
+
+	fmt.Fprintf(w, "Total characters: %v\n", resp.GetTotalCharacters())
+	fmt.Fprintf(w, "Translated characters: %v\n", resp.GetTranslatedCharacters())
+
+	return nil
+}
+
+// [END translate_v3_batch_translate_text_with_model]

--- a/translate/v3/batch_translate_text_with_model.go
+++ b/translate/v3/batch_translate_text_with_model.go
@@ -26,17 +26,8 @@ import (
 )
 
 // batchTranslateTextWithModel translates a large volume of text in asynchronous batch mode.
-func batchTranslateTextWithModel(
-	w io.Writer,
-	projectID string,
-	location string,
-	inputURI string,
-	outputURI string,
-	sourceLang string,
-	targetLang string,
-	modelID string,
-) error {
-	// projectID := "your-google-cloud-project-id"
+func batchTranslateTextWithModel(w io.Writer, projectID string, location string, inputURI string, outputURI string, sourceLang string, targetLang string, modelID string) error {
+	// projectID := "my-project-id"
 	// location := "us-central1"
 	// inputURI := "gs://cloud-samples-data/text.txt"
 	// outputURI := "gs://YOUR_BUCKET_ID/path_to_store_results/"

--- a/translate/v3/batch_translate_text_with_model.go
+++ b/translate/v3/batch_translate_text_with_model.go
@@ -36,11 +36,11 @@ func batchTranslateTextWithModel(w io.Writer, projectID string, location string,
 	// modelID := "your-model-id"
 
 	ctx := context.Background()
-	c, err := translate.NewTranslationClient(ctx)
+	client, err := translate.NewTranslationClient(ctx)
 	if err != nil {
 		return fmt.Errorf("NewTranslationClient: %v", err)
 	}
-	defer c.Close()
+	defer client.Close()
 
 	req := &translatepb.BatchTranslateTextRequest{
 		Parent:              fmt.Sprintf("projects/%s/locations/%s", projectID, location),
@@ -68,7 +68,7 @@ func batchTranslateTextWithModel(w io.Writer, projectID string, location string,
 	}
 
 	// The BatchTranslateText operation is async.
-	op, err := c.BatchTranslateText(ctx, req)
+	op, err := client.BatchTranslateText(ctx, req)
 	if err != nil {
 		return fmt.Errorf("BatchTranslateText: %v", err)
 	}

--- a/translate/v3/batch_translate_text_with_model_test.go
+++ b/translate/v3/batch_translate_text_with_model_test.go
@@ -14,49 +14,51 @@
 
 package v3
 
-import (
-	"bytes"
-	"context"
-	"fmt"
-	"strings"
-	"testing"
+// TODO: uncomment this test once the AutoML model is set in the testing projects.
 
-	"cloud.google.com/go/storage"
-	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-	"github.com/google/uuid"
-)
+// import (
+// 	"bytes"
+// 	"context"
+// 	"fmt"
+// 	"strings"
+// 	"testing"
 
-func TestBatchTranslateTextWithModel(t *testing.T) {
-	tc := testutil.SystemTest(t)
+// 	"cloud.google.com/go/storage"
+// 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+// 	"github.com/google/uuid"
+// )
 
-	bucketName := fmt.Sprintf("%s-translate_model-%v", tc.ProjectID, uuid.New().ID())
-	location := "us-central1"
-	inputURI := "gs://cloud-samples-data/translation/custom_model_text.txt"
-	outputURI := fmt.Sprintf("gs://%s/translation/output/", bucketName)
-	sourceLang := "en"
-	targetLang := "ja"
-	modelID := "TRL3128559826197068699"
+// func TestBatchTranslateTextWithModel(t *testing.T) {
+// 	tc := testutil.SystemTest(t)
 
-	// Create a temporary bucket to store annotation output.
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		t.Fatalf("storage.NewClient: %v", err)
-	}
-	defer client.Close()
+// 	bucketName := fmt.Sprintf("%s-translate_model-%v", tc.ProjectID, uuid.New().ID())
+// 	location := "us-central1"
+// 	inputURI := "gs://cloud-samples-data/translation/custom_model_text.txt"
+// 	outputURI := fmt.Sprintf("gs://%s/translation/output/", bucketName)
+// 	sourceLang := "en"
+// 	targetLang := "ja"
+// 	modelID := "TRL3128559826197068699"
 
-	bucket := client.Bucket(bucketName)
-	if err := bucket.Create(ctx, tc.ProjectID, nil); err != nil {
-		t.Fatalf("bucket.Create: %v", err)
-	}
-	defer deleteBucket(ctx, t, bucket)
+// 	// Create a temporary bucket to store annotation output.
+// 	ctx := context.Background()
+// 	client, err := storage.NewClient(ctx)
+// 	if err != nil {
+// 		t.Fatalf("storage.NewClient: %v", err)
+// 	}
+// 	defer client.Close()
 
-	// Translate a sample text and check the number of translated characters.
-	var buf bytes.Buffer
-	if err := batchTranslateTextWithModel(&buf, tc.ProjectID, location, inputURI, outputURI, sourceLang, targetLang, modelID); err != nil {
-		t.Fatalf("batchTranslateTextWithModel: %v", err)
-	}
-	if got, want := buf.String(), "Total characters"; !strings.Contains(got, want) {
-		t.Fatalf("batchTranslateTextWithModel got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
-	}
-}
+// 	bucket := client.Bucket(bucketName)
+// 	if err := bucket.Create(ctx, tc.ProjectID, nil); err != nil {
+// 		t.Fatalf("bucket.Create: %v", err)
+// 	}
+// 	defer deleteBucket(ctx, t, bucket)
+
+// 	// Translate a sample text and check the number of translated characters.
+// 	var buf bytes.Buffer
+// 	if err := batchTranslateTextWithModel(&buf, tc.ProjectID, location, inputURI, outputURI, sourceLang, targetLang, modelID); err != nil {
+// 		t.Fatalf("batchTranslateTextWithModel: %v", err)
+// 	}
+// 	if got, want := buf.String(), "Total characters"; !strings.Contains(got, want) {
+// 		t.Fatalf("batchTranslateTextWithModel got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
+// 	}
+// }

--- a/translate/v3/batch_translate_text_with_model_test.go
+++ b/translate/v3/batch_translate_text_with_model_test.go
@@ -1,0 +1,72 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+	"github.com/google/uuid"
+)
+
+func TestBatchTranslateTextWithModel(t *testing.T) {
+	tc := testutil.SystemTest(t)
+
+	var buf bytes.Buffer
+
+	bucketName := fmt.Sprintf("%s-translate_model-%v", tc.ProjectID, uuid.New().ID())
+	location := "us-central1"
+	inputURI := "gs://cloud-samples-data/translation/custom_model_text.txt"
+	outputURI := fmt.Sprintf("gs://%s/translation/output/", bucketName)
+	sourceLang := "en"
+	targetLang := "ja"
+	modelID := "TRL3128559826197068699"
+
+	// Create a temporary bucket to store annotation output.
+	ctx := context.Background()
+	c, err := storage.NewClient(ctx)
+	if err != nil {
+		t.Fatalf("storage.NewClient: %v", err)
+	}
+	defer c.Close()
+
+	bucket := c.Bucket(bucketName)
+	if err := bucket.Create(ctx, tc.ProjectID, nil); err != nil {
+		t.Fatalf("bucket.Create: %v", err)
+	}
+	defer bucket.Delete(ctx)
+
+	// Translate a sample text and check the number of translated characters.
+	if err := batchTranslateTextWithModel(
+		&buf,
+		tc.ProjectID,
+		location,
+		inputURI,
+		outputURI,
+		sourceLang,
+		targetLang,
+		modelID,
+	); err != nil {
+		t.Fatalf("batchTranslateTextWithModel: %v", err)
+	}
+	if got := buf.String(); !strings.Contains(got, "Total characters: 15") {
+		t.Fatalf("Got '%s', expected to contain 'Total characters: 15'", got)
+	}
+}

--- a/translate/v3/batch_translate_text_with_model_test.go
+++ b/translate/v3/batch_translate_text_with_model_test.go
@@ -54,16 +54,7 @@ func TestBatchTranslateTextWithModel(t *testing.T) {
 	defer bucket.Delete(ctx)
 
 	// Translate a sample text and check the number of translated characters.
-	if err := batchTranslateTextWithModel(
-		&buf,
-		tc.ProjectID,
-		location,
-		inputURI,
-		outputURI,
-		sourceLang,
-		targetLang,
-		modelID,
-	); err != nil {
+	if err := batchTranslateTextWithModel(&buf, tc.ProjectID, location, inputURI, outputURI, sourceLang, targetLang, modelID); err != nil {
 		t.Fatalf("batchTranslateTextWithModel: %v", err)
 	}
 	if got := buf.String(); !strings.Contains(got, "Total characters: 15") {

--- a/translate/v3/batch_translate_text_with_model_test.go
+++ b/translate/v3/batch_translate_text_with_model_test.go
@@ -59,6 +59,6 @@ package v3
 // 		t.Fatalf("batchTranslateTextWithModel: %v", err)
 // 	}
 // 	if got, want := buf.String(), "Total characters"; !strings.Contains(got, want) {
-// 		t.Fatalf("batchTranslateTextWithModel got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
+// 		t.Errorf("batchTranslateTextWithModel got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 // 	}
 // }

--- a/translate/v3/create_and_delete_glossary_test.go
+++ b/translate/v3/create_and_delete_glossary_test.go
@@ -37,13 +37,13 @@ func TestCreateAndDeleteGlossary(t *testing.T) {
 		t.Fatalf("createGlossary: %v", err)
 	}
 	if got, want := buf.String(), "Created"; !strings.Contains(got, want) {
-		t.Fatalf("createGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
+		t.Errorf("createGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 	if got, want := buf.String(), glossaryID; !strings.Contains(got, want) {
-		t.Fatalf("createGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
+		t.Errorf("createGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 	if got, want := buf.String(), glossaryInputURI; !strings.Contains(got, want) {
-		t.Fatalf("createGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
+		t.Errorf("createGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 
 	// Delete the glossary.
@@ -52,12 +52,12 @@ func TestCreateAndDeleteGlossary(t *testing.T) {
 		t.Fatalf("deleteGlossary: %v", err)
 	}
 	if got, want := buf.String(), "Deleted"; !strings.Contains(got, want) {
-		t.Fatalf("deleteGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
+		t.Errorf("deleteGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 	if got, want := buf.String(), location; !strings.Contains(got, want) {
-		t.Fatalf("deleteGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
+		t.Errorf("deleteGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 	if got, want := buf.String(), glossaryID; !strings.Contains(got, want) {
-		t.Fatalf("deleteGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
+		t.Errorf("deleteGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 }

--- a/translate/v3/create_and_delete_glossary_test.go
+++ b/translate/v3/create_and_delete_glossary_test.go
@@ -27,27 +27,23 @@ import (
 func TestCreateAndDeleteGlossary(t *testing.T) {
 	tc := testutil.SystemTest(t)
 
-	var buf bytes.Buffer
-	var got string
-
 	location := "us-central1"
 	glossaryID := fmt.Sprintf("create_and_delete_glossary-%v", uuid.New().ID())
 	glossaryInputURI := "gs://cloud-samples-data/translation/glossary_ja.csv"
 
 	// Create a glossary.
-	buf.Reset()
+	var buf bytes.Buffer
 	if err := createGlossary(&buf, tc.ProjectID, location, glossaryID, glossaryInputURI); err != nil {
 		t.Fatalf("createGlossary: %v", err)
 	}
-	got = buf.String()
-	if !strings.Contains(got, "Created") {
-		t.Fatalf("Got '%s', expected to contain 'Created'", got)
+	if got, want := buf.String(), "Created"; !strings.Contains(got, want) {
+		t.Fatalf("createGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
-	if !strings.Contains(got, glossaryID) {
-		t.Fatalf("Got '%s', expected to contain '%s'", got, glossaryID)
+	if got, want := buf.String(), glossaryID; !strings.Contains(got, want) {
+		t.Fatalf("createGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
-	if !strings.Contains(got, glossaryInputURI) {
-		t.Fatalf("Got '%s', expected to contain '%s'", got, glossaryInputURI)
+	if got, want := buf.String(), glossaryInputURI; !strings.Contains(got, want) {
+		t.Fatalf("createGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 
 	// Delete the glossary.
@@ -55,14 +51,13 @@ func TestCreateAndDeleteGlossary(t *testing.T) {
 	if err := deleteGlossary(&buf, tc.ProjectID, location, glossaryID); err != nil {
 		t.Fatalf("deleteGlossary: %v", err)
 	}
-	got = buf.String()
-	if !strings.Contains(got, "Deleted") {
-		t.Fatalf("Got '%s', expected to contain 'Deleted'", got)
+	if got, want := buf.String(), "Deleted"; !strings.Contains(got, want) {
+		t.Fatalf("deleteGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
-	if !strings.Contains(got, location) {
-		t.Fatalf("Got '%s', expected to contain '%s'", got, location)
+	if got, want := buf.String(), location; !strings.Contains(got, want) {
+		t.Fatalf("deleteGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
-	if !strings.Contains(got, glossaryID) {
-		t.Fatalf("Got '%s', expected to contain '%s'", got, glossaryID)
+	if got, want := buf.String(), glossaryID; !strings.Contains(got, want) {
+		t.Fatalf("deleteGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 }

--- a/translate/v3/create_and_delete_glossary_test.go
+++ b/translate/v3/create_and_delete_glossary_test.go
@@ -1,0 +1,68 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+	"github.com/google/uuid"
+)
+
+func TestCreateAndDeleteGlossary(t *testing.T) {
+	tc := testutil.SystemTest(t)
+
+	var buf bytes.Buffer
+	var got string
+
+	location := "us-central1"
+	glossaryID := fmt.Sprintf("create_and_delete_glossary-%v", uuid.New().ID())
+	glossaryInputURI := "gs://cloud-samples-data/translation/glossary_ja.csv"
+
+	// Create a glossary.
+	buf.Reset()
+	if err := createGlossary(&buf, tc.ProjectID, location, glossaryID, glossaryInputURI); err != nil {
+		t.Fatalf("createGlossary: %v", err)
+	}
+	got = buf.String()
+	if !strings.Contains(got, "Created") {
+		t.Fatalf("Got '%s', expected to contain 'Created'", got)
+	}
+	if !strings.Contains(got, glossaryID) {
+		t.Fatalf("Got '%s', expected to contain '%s'", got, glossaryID)
+	}
+	if !strings.Contains(got, glossaryInputURI) {
+		t.Fatalf("Got '%s', expected to contain '%s'", got, glossaryInputURI)
+	}
+
+	// Delete the glossary.
+	buf.Reset()
+	if err := deleteGlossary(&buf, tc.ProjectID, location, glossaryID); err != nil {
+		t.Fatalf("deleteGlossary: %v", err)
+	}
+	got = buf.String()
+	if !strings.Contains(got, "Deleted") {
+		t.Fatalf("Got '%s', expected to contain 'Deleted'", got)
+	}
+	if !strings.Contains(got, location) {
+		t.Fatalf("Got '%s', expected to contain '%s'", got, location)
+	}
+	if !strings.Contains(got, glossaryID) {
+		t.Fatalf("Got '%s', expected to contain '%s'", got, glossaryID)
+	}
+}

--- a/translate/v3/create_glossary.go
+++ b/translate/v3/create_glossary.go
@@ -33,11 +33,11 @@ func createGlossary(w io.Writer, projectID string, location string, glossaryID s
 	// glossaryInputURI := "gs://cloud-samples-data/translation/glossary.csv"
 
 	ctx := context.Background()
-	c, err := translate.NewTranslationClient(ctx)
+	client, err := translate.NewTranslationClient(ctx)
 	if err != nil {
 		return fmt.Errorf("NewTranslationClient: %v", err)
 	}
-	defer c.Close()
+	defer client.Close()
 
 	req := &translatepb.CreateGlossaryRequest{
 		Parent: fmt.Sprintf("projects/%s/locations/%s", projectID, location),
@@ -59,7 +59,7 @@ func createGlossary(w io.Writer, projectID string, location string, glossaryID s
 	}
 
 	// The CreateGlossary operation is async.
-	op, err := c.CreateGlossary(ctx, req)
+	op, err := client.CreateGlossary(ctx, req)
 	if err != nil {
 		return fmt.Errorf("CreateGlossary: %v", err)
 	}

--- a/translate/v3/create_glossary.go
+++ b/translate/v3/create_glossary.go
@@ -27,7 +27,7 @@ import (
 
 // createGlossary creates a glossary to use for other operations.
 func createGlossary(w io.Writer, projectID string, location string, glossaryID string, glossaryInputURI string) error {
-	// projectID := "your-google-cloud-project-id"
+	// projectID := "my-project-id"
 	// location := "us-central1"
 	// glossaryID := "glossary-id"
 	// glossaryInputURI := "gs://cloud-samples-data/translation/glossary.csv"

--- a/translate/v3/create_glossary.go
+++ b/translate/v3/create_glossary.go
@@ -1,0 +1,79 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package v3 contains samples for Google Cloud Translation API v3.
+package v3
+
+// [START translate_v3_create_glossary]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	translate "cloud.google.com/go/translate/apiv3"
+	translatepb "google.golang.org/genproto/googleapis/cloud/translate/v3"
+)
+
+// createGlossary creates a glossary to use for other operations.
+func createGlossary(w io.Writer, projectID string, location string, glossaryID string, glossaryInputURI string) error {
+	// projectID := "your-google-cloud-project-id"
+	// location := "us-central1"
+	// glossaryID := "glossary-id"
+	// glossaryInputURI := "gs://cloud-samples-data/translation/glossary.csv"
+
+	ctx := context.Background()
+	c, err := translate.NewTranslationClient(ctx)
+	if err != nil {
+		return fmt.Errorf("NewTranslationClient: %v", err)
+	}
+	defer c.Close()
+
+	req := &translatepb.CreateGlossaryRequest{
+		Parent: fmt.Sprintf("projects/%s/locations/%s", projectID, location),
+		Glossary: &translatepb.Glossary{
+			Name: fmt.Sprintf("projects/%s/locations/%s/glossaries/%s", projectID, location, glossaryID),
+			Languages: &translatepb.Glossary_LanguageCodesSet_{
+				LanguageCodesSet: &translatepb.Glossary_LanguageCodesSet{
+					LanguageCodes: []string{"en", "ja"},
+				},
+			},
+			InputConfig: &translatepb.GlossaryInputConfig{
+				Source: &translatepb.GlossaryInputConfig_GcsSource{
+					GcsSource: &translatepb.GcsSource{
+						InputUri: glossaryInputURI,
+					},
+				},
+			},
+		},
+	}
+
+	// The CreateGlossary operation is async.
+	op, err := c.CreateGlossary(ctx, req)
+	if err != nil {
+		return fmt.Errorf("CreateGlossary: %v", err)
+	}
+	fmt.Fprintf(w, "Processing operation name: %q\n", op.Name())
+
+	resp, err := op.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("Wait: %v", err)
+	}
+
+	fmt.Fprintf(w, "Created: %v\n", resp.GetName())
+	fmt.Fprintf(w, "Input URI: %v\n", resp.InputConfig.GetGcsSource().GetInputUri())
+
+	return nil
+}
+
+// [END translate_v3_create_glossary]

--- a/translate/v3/delete_bucket.go
+++ b/translate/v3/delete_bucket.go
@@ -1,0 +1,48 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"context"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/iterator"
+)
+
+// Helper function to delete a bucket with all their containing objects.
+func deleteBucket(ctx context.Context, t *testing.T, bucket *storage.BucketHandle) {
+	bucketAttrs, err := bucket.Attrs(ctx)
+	if err != nil {
+		t.Fatalf("bucket.Attrs: %v", err)
+	}
+	bucketName := bucketAttrs.Name
+	it := bucket.Objects(ctx, nil)
+	for {
+		attrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			t.Fatalf("bucket.Objects: %v", err)
+		}
+		if err := bucket.Object(attrs.Name).Delete(ctx); err != nil {
+			t.Fatalf("Bucket(%v).Object(%v).Delete: %v", bucketName, attrs.Name, err)
+		}
+	}
+	if err := bucket.Delete(ctx); err != nil {
+		t.Fatalf("bucket.Delete: %v", err)
+	}
+}

--- a/translate/v3/delete_bucket.go
+++ b/translate/v3/delete_bucket.go
@@ -26,7 +26,7 @@ import (
 func deleteBucket(ctx context.Context, t *testing.T, bucket *storage.BucketHandle) {
 	bucketAttrs, err := bucket.Attrs(ctx)
 	if err != nil {
-		t.Fatalf("bucket.Attrs: %v", err)
+		t.Errorf("bucket.Attrs: %v", err)
 	}
 	bucketName := bucketAttrs.Name
 	it := bucket.Objects(ctx, nil)
@@ -36,13 +36,13 @@ func deleteBucket(ctx context.Context, t *testing.T, bucket *storage.BucketHandl
 			break
 		}
 		if err != nil {
-			t.Fatalf("bucket.Objects: %v", err)
+			t.Errorf("bucket.Objects: %v", err)
 		}
 		if err := bucket.Object(attrs.Name).Delete(ctx); err != nil {
-			t.Fatalf("Bucket(%v).Object(%v).Delete: %v", bucketName, attrs.Name, err)
+			t.Errorf("Bucket(%v).Object(%v).Delete: %v", bucketName, attrs.Name, err)
 		}
 	}
 	if err := bucket.Delete(ctx); err != nil {
-		t.Fatalf("bucket.Delete: %v", err)
+		t.Errorf("bucket.Delete: %v", err)
 	}
 }

--- a/translate/v3/delete_glossary.go
+++ b/translate/v3/delete_glossary.go
@@ -32,18 +32,18 @@ func deleteGlossary(w io.Writer, projectID string, location string, glossaryID s
 	// glossaryID := "glossary-id"
 
 	ctx := context.Background()
-	c, err := translate.NewTranslationClient(ctx)
+	client, err := translate.NewTranslationClient(ctx)
 	if err != nil {
 		return fmt.Errorf("NewTranslationClient: %v", err)
 	}
-	defer c.Close()
+	defer client.Close()
 
 	req := &translatepb.DeleteGlossaryRequest{
 		Name: fmt.Sprintf("projects/%s/locations/%s/glossaries/%s", projectID, location, glossaryID),
 	}
 
 	// The DeleteGlossary operation is async.
-	op, err := c.DeleteGlossary(ctx, req)
+	op, err := client.DeleteGlossary(ctx, req)
 	if err != nil {
 		return fmt.Errorf("DeleteGlossary: %v", err)
 	}

--- a/translate/v3/delete_glossary.go
+++ b/translate/v3/delete_glossary.go
@@ -1,0 +1,62 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package v3 contains samples for Google Cloud Translation API v3.
+package v3
+
+// [START translate_v3_delete_glossary]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	translate "cloud.google.com/go/translate/apiv3"
+	translatepb "google.golang.org/genproto/googleapis/cloud/translate/v3"
+)
+
+// deleteGlossary deletes a glossary.
+func deleteGlossary(w io.Writer, projectID string, location string, glossaryID string) error {
+	// projectID := "your-google-cloud-project-id"
+	// location := "us-central1"
+	// glossaryID := "glossary-id"
+
+	ctx := context.Background()
+	c, err := translate.NewTranslationClient(ctx)
+	if err != nil {
+		return fmt.Errorf("NewTranslationClient: %v", err)
+	}
+	defer c.Close()
+
+	req := &translatepb.DeleteGlossaryRequest{
+		Name: fmt.Sprintf("projects/%s/locations/%s/glossaries/%s", projectID, location, glossaryID),
+	}
+
+	// The DeleteGlossary operation is async.
+	op, err := c.DeleteGlossary(ctx, req)
+	if err != nil {
+		return fmt.Errorf("DeleteGlossary: %v", err)
+	}
+	fmt.Fprintf(w, "Processing operation name: %q\n", op.Name())
+
+	resp, err := op.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("Wait: %v", err)
+	}
+
+	fmt.Fprintf(w, "Deleted: %v\n", resp.GetName())
+
+	return nil
+}
+
+// [END translate_v3_delete_glossary]

--- a/translate/v3/delete_glossary.go
+++ b/translate/v3/delete_glossary.go
@@ -27,7 +27,7 @@ import (
 
 // deleteGlossary deletes a glossary.
 func deleteGlossary(w io.Writer, projectID string, location string, glossaryID string) error {
-	// projectID := "your-google-cloud-project-id"
+	// projectID := "my-project-id"
 	// location := "us-central1"
 	// glossaryID := "glossary-id"
 

--- a/translate/v3/detect_language.go
+++ b/translate/v3/detect_language.go
@@ -1,0 +1,65 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package v3 contains samples for Google Cloud Translation API v3.
+package v3
+
+// [START translate_v3_detect_language]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	translate "cloud.google.com/go/translate/apiv3"
+	translatepb "google.golang.org/genproto/googleapis/cloud/translate/v3"
+)
+
+// detectLanguage detects the language of a text string.
+func detectLanguage(w io.Writer, projectID string, text string) error {
+	// projectID := "your-google-cloud-project-id"
+	// text := "Hello, world!"
+
+	ctx := context.Background()
+	c, err := translate.NewTranslationClient(ctx)
+	if err != nil {
+		return fmt.Errorf("NewTranslationClient: %v", err)
+	}
+	defer c.Close()
+
+	req := &translatepb.DetectLanguageRequest{
+		Parent:   fmt.Sprintf("projects/%s/locations/global", projectID),
+		MimeType: "text/plain", // Mime types: "text/plain", "text/html"
+		Source: &translatepb.DetectLanguageRequest_Content{
+			Content: text,
+		},
+	}
+
+	resp, err := c.DetectLanguage(ctx, req)
+	if err != nil {
+		return fmt.Errorf("DetectLanguage: %v", err)
+	}
+
+	// Display list of detected languages sorted by detection confidence.
+	// The most probable language is first.
+	for _, language := range resp.GetLanguages() {
+		// The language detected.
+		fmt.Fprintf(w, "Language code: %v\n", language.GetLanguageCode())
+		// Confidence of detection result for this language.
+		fmt.Fprintf(w, "Confidence: %v\n", language.GetConfidence())
+	}
+
+	return nil
+}
+
+// [END translate_v3_detect_language]

--- a/translate/v3/detect_language.go
+++ b/translate/v3/detect_language.go
@@ -31,11 +31,11 @@ func detectLanguage(w io.Writer, projectID string, text string) error {
 	// text := "Hello, world!"
 
 	ctx := context.Background()
-	c, err := translate.NewTranslationClient(ctx)
+	client, err := translate.NewTranslationClient(ctx)
 	if err != nil {
 		return fmt.Errorf("NewTranslationClient: %v", err)
 	}
-	defer c.Close()
+	defer client.Close()
 
 	req := &translatepb.DetectLanguageRequest{
 		Parent:   fmt.Sprintf("projects/%s/locations/global", projectID),
@@ -45,7 +45,7 @@ func detectLanguage(w io.Writer, projectID string, text string) error {
 		},
 	}
 
-	resp, err := c.DetectLanguage(ctx, req)
+	resp, err := client.DetectLanguage(ctx, req)
 	if err != nil {
 		return fmt.Errorf("DetectLanguage: %v", err)
 	}

--- a/translate/v3/detect_language.go
+++ b/translate/v3/detect_language.go
@@ -27,7 +27,7 @@ import (
 
 // detectLanguage detects the language of a text string.
 func detectLanguage(w io.Writer, projectID string, text string) error {
-	// projectID := "your-google-cloud-project-id"
+	// projectID := "my-project-id"
 	// text := "Hello, world!"
 
 	ctx := context.Background()

--- a/translate/v3/detect_language_test.go
+++ b/translate/v3/detect_language_test.go
@@ -25,15 +25,14 @@ import (
 func TestDetectLanguage(t *testing.T) {
 	tc := testutil.SystemTest(t)
 
-	var buf bytes.Buffer
-
 	text := "Hæ sæta"
 
 	// Detect language.
+	var buf bytes.Buffer
 	if err := detectLanguage(&buf, tc.ProjectID, text); err != nil {
 		t.Fatalf("detectLanguage: %v", err)
 	}
-	if got := buf.String(); !strings.Contains(got, "is") {
-		t.Fatalf("Got '%s', expected to contain 'is'", got)
+	if got, want := buf.String(), "is"; !strings.Contains(got, want) {
+		t.Fatalf("detectLanguage got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 }

--- a/translate/v3/detect_language_test.go
+++ b/translate/v3/detect_language_test.go
@@ -33,6 +33,6 @@ func TestDetectLanguage(t *testing.T) {
 		t.Fatalf("detectLanguage: %v", err)
 	}
 	if got, want := buf.String(), "is"; !strings.Contains(got, want) {
-		t.Fatalf("detectLanguage got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
+		t.Errorf("detectLanguage got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 }

--- a/translate/v3/detect_language_test.go
+++ b/translate/v3/detect_language_test.go
@@ -1,0 +1,39 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+)
+
+func TestDetectLanguage(t *testing.T) {
+	tc := testutil.SystemTest(t)
+
+	var buf bytes.Buffer
+
+	text := "Hæ sæta"
+
+	// Detect language.
+	if err := detectLanguage(&buf, tc.ProjectID, text); err != nil {
+		t.Fatalf("detectLanguage: %v", err)
+	}
+	if got := buf.String(); !strings.Contains(got, "is") {
+		t.Fatalf("Got '%s', expected to contain 'is'", got)
+	}
+}

--- a/translate/v3/get_glossary.go
+++ b/translate/v3/get_glossary.go
@@ -27,7 +27,7 @@ import (
 
 // getGlossary gets the specified glossary.
 func getGlossary(w io.Writer, projectID string, location string, glossaryID string) error {
-	// projectID := "your-google-cloud-project-id"
+	// projectID := "my-project-id"
 	// location := "us-central1"
 	// glossaryID := "glossary-id"
 

--- a/translate/v3/get_glossary.go
+++ b/translate/v3/get_glossary.go
@@ -32,17 +32,17 @@ func getGlossary(w io.Writer, projectID string, location string, glossaryID stri
 	// glossaryID := "glossary-id"
 
 	ctx := context.Background()
-	c, err := translate.NewTranslationClient(ctx)
+	client, err := translate.NewTranslationClient(ctx)
 	if err != nil {
 		return fmt.Errorf("NewTranslationClient: %v", err)
 	}
-	defer c.Close()
+	defer client.Close()
 
 	req := &translatepb.GetGlossaryRequest{
 		Name: fmt.Sprintf("projects/%s/locations/%s/glossaries/%s", projectID, location, glossaryID),
 	}
 
-	resp, err := c.GetGlossary(ctx, req)
+	resp, err := client.GetGlossary(ctx, req)
 	if err != nil {
 		return fmt.Errorf("GetGlossary: %v", err)
 	}

--- a/translate/v3/get_glossary.go
+++ b/translate/v3/get_glossary.go
@@ -1,0 +1,57 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package v3 contains samples for Google Cloud Translation API v3.
+package v3
+
+// [START translate_v3_get_glossary]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	translate "cloud.google.com/go/translate/apiv3"
+	translatepb "google.golang.org/genproto/googleapis/cloud/translate/v3"
+)
+
+// getGlossary gets the specified glossary.
+func getGlossary(w io.Writer, projectID string, location string, glossaryID string) error {
+	// projectID := "your-google-cloud-project-id"
+	// location := "us-central1"
+	// glossaryID := "glossary-id"
+
+	ctx := context.Background()
+	c, err := translate.NewTranslationClient(ctx)
+	if err != nil {
+		return fmt.Errorf("NewTranslationClient: %v", err)
+	}
+	defer c.Close()
+
+	req := &translatepb.GetGlossaryRequest{
+		Name: fmt.Sprintf("projects/%s/locations/%s/glossaries/%s", projectID, location, glossaryID),
+	}
+
+	resp, err := c.GetGlossary(ctx, req)
+	if err != nil {
+		return fmt.Errorf("GetGlossary: %v", err)
+	}
+
+	fmt.Fprintf(w, "Glossary name: %v\n", resp.GetName())
+	fmt.Fprintf(w, "Entry count: %v\n", resp.GetEntryCount())
+	fmt.Fprintf(w, "Input URI: %v\n", resp.GetInputConfig().GetGcsSource().GetInputUri())
+
+	return nil
+}
+
+// [END translate_v3_get_glossary]

--- a/translate/v3/get_glossary_test.go
+++ b/translate/v3/get_glossary_test.go
@@ -27,14 +27,12 @@ import (
 func TestGetGlossary(t *testing.T) {
 	tc := testutil.SystemTest(t)
 
-	var buf bytes.Buffer
-	var got string
-
 	location := "us-central1"
 	glossaryID := fmt.Sprintf("get_glossary-%v", uuid.New().ID())
 	glossaryInputURI := "gs://cloud-samples-data/translation/glossary_ja.csv"
 
 	// Create a glossary.
+	var buf bytes.Buffer
 	if err := createGlossary(&buf, tc.ProjectID, location, glossaryID, glossaryInputURI); err != nil {
 		t.Fatalf("createGlossary: %v", err)
 	}
@@ -44,11 +42,10 @@ func TestGetGlossary(t *testing.T) {
 	if err := getGlossary(&buf, tc.ProjectID, location, glossaryID); err != nil {
 		t.Fatalf("getGlossary: %v", err)
 	}
-	got = buf.String()
-	if !strings.Contains(got, glossaryID) {
-		t.Fatalf("Got '%s', expected to contain '%s'", got, glossaryID)
+	if got, want := buf.String(), glossaryID; !strings.Contains(got, want) {
+		t.Fatalf("getGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
-	if !strings.Contains(got, glossaryInputURI) {
-		t.Fatalf("Got '%s', expected to contain '%s'", got, glossaryInputURI)
+	if got, want := buf.String(), glossaryInputURI; !strings.Contains(got, want) {
+		t.Fatalf("getGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 }

--- a/translate/v3/get_glossary_test.go
+++ b/translate/v3/get_glossary_test.go
@@ -43,9 +43,9 @@ func TestGetGlossary(t *testing.T) {
 		t.Fatalf("getGlossary: %v", err)
 	}
 	if got, want := buf.String(), glossaryID; !strings.Contains(got, want) {
-		t.Fatalf("getGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
+		t.Errorf("getGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 	if got, want := buf.String(), glossaryInputURI; !strings.Contains(got, want) {
-		t.Fatalf("getGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
+		t.Errorf("getGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 }

--- a/translate/v3/get_glossary_test.go
+++ b/translate/v3/get_glossary_test.go
@@ -1,0 +1,54 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+	"github.com/google/uuid"
+)
+
+func TestGetGlossary(t *testing.T) {
+	tc := testutil.SystemTest(t)
+
+	var buf bytes.Buffer
+	var got string
+
+	location := "us-central1"
+	glossaryID := fmt.Sprintf("get_glossary-%v", uuid.New().ID())
+	glossaryInputURI := "gs://cloud-samples-data/translation/glossary_ja.csv"
+
+	// Create a glossary.
+	if err := createGlossary(&buf, tc.ProjectID, location, glossaryID, glossaryInputURI); err != nil {
+		t.Fatalf("createGlossary: %v", err)
+	}
+	defer deleteGlossary(&buf, tc.ProjectID, location, glossaryID)
+
+	// Check the glossary.
+	if err := getGlossary(&buf, tc.ProjectID, location, glossaryID); err != nil {
+		t.Fatalf("getGlossary: %v", err)
+	}
+	got = buf.String()
+	if !strings.Contains(got, glossaryID) {
+		t.Fatalf("Got '%s', expected to contain '%s'", got, glossaryID)
+	}
+	if !strings.Contains(got, glossaryInputURI) {
+		t.Fatalf("Got '%s', expected to contain '%s'", got, glossaryInputURI)
+	}
+}

--- a/translate/v3/get_supported_languages.go
+++ b/translate/v3/get_supported_languages.go
@@ -1,0 +1,57 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package v3 contains samples for Google Cloud Translation API v3.
+package v3
+
+// [START translate_v3_get_supported_languages]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	translate "cloud.google.com/go/translate/apiv3"
+	translatepb "google.golang.org/genproto/googleapis/cloud/translate/v3"
+)
+
+// getSupportedLanguages gets a list of supported language codes.
+func getSupportedLanguages(w io.Writer, projectID string) error {
+	// projectID := "your-google-cloud-project-id"
+
+	ctx := context.Background()
+	c, err := translate.NewTranslationClient(ctx)
+	if err != nil {
+		return fmt.Errorf("NewTranslationClient: %v", err)
+	}
+	defer c.Close()
+
+	req := &translatepb.GetSupportedLanguagesRequest{
+		Parent: fmt.Sprintf("projects/%s/locations/global", projectID),
+	}
+
+	resp, err := c.GetSupportedLanguages(ctx, req)
+	if err != nil {
+		return fmt.Errorf("GetSupportedLanguages: %v", err)
+	}
+
+	// List language codes of supported languages
+	fmt.Fprintf(w, "Supported languages:\n")
+	for _, language := range resp.GetLanguages() {
+		fmt.Fprintf(w, "Language code: %v\n", language.GetLanguageCode())
+	}
+
+	return nil
+}
+
+// [END translate_v3_get_supported_languages]

--- a/translate/v3/get_supported_languages.go
+++ b/translate/v3/get_supported_languages.go
@@ -30,17 +30,17 @@ func getSupportedLanguages(w io.Writer, projectID string) error {
 	// projectID := "my-project-id"
 
 	ctx := context.Background()
-	c, err := translate.NewTranslationClient(ctx)
+	client, err := translate.NewTranslationClient(ctx)
 	if err != nil {
 		return fmt.Errorf("NewTranslationClient: %v", err)
 	}
-	defer c.Close()
+	defer client.Close()
 
 	req := &translatepb.GetSupportedLanguagesRequest{
 		Parent: fmt.Sprintf("projects/%s/locations/global", projectID),
 	}
 
-	resp, err := c.GetSupportedLanguages(ctx, req)
+	resp, err := client.GetSupportedLanguages(ctx, req)
 	if err != nil {
 		return fmt.Errorf("GetSupportedLanguages: %v", err)
 	}

--- a/translate/v3/get_supported_languages.go
+++ b/translate/v3/get_supported_languages.go
@@ -27,7 +27,7 @@ import (
 
 // getSupportedLanguages gets a list of supported language codes.
 func getSupportedLanguages(w io.Writer, projectID string) error {
-	// projectID := "your-google-cloud-project-id"
+	// projectID := "my-project-id"
 
 	ctx := context.Background()
 	c, err := translate.NewTranslationClient(ctx)

--- a/translate/v3/get_supported_languages_for_target.go
+++ b/translate/v3/get_supported_languages_for_target.go
@@ -27,7 +27,7 @@ import (
 
 // getSupportedLanguagesForTarget gets a list of supported language codes with target language names.
 func getSupportedLanguagesForTarget(w io.Writer, projectID string, languageCode string) error {
-	// projectID := "your-google-cloud-project-id"
+	// projectID := "my-project-id"
 	// languageCode := "is"
 
 	ctx := context.Background()

--- a/translate/v3/get_supported_languages_for_target.go
+++ b/translate/v3/get_supported_languages_for_target.go
@@ -1,0 +1,60 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package v3 contains samples for Google Cloud Translation API v3.
+package v3
+
+// [START translate_v3_get_supported_languages_for_target]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	translate "cloud.google.com/go/translate/apiv3"
+	translatepb "google.golang.org/genproto/googleapis/cloud/translate/v3"
+)
+
+// getSupportedLanguagesForTarget gets a list of supported language codes with target language names.
+func getSupportedLanguagesForTarget(w io.Writer, projectID string, languageCode string) error {
+	// projectID := "your-google-cloud-project-id"
+	// languageCode := "is"
+
+	ctx := context.Background()
+	c, err := translate.NewTranslationClient(ctx)
+	if err != nil {
+		return fmt.Errorf("NewTranslationClient: %v", err)
+	}
+	defer c.Close()
+
+	req := &translatepb.GetSupportedLanguagesRequest{
+		Parent:              fmt.Sprintf("projects/%s/locations/global", projectID),
+		DisplayLanguageCode: languageCode,
+	}
+
+	resp, err := c.GetSupportedLanguages(ctx, req)
+	if err != nil {
+		return fmt.Errorf("GetSupportedLanguages: %v", err)
+	}
+
+	// List language codes of supported languages
+	fmt.Fprintf(w, "Supported languages:\n")
+	for _, language := range resp.GetLanguages() {
+		fmt.Fprintf(w, "Language code: %v\n", language.GetLanguageCode())
+		fmt.Fprintf(w, "Display name: %v\n", language.GetDisplayName())
+	}
+
+	return nil
+}
+
+// [END translate_v3_get_supported_languages_for_target]

--- a/translate/v3/get_supported_languages_for_target.go
+++ b/translate/v3/get_supported_languages_for_target.go
@@ -31,18 +31,18 @@ func getSupportedLanguagesForTarget(w io.Writer, projectID string, languageCode 
 	// languageCode := "is"
 
 	ctx := context.Background()
-	c, err := translate.NewTranslationClient(ctx)
+	client, err := translate.NewTranslationClient(ctx)
 	if err != nil {
 		return fmt.Errorf("NewTranslationClient: %v", err)
 	}
-	defer c.Close()
+	defer client.Close()
 
 	req := &translatepb.GetSupportedLanguagesRequest{
 		Parent:              fmt.Sprintf("projects/%s/locations/global", projectID),
 		DisplayLanguageCode: languageCode,
 	}
 
-	resp, err := c.GetSupportedLanguages(ctx, req)
+	resp, err := client.GetSupportedLanguages(ctx, req)
 	if err != nil {
 		return fmt.Errorf("GetSupportedLanguages: %v", err)
 	}

--- a/translate/v3/get_supported_languages_for_target_test.go
+++ b/translate/v3/get_supported_languages_for_target_test.go
@@ -1,0 +1,44 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+)
+
+func TestGetSupportedLanguagesForTarget(t *testing.T) {
+	tc := testutil.SystemTest(t)
+
+	var buf bytes.Buffer
+	var got string
+
+	languageCode := "is"
+
+	// Get supported languages.
+	if err := getSupportedLanguagesForTarget(&buf, tc.ProjectID, languageCode); err != nil {
+		t.Fatalf("getSupportedLanguagesWithTarget: %v", err)
+	}
+	got = buf.String()
+	if !strings.Contains(got, "Language code: sq") {
+		t.Fatalf("Got '%s', expected to contain 'Language code: sq'", got)
+	}
+	if !strings.Contains(got, "Display name: albanska") {
+		t.Fatalf("Got '%s', expected to contain 'Display name: albanska'", got)
+	}
+}

--- a/translate/v3/get_supported_languages_for_target_test.go
+++ b/translate/v3/get_supported_languages_for_target_test.go
@@ -33,9 +33,9 @@ func TestGetSupportedLanguagesForTarget(t *testing.T) {
 		t.Fatalf("getSupportedLanguagesForTarget: %v", err)
 	}
 	if got, want := buf.String(), "Language code: sq"; !strings.Contains(got, want) {
-		t.Fatalf("getSupportedLanguagesForTarget got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
+		t.Errorf("getSupportedLanguagesForTarget got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 	if got, want := buf.String(), "Display name: albanska"; !strings.Contains(got, want) {
-		t.Fatalf("getSupportedLanguagesForTarget got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
+		t.Errorf("getSupportedLanguagesForTarget got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 }

--- a/translate/v3/get_supported_languages_for_target_test.go
+++ b/translate/v3/get_supported_languages_for_target_test.go
@@ -25,20 +25,17 @@ import (
 func TestGetSupportedLanguagesForTarget(t *testing.T) {
 	tc := testutil.SystemTest(t)
 
-	var buf bytes.Buffer
-	var got string
-
 	languageCode := "is"
 
 	// Get supported languages.
+	var buf bytes.Buffer
 	if err := getSupportedLanguagesForTarget(&buf, tc.ProjectID, languageCode); err != nil {
-		t.Fatalf("getSupportedLanguagesWithTarget: %v", err)
+		t.Fatalf("getSupportedLanguagesForTarget: %v", err)
 	}
-	got = buf.String()
-	if !strings.Contains(got, "Language code: sq") {
-		t.Fatalf("Got '%s', expected to contain 'Language code: sq'", got)
+	if got, want := buf.String(), "Language code: sq"; !strings.Contains(got, want) {
+		t.Fatalf("getSupportedLanguagesForTarget got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
-	if !strings.Contains(got, "Display name: albanska") {
-		t.Fatalf("Got '%s', expected to contain 'Display name: albanska'", got)
+	if got, want := buf.String(), "Display name: albanska"; !strings.Contains(got, want) {
+		t.Fatalf("getSupportedLanguagesForTarget got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 }

--- a/translate/v3/get_supported_languages_test.go
+++ b/translate/v3/get_supported_languages_test.go
@@ -31,6 +31,6 @@ func TestGetSupportedLanguages(t *testing.T) {
 		t.Fatalf("getSupportedLanguages: %v", err)
 	}
 	if got, want := buf.String(), "zh-CN"; !strings.Contains(got, want) {
-		t.Fatalf("getSupportedLanguages got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
+		t.Errorf("getSupportedLanguages got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 }

--- a/translate/v3/get_supported_languages_test.go
+++ b/translate/v3/get_supported_languages_test.go
@@ -1,0 +1,37 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+)
+
+func TestGetSupportedLanguages(t *testing.T) {
+	tc := testutil.SystemTest(t)
+
+	var buf bytes.Buffer
+
+	// Get supported languages.
+	if err := getSupportedLanguages(&buf, tc.ProjectID); err != nil {
+		t.Fatalf("getSupportedLanguages: %v", err)
+	}
+	if got := buf.String(); !strings.Contains(got, "zh-CN") {
+		t.Fatalf("Got '%s', expected to contain 'zh-CN'", got)
+	}
+}

--- a/translate/v3/get_supported_languages_test.go
+++ b/translate/v3/get_supported_languages_test.go
@@ -25,13 +25,12 @@ import (
 func TestGetSupportedLanguages(t *testing.T) {
 	tc := testutil.SystemTest(t)
 
-	var buf bytes.Buffer
-
 	// Get supported languages.
+	var buf bytes.Buffer
 	if err := getSupportedLanguages(&buf, tc.ProjectID); err != nil {
 		t.Fatalf("getSupportedLanguages: %v", err)
 	}
-	if got := buf.String(); !strings.Contains(got, "zh-CN") {
-		t.Fatalf("Got '%s', expected to contain 'zh-CN'", got)
+	if got, want := buf.String(), "zh-CN"; !strings.Contains(got, want) {
+		t.Fatalf("getSupportedLanguages got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 }

--- a/translate/v3/list_glossaries.go
+++ b/translate/v3/list_glossaries.go
@@ -1,0 +1,71 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package v3 contains samples for Google Cloud Translation API v3.
+package v3
+
+// [START translate_v3_list_glossaries]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	translate "cloud.google.com/go/translate/apiv3"
+	"google.golang.org/api/iterator"
+	translatepb "google.golang.org/genproto/googleapis/cloud/translate/v3"
+)
+
+// listGlossaries gets the specified glossary.
+func listGlossaries(w io.Writer, projectID string, location string) error {
+	// projectID := "your-google-cloud-project-id"
+	// location := "us-central1"
+
+	ctx := context.Background()
+	c, err := translate.NewTranslationClient(ctx)
+	if err != nil {
+		return fmt.Errorf("NewTranslationClient: %v", err)
+	}
+	defer c.Close()
+
+	req := &translatepb.ListGlossariesRequest{
+		Parent: fmt.Sprintf("projects/%s/locations/%s", projectID, location),
+	}
+
+	it := c.ListGlossaries(ctx, req)
+
+	// Iterate over all results
+	for {
+		glossary, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("ListGlossaries.Next: %v", err)
+		}
+		fmt.Fprintf(w, "Name: %v\n", glossary.GetName())
+		fmt.Fprintf(w, "Entry count: %v\n", glossary.GetEntryCount())
+		fmt.Fprintf(w, "Input URI: %v\n", glossary.GetInputConfig().GetGcsSource().GetInputUri())
+		for _, languageCode := range glossary.GetLanguageCodesSet().GetLanguageCodes() {
+			fmt.Fprintf(w, "Language code: %v\n", languageCode)
+		}
+		if languagePair := glossary.GetLanguagePair(); languagePair != nil {
+			fmt.Fprintf(w, "Language pair: %v, %v\n",
+				languagePair.GetSourceLanguageCode(), languagePair.GetTargetLanguageCode())
+		}
+	}
+
+	return nil
+}
+
+// [END translate_v3_list_glossaries]

--- a/translate/v3/list_glossaries.go
+++ b/translate/v3/list_glossaries.go
@@ -32,17 +32,17 @@ func listGlossaries(w io.Writer, projectID string, location string) error {
 	// location := "us-central1"
 
 	ctx := context.Background()
-	c, err := translate.NewTranslationClient(ctx)
+	client, err := translate.NewTranslationClient(ctx)
 	if err != nil {
 		return fmt.Errorf("NewTranslationClient: %v", err)
 	}
-	defer c.Close()
+	defer client.Close()
 
 	req := &translatepb.ListGlossariesRequest{
 		Parent: fmt.Sprintf("projects/%s/locations/%s", projectID, location),
 	}
 
-	it := c.ListGlossaries(ctx, req)
+	it := client.ListGlossaries(ctx, req)
 
 	// Iterate over all results
 	for {

--- a/translate/v3/list_glossaries.go
+++ b/translate/v3/list_glossaries.go
@@ -28,7 +28,7 @@ import (
 
 // listGlossaries gets the specified glossary.
 func listGlossaries(w io.Writer, projectID string, location string) error {
-	// projectID := "your-google-cloud-project-id"
+	// projectID := "my-project-id"
 	// location := "us-central1"
 
 	ctx := context.Background()

--- a/translate/v3/list_glossaries_test.go
+++ b/translate/v3/list_glossaries_test.go
@@ -27,14 +27,12 @@ import (
 func TestListGlossaries(t *testing.T) {
 	tc := testutil.SystemTest(t)
 
-	var buf bytes.Buffer
-	var got string
-
 	location := "us-central1"
 	glossaryID := fmt.Sprintf("get_glossary-%v", uuid.New().ID())
 	glossaryInputURI := "gs://cloud-samples-data/translation/glossary_ja.csv"
 
 	// Create a glossary.
+	var buf bytes.Buffer
 	if err := createGlossary(&buf, tc.ProjectID, location, glossaryID, glossaryInputURI); err != nil {
 		t.Fatalf("createGlossary: %v", err)
 	}
@@ -44,11 +42,10 @@ func TestListGlossaries(t *testing.T) {
 	if err := listGlossaries(&buf, tc.ProjectID, location); err != nil {
 		t.Fatalf("listGlossaries: %v", err)
 	}
-	got = buf.String()
-	if !strings.Contains(got, glossaryID) {
-		t.Fatalf("Got '%s', expected to contain '%s'", got, glossaryID)
+	if got, want := buf.String(), glossaryID; !strings.Contains(got, want) {
+		t.Fatalf("listGlossaries got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
-	if !strings.Contains(got, glossaryInputURI) {
-		t.Fatalf("Got '%s', expected to contain '%s'", got, glossaryInputURI)
+	if got, want := buf.String(), glossaryInputURI; !strings.Contains(got, want) {
+		t.Fatalf("listGlossaries got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 }

--- a/translate/v3/list_glossaries_test.go
+++ b/translate/v3/list_glossaries_test.go
@@ -1,0 +1,54 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+	"github.com/google/uuid"
+)
+
+func TestListGlossaries(t *testing.T) {
+	tc := testutil.SystemTest(t)
+
+	var buf bytes.Buffer
+	var got string
+
+	location := "us-central1"
+	glossaryID := fmt.Sprintf("get_glossary-%v", uuid.New().ID())
+	glossaryInputURI := "gs://cloud-samples-data/translation/glossary_ja.csv"
+
+	// Create a glossary.
+	if err := createGlossary(&buf, tc.ProjectID, location, glossaryID, glossaryInputURI); err != nil {
+		t.Fatalf("createGlossary: %v", err)
+	}
+	defer deleteGlossary(&buf, tc.ProjectID, location, glossaryID)
+
+	// Check the glossaries.
+	if err := listGlossaries(&buf, tc.ProjectID, location); err != nil {
+		t.Fatalf("listGlossaries: %v", err)
+	}
+	got = buf.String()
+	if !strings.Contains(got, glossaryID) {
+		t.Fatalf("Got '%s', expected to contain '%s'", got, glossaryID)
+	}
+	if !strings.Contains(got, glossaryInputURI) {
+		t.Fatalf("Got '%s', expected to contain '%s'", got, glossaryInputURI)
+	}
+}

--- a/translate/v3/list_glossaries_test.go
+++ b/translate/v3/list_glossaries_test.go
@@ -43,9 +43,9 @@ func TestListGlossaries(t *testing.T) {
 		t.Fatalf("listGlossaries: %v", err)
 	}
 	if got, want := buf.String(), glossaryID; !strings.Contains(got, want) {
-		t.Fatalf("listGlossaries got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
+		t.Errorf("listGlossaries got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 	if got, want := buf.String(), glossaryInputURI; !strings.Contains(got, want) {
-		t.Fatalf("listGlossaries got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
+		t.Errorf("listGlossaries got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 }

--- a/translate/v3/translate_text.go
+++ b/translate/v3/translate_text.go
@@ -1,0 +1,63 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package v3 contains samples for Google Cloud Translation API v3.
+package v3
+
+// [START translate_v3_translate_text]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	translate "cloud.google.com/go/translate/apiv3"
+	translatepb "google.golang.org/genproto/googleapis/cloud/translate/v3"
+)
+
+// translateText translates input text and returns translated text.
+func translateText(w io.Writer, projectID string, sourceLang string, targetLang string, text string) error {
+	// projectID := "your-google-cloud-project-id"
+	// sourceLang := "en-US"
+	// targetLang := "fr"
+	// text := "Text you wish to translate"
+
+	ctx := context.Background()
+	c, err := translate.NewTranslationClient(ctx)
+	if err != nil {
+		return fmt.Errorf("NewTranslationClient: %v", err)
+	}
+	defer c.Close()
+
+	req := &translatepb.TranslateTextRequest{
+		Parent:             fmt.Sprintf("projects/%s/locations/global", projectID),
+		SourceLanguageCode: sourceLang,
+		TargetLanguageCode: targetLang,
+		MimeType:           "text/plain", // Mime types: "text/plain", "text/html"
+		Contents:           []string{text},
+	}
+
+	resp, err := c.TranslateText(ctx, req)
+	if err != nil {
+		return fmt.Errorf("TranslateText: %v", err)
+	}
+
+	// Display the translation for each input text provided
+	for _, translation := range resp.GetTranslations() {
+		fmt.Fprintf(w, "Translated text: %v\n", translation.GetTranslatedText())
+	}
+
+	return nil
+}
+
+// [END translate_v3_translate_text]

--- a/translate/v3/translate_text.go
+++ b/translate/v3/translate_text.go
@@ -33,11 +33,11 @@ func translateText(w io.Writer, projectID string, sourceLang string, targetLang 
 	// text := "Text you wish to translate"
 
 	ctx := context.Background()
-	c, err := translate.NewTranslationClient(ctx)
+	client, err := translate.NewTranslationClient(ctx)
 	if err != nil {
 		return fmt.Errorf("NewTranslationClient: %v", err)
 	}
-	defer c.Close()
+	defer client.Close()
 
 	req := &translatepb.TranslateTextRequest{
 		Parent:             fmt.Sprintf("projects/%s/locations/global", projectID),
@@ -47,7 +47,7 @@ func translateText(w io.Writer, projectID string, sourceLang string, targetLang 
 		Contents:           []string{text},
 	}
 
-	resp, err := c.TranslateText(ctx, req)
+	resp, err := client.TranslateText(ctx, req)
 	if err != nil {
 		return fmt.Errorf("TranslateText: %v", err)
 	}

--- a/translate/v3/translate_text.go
+++ b/translate/v3/translate_text.go
@@ -27,7 +27,7 @@ import (
 
 // translateText translates input text and returns translated text.
 func translateText(w io.Writer, projectID string, sourceLang string, targetLang string, text string) error {
-	// projectID := "your-google-cloud-project-id"
+	// projectID := "my-project-id"
 	// sourceLang := "en-US"
 	// targetLang := "fr"
 	// text := "Text you wish to translate"

--- a/translate/v3/translate_text_test.go
+++ b/translate/v3/translate_text_test.go
@@ -35,6 +35,6 @@ func TestTranslateText(t *testing.T) {
 		t.Fatalf("translateText: %v", err)
 	}
 	if got, want1, want2 := buf.String(), "Zdravo svet", "Pozdrav svijetu"; !strings.Contains(got, want1) && !strings.Contains(got, want2) {
-		t.Fatalf("translateText got:\n----\n%s----\nWant to contain:\n----\n%s\n----\nOR\n----\n%s\n----", got, want1, want2)
+		t.Errorf("translateText got:\n----\n%s----\nWant to contain:\n----\n%s\n----\nOR\n----\n%s\n----", got, want1, want2)
 	}
 }

--- a/translate/v3/translate_text_test.go
+++ b/translate/v3/translate_text_test.go
@@ -25,19 +25,16 @@ import (
 func TestTranslateText(t *testing.T) {
 	tc := testutil.SystemTest(t)
 
-	var buf bytes.Buffer
-	var got string
-
 	sourceLang := "en-US"
 	targetLang := "sr-Latn"
 	text := "Hello world"
 
 	// Translate text.
+	var buf bytes.Buffer
 	if err := translateText(&buf, tc.ProjectID, sourceLang, targetLang, text); err != nil {
 		t.Fatalf("translateText: %v", err)
 	}
-	got = buf.String()
-	if !strings.Contains(got, "Zdravo svet") && !strings.Contains(got, "Pozdrav svijetu") {
-		t.Fatalf("Got '%s', expected to contain 'Zdravo svet' or 'Pozdrav svijetu'", got)
+	if got, want1, want2 := buf.String(), "Zdravo svet", "Pozdrav svijetu"; !strings.Contains(got, want1) && !strings.Contains(got, want2) {
+		t.Fatalf("translateText got:\n----\n%s----\nWant to contain:\n----\n%s\n----\nOR\n----\n%s\n----", got, want1, want2)
 	}
 }

--- a/translate/v3/translate_text_test.go
+++ b/translate/v3/translate_text_test.go
@@ -1,0 +1,43 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+)
+
+func TestTranslateText(t *testing.T) {
+	tc := testutil.SystemTest(t)
+
+	var buf bytes.Buffer
+	var got string
+
+	sourceLang := "en-US"
+	targetLang := "sr-Latn"
+	text := "Hello world"
+
+	// Translate text.
+	if err := translateText(&buf, tc.ProjectID, sourceLang, targetLang, text); err != nil {
+		t.Fatalf("translateText: %v", err)
+	}
+	got = buf.String()
+	if !strings.Contains(got, "Zdravo svet") && !strings.Contains(got, "Pozdrav svijetu") {
+		t.Fatalf("Got '%s', expected to contain 'Zdravo svet' or 'Pozdrav svijetu'", got)
+	}
+}

--- a/translate/v3/translate_text_with_glossary.go
+++ b/translate/v3/translate_text_with_glossary.go
@@ -35,11 +35,11 @@ func translateTextWithGlossary(w io.Writer, projectID string, location string, s
 	// glossaryID := "your-glossary-id"
 
 	ctx := context.Background()
-	c, err := translate.NewTranslationClient(ctx)
+	client, err := translate.NewTranslationClient(ctx)
 	if err != nil {
 		return fmt.Errorf("NewTranslationClient: %v", err)
 	}
-	defer c.Close()
+	defer client.Close()
 
 	req := &translatepb.TranslateTextRequest{
 		Parent:             fmt.Sprintf("projects/%s/locations/%s", projectID, location),
@@ -52,7 +52,7 @@ func translateTextWithGlossary(w io.Writer, projectID string, location string, s
 		},
 	}
 
-	resp, err := c.TranslateText(ctx, req)
+	resp, err := client.TranslateText(ctx, req)
 	if err != nil {
 		return fmt.Errorf("TranslateText: %v", err)
 	}

--- a/translate/v3/translate_text_with_glossary.go
+++ b/translate/v3/translate_text_with_glossary.go
@@ -26,16 +26,8 @@ import (
 )
 
 // translateTextWithGlossary translates input text and returns translated text.
-func translateTextWithGlossary(
-	w io.Writer,
-	projectID string,
-	location string,
-	sourceLang string,
-	targetLang string,
-	text string,
-	glossaryID string,
-) error {
-	// projectID := "your-google-cloud-project-id"
+func translateTextWithGlossary(w io.Writer, projectID string, location string, sourceLang string, targetLang string, text string, glossaryID string) error {
+	// projectID := "my-project-id"
 	// location := "us-central1"
 	// sourceLang := "en"
 	// targetLang := "ja"

--- a/translate/v3/translate_text_with_glossary.go
+++ b/translate/v3/translate_text_with_glossary.go
@@ -1,0 +1,76 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package v3 contains samples for Google Cloud Translation API v3.
+package v3
+
+// [START translate_v3_translate_text_with_glossary]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	translate "cloud.google.com/go/translate/apiv3"
+	translatepb "google.golang.org/genproto/googleapis/cloud/translate/v3"
+)
+
+// translateTextWithGlossary translates input text and returns translated text.
+func translateTextWithGlossary(
+	w io.Writer,
+	projectID string,
+	location string,
+	sourceLang string,
+	targetLang string,
+	text string,
+	glossaryID string,
+) error {
+	// projectID := "your-google-cloud-project-id"
+	// location := "us-central1"
+	// sourceLang := "en"
+	// targetLang := "ja"
+	// text := "Hello world"
+	// glossaryID := "your-glossary-id"
+
+	ctx := context.Background()
+	c, err := translate.NewTranslationClient(ctx)
+	if err != nil {
+		return fmt.Errorf("NewTranslationClient: %v", err)
+	}
+	defer c.Close()
+
+	req := &translatepb.TranslateTextRequest{
+		Parent:             fmt.Sprintf("projects/%s/locations/%s", projectID, location),
+		SourceLanguageCode: sourceLang,
+		TargetLanguageCode: targetLang,
+		MimeType:           "text/plain", // Mime types: "text/plain", "text/html"
+		Contents:           []string{text},
+		GlossaryConfig: &translatepb.TranslateTextGlossaryConfig{
+			Glossary: fmt.Sprintf("projects/%s/locations/%s/glossaries/%s", projectID, location, glossaryID),
+		},
+	}
+
+	resp, err := c.TranslateText(ctx, req)
+	if err != nil {
+		return fmt.Errorf("TranslateText: %v", err)
+	}
+
+	// Display the translation for each input text provided
+	for _, translation := range resp.GetTranslations() {
+		fmt.Fprintf(w, "Translated text: %v\n", translation.GetTranslatedText())
+	}
+
+	return nil
+}
+
+// [END translate_v3_translate_text_with_glossary]

--- a/translate/v3/translate_text_with_glossary_and_model.go
+++ b/translate/v3/translate_text_with_glossary_and_model.go
@@ -26,17 +26,8 @@ import (
 )
 
 // translateTextWithGlossaryAndModel translates input text and returns translated text.
-func translateTextWithGlossaryAndModel(
-	w io.Writer,
-	projectID string,
-	location string,
-	sourceLang string,
-	targetLang string,
-	text string,
-	glossaryID string,
-	modelID string,
-) error {
-	// projectID := "your-google-cloud-project-id"
+func translateTextWithGlossaryAndModel(w io.Writer, projectID string, location string, sourceLang string, targetLang string, text string, glossaryID string, modelID string) error {
+	// projectID := "my-project-id"
 	// location := "us-central1"
 	// sourceLang := "en"
 	// targetLang := "ja"

--- a/translate/v3/translate_text_with_glossary_and_model.go
+++ b/translate/v3/translate_text_with_glossary_and_model.go
@@ -36,11 +36,11 @@ func translateTextWithGlossaryAndModel(w io.Writer, projectID string, location s
 	// modelID := "your-model-id"
 
 	ctx := context.Background()
-	c, err := translate.NewTranslationClient(ctx)
+	client, err := translate.NewTranslationClient(ctx)
 	if err != nil {
 		return fmt.Errorf("NewTranslationClient: %v", err)
 	}
-	defer c.Close()
+	defer client.Close()
 
 	req := &translatepb.TranslateTextRequest{
 		Parent:             fmt.Sprintf("projects/%s/locations/%s", projectID, location),
@@ -54,7 +54,7 @@ func translateTextWithGlossaryAndModel(w io.Writer, projectID string, location s
 		Model: fmt.Sprintf("projects/%s/locations/%s/models/%s", projectID, location, modelID),
 	}
 
-	resp, err := c.TranslateText(ctx, req)
+	resp, err := client.TranslateText(ctx, req)
 	if err != nil {
 		return fmt.Errorf("TranslateText: %v", err)
 	}

--- a/translate/v3/translate_text_with_glossary_and_model.go
+++ b/translate/v3/translate_text_with_glossary_and_model.go
@@ -1,0 +1,79 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package v3 contains samples for Google Cloud Translation API v3.
+package v3
+
+// [START translate_v3_translate_text_with_glossary_and_model]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	translate "cloud.google.com/go/translate/apiv3"
+	translatepb "google.golang.org/genproto/googleapis/cloud/translate/v3"
+)
+
+// translateTextWithGlossaryAndModel translates input text and returns translated text.
+func translateTextWithGlossaryAndModel(
+	w io.Writer,
+	projectID string,
+	location string,
+	sourceLang string,
+	targetLang string,
+	text string,
+	glossaryID string,
+	modelID string,
+) error {
+	// projectID := "your-google-cloud-project-id"
+	// location := "us-central1"
+	// sourceLang := "en"
+	// targetLang := "ja"
+	// text := "Hello world"
+	// glossaryID := "your-glossary-id"
+	// modelID := "your-model-id"
+
+	ctx := context.Background()
+	c, err := translate.NewTranslationClient(ctx)
+	if err != nil {
+		return fmt.Errorf("NewTranslationClient: %v", err)
+	}
+	defer c.Close()
+
+	req := &translatepb.TranslateTextRequest{
+		Parent:             fmt.Sprintf("projects/%s/locations/%s", projectID, location),
+		SourceLanguageCode: sourceLang,
+		TargetLanguageCode: targetLang,
+		MimeType:           "text/plain", // Mime types: "text/plain", "text/html"
+		Contents:           []string{text},
+		GlossaryConfig: &translatepb.TranslateTextGlossaryConfig{
+			Glossary: fmt.Sprintf("projects/%s/locations/%s/glossaries/%s", projectID, location, glossaryID),
+		},
+		Model: fmt.Sprintf("projects/%s/locations/%s/models/%s", projectID, location, modelID),
+	}
+
+	resp, err := c.TranslateText(ctx, req)
+	if err != nil {
+		return fmt.Errorf("TranslateText: %v", err)
+	}
+
+	// Display the translation for each input text provided
+	for _, translation := range resp.GetTranslations() {
+		fmt.Fprintf(w, "Translated text: %v\n", translation.GetTranslatedText())
+	}
+
+	return nil
+}
+
+// [END translate_v3_translate_text_with_glossary_and_model]

--- a/translate/v3/translate_text_with_glossary_and_model_test.go
+++ b/translate/v3/translate_text_with_glossary_and_model_test.go
@@ -1,0 +1,72 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+	"github.com/google/uuid"
+)
+
+func TestTranslateTextWithGlossaryAndModel(t *testing.T) {
+	tc := testutil.SystemTest(t)
+
+	var buf bytes.Buffer
+	var got string
+
+	location := "us-central1"
+	sourceLang := "en"
+	targetLang := "ja"
+	text := "That' il do it. deception"
+	glossaryID := fmt.Sprintf("translate_text_with_glossary_and_model-%v", uuid.New().ID())
+	glossaryInputURI := "gs://cloud-samples-data/translation/glossary_ja.csv"
+	modelID := "TRL3128559826197068699"
+
+	// Create a glossary.
+	if err := createGlossary(&buf, tc.ProjectID, location, glossaryID, glossaryInputURI); err != nil {
+		t.Fatalf("createGlossary: %v", err)
+	}
+	defer deleteGlossary(&buf, tc.ProjectID, location, glossaryID)
+
+	// Translate text.
+	if err := translateTextWithGlossaryAndModel(
+		&buf,
+		tc.ProjectID,
+		location,
+		sourceLang,
+		targetLang,
+		text,
+		glossaryID,
+		modelID,
+	); err != nil {
+		t.Fatalf("translateTextWithGlossaryAndModel: %v", err)
+	}
+
+	got = buf.String()
+
+	// Custom model.
+	if !strings.Contains(got, "それはそうだ") && !strings.Contains(got, "それじゃあ") {
+		t.Fatalf("Got '%s', expected to contain 'それはそうだ' or 'それじゃあ'", got)
+	}
+
+	// Glossary.
+	if !strings.Contains(got, "欺く") {
+		t.Fatalf("Got '%s', expected to contain '欺く'", got)
+	}
+}

--- a/translate/v3/translate_text_with_glossary_and_model_test.go
+++ b/translate/v3/translate_text_with_glossary_and_model_test.go
@@ -27,9 +27,6 @@ import (
 func TestTranslateTextWithGlossaryAndModel(t *testing.T) {
 	tc := testutil.SystemTest(t)
 
-	var buf bytes.Buffer
-	var got string
-
 	location := "us-central1"
 	sourceLang := "en"
 	targetLang := "ja"
@@ -39,6 +36,7 @@ func TestTranslateTextWithGlossaryAndModel(t *testing.T) {
 	modelID := "TRL3128559826197068699"
 
 	// Create a glossary.
+	var buf bytes.Buffer
 	if err := createGlossary(&buf, tc.ProjectID, location, glossaryID, glossaryInputURI); err != nil {
 		t.Fatalf("createGlossary: %v", err)
 	}
@@ -49,15 +47,13 @@ func TestTranslateTextWithGlossaryAndModel(t *testing.T) {
 		t.Fatalf("translateTextWithGlossaryAndModel: %v", err)
 	}
 
-	got = buf.String()
-
 	// Custom model.
-	if !strings.Contains(got, "それはそうだ") && !strings.Contains(got, "それじゃあ") {
-		t.Fatalf("Got '%s', expected to contain 'それはそうだ' or 'それじゃあ'", got)
+	if got, want1, want2 := buf.String(), "それはそうだ", "それじゃあ"; !strings.Contains(got, want1) && !strings.Contains(got, want2) {
+		t.Fatalf("translateTextWithGlossaryAndModel got:\n----\n%s----\nWant to contain:\n----\n%s\n----\nOR\n----\n%s\n----", got, want1, want2)
 	}
 
 	// Glossary.
-	if !strings.Contains(got, "欺く") {
-		t.Fatalf("Got '%s', expected to contain '欺く'", got)
+	if got, want := buf.String(), "欺く"; !strings.Contains(got, want) {
+		t.Fatalf("translateTextWithGlossaryAndModel got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 	}
 }

--- a/translate/v3/translate_text_with_glossary_and_model_test.go
+++ b/translate/v3/translate_text_with_glossary_and_model_test.go
@@ -45,16 +45,7 @@ func TestTranslateTextWithGlossaryAndModel(t *testing.T) {
 	defer deleteGlossary(&buf, tc.ProjectID, location, glossaryID)
 
 	// Translate text.
-	if err := translateTextWithGlossaryAndModel(
-		&buf,
-		tc.ProjectID,
-		location,
-		sourceLang,
-		targetLang,
-		text,
-		glossaryID,
-		modelID,
-	); err != nil {
+	if err := translateTextWithGlossaryAndModel(&buf, tc.ProjectID, location, sourceLang, targetLang, text, glossaryID, modelID); err != nil {
 		t.Fatalf("translateTextWithGlossaryAndModel: %v", err)
 	}
 

--- a/translate/v3/translate_text_with_glossary_and_model_test.go
+++ b/translate/v3/translate_text_with_glossary_and_model_test.go
@@ -14,46 +14,48 @@
 
 package v3
 
-import (
-	"bytes"
-	"fmt"
-	"strings"
-	"testing"
+// TODO: uncomment this test once the AutoML model is set in the testing projects.
 
-	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-	"github.com/google/uuid"
-)
+// import (
+// 	"bytes"
+// 	"fmt"
+// 	"strings"
+// 	"testing"
 
-func TestTranslateTextWithGlossaryAndModel(t *testing.T) {
-	tc := testutil.SystemTest(t)
+// 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+// 	"github.com/google/uuid"
+// )
 
-	location := "us-central1"
-	sourceLang := "en"
-	targetLang := "ja"
-	text := "That' il do it. deception"
-	glossaryID := fmt.Sprintf("translate_text_with_glossary_and_model-%v", uuid.New().ID())
-	glossaryInputURI := "gs://cloud-samples-data/translation/glossary_ja.csv"
-	modelID := "TRL3128559826197068699"
+// func TestTranslateTextWithGlossaryAndModel(t *testing.T) {
+// 	tc := testutil.SystemTest(t)
 
-	// Create a glossary.
-	var buf bytes.Buffer
-	if err := createGlossary(&buf, tc.ProjectID, location, glossaryID, glossaryInputURI); err != nil {
-		t.Fatalf("createGlossary: %v", err)
-	}
-	defer deleteGlossary(&buf, tc.ProjectID, location, glossaryID)
+// 	location := "us-central1"
+// 	sourceLang := "en"
+// 	targetLang := "ja"
+// 	text := "That' il do it. deception"
+// 	glossaryID := fmt.Sprintf("translate_text_with_glossary_and_model-%v", uuid.New().ID())
+// 	glossaryInputURI := "gs://cloud-samples-data/translation/glossary_ja.csv"
+// 	modelID := "TRL3128559826197068699"
 
-	// Translate text.
-	if err := translateTextWithGlossaryAndModel(&buf, tc.ProjectID, location, sourceLang, targetLang, text, glossaryID, modelID); err != nil {
-		t.Fatalf("translateTextWithGlossaryAndModel: %v", err)
-	}
+// 	// Create a glossary.
+// 	var buf bytes.Buffer
+// 	if err := createGlossary(&buf, tc.ProjectID, location, glossaryID, glossaryInputURI); err != nil {
+// 		t.Fatalf("createGlossary: %v", err)
+// 	}
+// 	defer deleteGlossary(&buf, tc.ProjectID, location, glossaryID)
 
-	// Custom model.
-	if got, want1, want2 := buf.String(), "それはそうだ", "それじゃあ"; !strings.Contains(got, want1) && !strings.Contains(got, want2) {
-		t.Fatalf("translateTextWithGlossaryAndModel got:\n----\n%s----\nWant to contain:\n----\n%s\n----\nOR\n----\n%s\n----", got, want1, want2)
-	}
+// 	// Translate text.
+// 	if err := translateTextWithGlossaryAndModel(&buf, tc.ProjectID, location, sourceLang, targetLang, text, glossaryID, modelID); err != nil {
+// 		t.Fatalf("translateTextWithGlossaryAndModel: %v", err)
+// 	}
 
-	// Glossary.
-	if got, want := buf.String(), "欺く"; !strings.Contains(got, want) {
-		t.Fatalf("translateTextWithGlossaryAndModel got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
-	}
-}
+// 	// Custom model.
+// 	if got, want1, want2 := buf.String(), "それはそうだ", "それじゃあ"; !strings.Contains(got, want1) && !strings.Contains(got, want2) {
+// 		t.Fatalf("translateTextWithGlossaryAndModel got:\n----\n%s----\nWant to contain:\n----\n%s\n----\nOR\n----\n%s\n----", got, want1, want2)
+// 	}
+
+// 	// Glossary.
+// 	if got, want := buf.String(), "欺く"; !strings.Contains(got, want) {
+// 		t.Fatalf("translateTextWithGlossaryAndModel got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
+// 	}
+// }

--- a/translate/v3/translate_text_with_glossary_and_model_test.go
+++ b/translate/v3/translate_text_with_glossary_and_model_test.go
@@ -51,11 +51,11 @@ package v3
 
 // 	// Custom model.
 // 	if got, want1, want2 := buf.String(), "それはそうだ", "それじゃあ"; !strings.Contains(got, want1) && !strings.Contains(got, want2) {
-// 		t.Fatalf("translateTextWithGlossaryAndModel got:\n----\n%s----\nWant to contain:\n----\n%s\n----\nOR\n----\n%s\n----", got, want1, want2)
+// 		t.Errorf("translateTextWithGlossaryAndModel got:\n----\n%s----\nWant to contain:\n----\n%s\n----\nOR\n----\n%s\n----", got, want1, want2)
 // 	}
 
 // 	// Glossary.
 // 	if got, want := buf.String(), "欺く"; !strings.Contains(got, want) {
-// 		t.Fatalf("translateTextWithGlossaryAndModel got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
+// 		t.Errorf("translateTextWithGlossaryAndModel got:\n----\n%s----\nWant to contain:\n----\n%s\n----", got, want)
 // 	}
 // }

--- a/translate/v3/translate_text_with_glossary_test.go
+++ b/translate/v3/translate_text_with_glossary_test.go
@@ -44,15 +44,7 @@ func TestTranslateTextWithGlossary(t *testing.T) {
 	defer deleteGlossary(&buf, tc.ProjectID, location, glossaryID)
 
 	// Translate text.
-	if err := translateTextWithGlossary(
-		&buf,
-		tc.ProjectID,
-		location,
-		sourceLang,
-		targetLang,
-		text,
-		glossaryID,
-	); err != nil {
+	if err := translateTextWithGlossary(&buf, tc.ProjectID, location, sourceLang, targetLang, text, glossaryID); err != nil {
 		t.Fatalf("translateTextWithGlossary: %v", err)
 	}
 	got = buf.String()

--- a/translate/v3/translate_text_with_glossary_test.go
+++ b/translate/v3/translate_text_with_glossary_test.go
@@ -27,9 +27,6 @@ import (
 func TestTranslateTextWithGlossary(t *testing.T) {
 	tc := testutil.SystemTest(t)
 
-	var buf bytes.Buffer
-	var got string
-
 	location := "us-central1"
 	sourceLang := "en"
 	targetLang := "ja"
@@ -38,6 +35,7 @@ func TestTranslateTextWithGlossary(t *testing.T) {
 	glossaryInputURI := "gs://cloud-samples-data/translation/glossary_ja.csv"
 
 	// Create a glossary.
+	var buf bytes.Buffer
 	if err := createGlossary(&buf, tc.ProjectID, location, glossaryID, glossaryInputURI); err != nil {
 		t.Fatalf("createGlossary: %v", err)
 	}
@@ -47,8 +45,7 @@ func TestTranslateTextWithGlossary(t *testing.T) {
 	if err := translateTextWithGlossary(&buf, tc.ProjectID, location, sourceLang, targetLang, text, glossaryID); err != nil {
 		t.Fatalf("translateTextWithGlossary: %v", err)
 	}
-	got = buf.String()
-	if !strings.Contains(got, "アカウント") && !strings.Contains(got, "口座") {
-		t.Fatalf("Got '%s', expected to contain 'アカウント' or '口座'", got)
+	if got, want1, want2 := buf.String(), "アカウント", "口座"; !strings.Contains(got, want1) && !strings.Contains(got, want2) {
+		t.Fatalf("translateTextWithGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----\nOR\n----\n%s\n----", got, want1, want2)
 	}
 }

--- a/translate/v3/translate_text_with_glossary_test.go
+++ b/translate/v3/translate_text_with_glossary_test.go
@@ -46,6 +46,6 @@ func TestTranslateTextWithGlossary(t *testing.T) {
 		t.Fatalf("translateTextWithGlossary: %v", err)
 	}
 	if got, want1, want2 := buf.String(), "アカウント", "口座"; !strings.Contains(got, want1) && !strings.Contains(got, want2) {
-		t.Fatalf("translateTextWithGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----\nOR\n----\n%s\n----", got, want1, want2)
+		t.Errorf("translateTextWithGlossary got:\n----\n%s----\nWant to contain:\n----\n%s\n----\nOR\n----\n%s\n----", got, want1, want2)
 	}
 }

--- a/translate/v3/translate_text_with_glossary_test.go
+++ b/translate/v3/translate_text_with_glossary_test.go
@@ -1,0 +1,62 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+	"github.com/google/uuid"
+)
+
+func TestTranslateTextWithGlossary(t *testing.T) {
+	tc := testutil.SystemTest(t)
+
+	var buf bytes.Buffer
+	var got string
+
+	location := "us-central1"
+	sourceLang := "en"
+	targetLang := "ja"
+	text := "account"
+	glossaryID := fmt.Sprintf("translate_text_with_glossary-%v", uuid.New().ID())
+	glossaryInputURI := "gs://cloud-samples-data/translation/glossary_ja.csv"
+
+	// Create a glossary.
+	if err := createGlossary(&buf, tc.ProjectID, location, glossaryID, glossaryInputURI); err != nil {
+		t.Fatalf("createGlossary: %v", err)
+	}
+	defer deleteGlossary(&buf, tc.ProjectID, location, glossaryID)
+
+	// Translate text.
+	if err := translateTextWithGlossary(
+		&buf,
+		tc.ProjectID,
+		location,
+		sourceLang,
+		targetLang,
+		text,
+		glossaryID,
+	); err != nil {
+		t.Fatalf("translateTextWithGlossary: %v", err)
+	}
+	got = buf.String()
+	if !strings.Contains(got, "アカウント") && !strings.Contains(got, "口座") {
+		t.Fatalf("Got '%s', expected to contain 'アカウント' or '口座'", got)
+	}
+}

--- a/translate/v3/translate_text_with_model.go
+++ b/translate/v3/translate_text_with_model.go
@@ -26,16 +26,8 @@ import (
 )
 
 // translateTextWithModel translates input text and returns translated text.
-func translateTextWithModel(
-	w io.Writer,
-	projectID string,
-	location string,
-	sourceLang string,
-	targetLang string,
-	text string,
-	modelID string,
-) error {
-	// projectID := "your-google-cloud-project-id"
+func translateTextWithModel(w io.Writer, projectID string, location string, sourceLang string, targetLang string, text string, modelID string) error {
+	// projectID := "my-project-id"
 	// location := "us-central1"
 	// sourceLang := "en"
 	// targetLang := "fr"

--- a/translate/v3/translate_text_with_model.go
+++ b/translate/v3/translate_text_with_model.go
@@ -1,0 +1,74 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package v3 contains samples for Google Cloud Translation API v3.
+package v3
+
+// [START translate_v3_translate_text_with_model]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	translate "cloud.google.com/go/translate/apiv3"
+	translatepb "google.golang.org/genproto/googleapis/cloud/translate/v3"
+)
+
+// translateTextWithModel translates input text and returns translated text.
+func translateTextWithModel(
+	w io.Writer,
+	projectID string,
+	location string,
+	sourceLang string,
+	targetLang string,
+	text string,
+	modelID string,
+) error {
+	// projectID := "your-google-cloud-project-id"
+	// location := "us-central1"
+	// sourceLang := "en"
+	// targetLang := "fr"
+	// text := "Hello, world!"
+	// modelID := "your-model-id"
+
+	ctx := context.Background()
+	c, err := translate.NewTranslationClient(ctx)
+	if err != nil {
+		return fmt.Errorf("NewTranslationClient: %v", err)
+	}
+	defer c.Close()
+
+	req := &translatepb.TranslateTextRequest{
+		Parent:             fmt.Sprintf("projects/%s/locations/%s", projectID, location),
+		SourceLanguageCode: sourceLang,
+		TargetLanguageCode: targetLang,
+		MimeType:           "text/plain", // Mime types: "text/plain", "text/html"
+		Contents:           []string{text},
+		Model:              fmt.Sprintf("projects/%s/locations/%s/models/%s", projectID, location, modelID),
+	}
+
+	resp, err := c.TranslateText(ctx, req)
+	if err != nil {
+		return fmt.Errorf("TranslateText: %v", err)
+	}
+
+	// Display the translation for each input text provided
+	for _, translation := range resp.GetTranslations() {
+		fmt.Fprintf(w, "Translated text: %v\n", translation.GetTranslatedText())
+	}
+
+	return nil
+}
+
+// [END translate_v3_translate_text_with_model]

--- a/translate/v3/translate_text_with_model.go
+++ b/translate/v3/translate_text_with_model.go
@@ -35,11 +35,11 @@ func translateTextWithModel(w io.Writer, projectID string, location string, sour
 	// modelID := "your-model-id"
 
 	ctx := context.Background()
-	c, err := translate.NewTranslationClient(ctx)
+	client, err := translate.NewTranslationClient(ctx)
 	if err != nil {
 		return fmt.Errorf("NewTranslationClient: %v", err)
 	}
-	defer c.Close()
+	defer client.Close()
 
 	req := &translatepb.TranslateTextRequest{
 		Parent:             fmt.Sprintf("projects/%s/locations/%s", projectID, location),
@@ -50,7 +50,7 @@ func translateTextWithModel(w io.Writer, projectID string, location string, sour
 		Model:              fmt.Sprintf("projects/%s/locations/%s/models/%s", projectID, location, modelID),
 	}
 
-	resp, err := c.TranslateText(ctx, req)
+	resp, err := client.TranslateText(ctx, req)
 	if err != nil {
 		return fmt.Errorf("TranslateText: %v", err)
 	}

--- a/translate/v3/translate_text_with_model_test.go
+++ b/translate/v3/translate_text_with_model_test.go
@@ -1,0 +1,45 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+)
+
+func TestTranslateTextWithModel(t *testing.T) {
+	tc := testutil.SystemTest(t)
+
+	var buf bytes.Buffer
+	var got string
+
+	location := "us-central1"
+	sourceLang := "en"
+	targetLang := "ja"
+	text := "That' il do it."
+	modelID := "TRL3128559826197068699"
+
+	// Translate text.
+	if err := translateTextWithModel(&buf, tc.ProjectID, location, sourceLang, targetLang, text, modelID); err != nil {
+		t.Fatalf("translateTextWithModel: %v", err)
+	}
+	got = buf.String()
+	if !strings.Contains(got, "それはそうだ") && !strings.Contains(got, "それじゃあ") {
+		t.Fatalf("Got '%s', expected to contain 'それはそうだ' or 'それじゃあ'", got)
+	}
+}

--- a/translate/v3/translate_text_with_model_test.go
+++ b/translate/v3/translate_text_with_model_test.go
@@ -39,6 +39,6 @@ package v3
 // 		t.Fatalf("translateTextWithModel: %v", err)
 // 	}
 // 	if got, want1, want2 := buf.String(), "それはそうだ", "それじゃあ"; !strings.Contains(got, want1) && !strings.Contains(got, want2) {
-// 		t.Fatalf("translateTextWithModel got:\n----\n%s----\nWant to contain:\n----\n%s\n----\nOR\n----\n%s\n----", got, want1, want2)
+// 		t.Errorf("translateTextWithModel got:\n----\n%s----\nWant to contain:\n----\n%s\n----\nOR\n----\n%s\n----", got, want1, want2)
 // 	}
 // }

--- a/translate/v3/translate_text_with_model_test.go
+++ b/translate/v3/translate_text_with_model_test.go
@@ -25,9 +25,6 @@ import (
 func TestTranslateTextWithModel(t *testing.T) {
 	tc := testutil.SystemTest(t)
 
-	var buf bytes.Buffer
-	var got string
-
 	location := "us-central1"
 	sourceLang := "en"
 	targetLang := "ja"
@@ -35,11 +32,11 @@ func TestTranslateTextWithModel(t *testing.T) {
 	modelID := "TRL3128559826197068699"
 
 	// Translate text.
+	var buf bytes.Buffer
 	if err := translateTextWithModel(&buf, tc.ProjectID, location, sourceLang, targetLang, text, modelID); err != nil {
 		t.Fatalf("translateTextWithModel: %v", err)
 	}
-	got = buf.String()
-	if !strings.Contains(got, "それはそうだ") && !strings.Contains(got, "それじゃあ") {
-		t.Fatalf("Got '%s', expected to contain 'それはそうだ' or 'それじゃあ'", got)
+	if got, want1, want2 := buf.String(), "それはそうだ", "それじゃあ"; !strings.Contains(got, want1) && !strings.Contains(got, want2) {
+		t.Fatalf("translateTextWithModel got:\n----\n%s----\nWant to contain:\n----\n%s\n----\nOR\n----\n%s\n----", got, want1, want2)
 	}
 }

--- a/translate/v3/translate_text_with_model_test.go
+++ b/translate/v3/translate_text_with_model_test.go
@@ -14,29 +14,31 @@
 
 package v3
 
-import (
-	"bytes"
-	"strings"
-	"testing"
+// TODO: uncomment this test once the AutoML model is set in the testing projects.
 
-	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-)
+// import (
+// 	"bytes"
+// 	"strings"
+// 	"testing"
 
-func TestTranslateTextWithModel(t *testing.T) {
-	tc := testutil.SystemTest(t)
+// 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+// )
 
-	location := "us-central1"
-	sourceLang := "en"
-	targetLang := "ja"
-	text := "That' il do it."
-	modelID := "TRL3128559826197068699"
+// func TestTranslateTextWithModel(t *testing.T) {
+// 	tc := testutil.SystemTest(t)
 
-	// Translate text.
-	var buf bytes.Buffer
-	if err := translateTextWithModel(&buf, tc.ProjectID, location, sourceLang, targetLang, text, modelID); err != nil {
-		t.Fatalf("translateTextWithModel: %v", err)
-	}
-	if got, want1, want2 := buf.String(), "それはそうだ", "それじゃあ"; !strings.Contains(got, want1) && !strings.Contains(got, want2) {
-		t.Fatalf("translateTextWithModel got:\n----\n%s----\nWant to contain:\n----\n%s\n----\nOR\n----\n%s\n----", got, want1, want2)
-	}
-}
+// 	location := "us-central1"
+// 	sourceLang := "en"
+// 	targetLang := "ja"
+// 	text := "That' il do it."
+// 	modelID := "TRL3128559826197068699"
+
+// 	// Translate text.
+// 	var buf bytes.Buffer
+// 	if err := translateTextWithModel(&buf, tc.ProjectID, location, sourceLang, targetLang, text, modelID); err != nil {
+// 		t.Fatalf("translateTextWithModel: %v", err)
+// 	}
+// 	if got, want1, want2 := buf.String(), "それはそうだ", "それじゃあ"; !strings.Contains(got, want1) && !strings.Contains(got, want2) {
+// 		t.Fatalf("translateTextWithModel got:\n----\n%s----\nWant to contain:\n----\n%s\n----\nOR\n----\n%s\n----", got, want1, want2)
+// 	}
+// }


### PR DESCRIPTION
Adding tests for [translate v3](https://cloud.google.com/translate/docs/intro-to-v3).

[Python canonicals](https://github.com/munkhuushmgl/python-docs-samples/tree/345425637eceb3b46795e39babe09133cc1cf4ae/translate/cloud-client)

> **Note:** Tests involving custom models will be failing until we create the AutoML models on all the testing projects in GCP.
> In the meantime, the code *should* be working (tested locally successfully) so it's ready for review.
> We can merge after creating the AutoML models and confirm all tests pass.