### PR TITLE
testing: don't test .md or deleted dirs

### DIFF
--- a/testing/kokoro/system_tests.sh
+++ b/testing/kokoro/system_tests.sh
@@ -16,14 +16,32 @@
 
 set -e
 
+go version
+date
+
+CHANGES=$(git --no-pager diff --name-only HEAD..master)
+SIGNIFICANT_CHANGES=$(echo $CHANGES | tr ' ' '\n' | egrep -v '(\.md$|^\.github)')
+
+# If this is a PR with only insignificant changes, don't run any tests.
+if [[ -n ${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-} ]] && [[ -z "$SIGNIFICANT_CHANGES" ]]; then
+  echo "No big changes. Not running any tests."
+  exit 0
+fi
+
 export GO111MODULE=on # Always use modules.
 export GOPROXY=https://proxy.golang.org
 
 export GOLANG_SAMPLES_KMS_KEYRING=ring1
 export GOLANG_SAMPLES_KMS_CRYPTOKEY=key1
+
 export GOLANG_SAMPLES_IOT_PUB=$KOKORO_GFILE_DIR/rsa_cert.pem
 export GOLANG_SAMPLES_IOT_PRIV=$KOKORO_GFILE_DIR/rsa_private.pem
+
 export GCLOUD_ORGANIZATION=1081635000895
+
+export GOLANG_SAMPLES_SPANNER=projects/golang-samples-tests/instances/golang-samples-tests
+export GOLANG_SAMPLES_BIGTABLE_PROJECT=golang-samples-tests
+export GOLANG_SAMPLES_BIGTABLE_INSTANCE=testing-instance
 
 TIMEOUT=45m
 
@@ -37,20 +55,18 @@ if [ -z "$GOLANG_SAMPLES_PROJECT_ID" ]; then
   exit 1
 fi
 echo "Running tests in project $GOLANG_SAMPLES_PROJECT_ID";
-trap "gimmeproj -project golang-samples-tests done $GOLANG_SAMPLES_PROJECT_ID" EXIT
+
+# Always return the project and clean the cache so Kokoro doesn't try to copy
+# it when exiting.
+trap "go clean -modcache; gimmeproj -project golang-samples-tests done $GOLANG_SAMPLES_PROJECT_ID" EXIT
 
 # Set application credentials to the project-specific account. Some APIs do not
 # allow the service account project and GOOGLE_CLOUD_PROJECT to be different.
 export GOOGLE_APPLICATION_CREDENTIALS=$KOKORO_KEYSTORE_DIR/71386_kokoro-$GOLANG_SAMPLES_PROJECT_ID
+export GOLANG_SAMPLES_SERVICE_ACCOUNT_EMAIL=kokoro-$GOLANG_SAMPLES_PROJECT_ID@$GOLANG_SAMPLES_PROJECT_ID.iam.gserviceaccount.com
 
 set -x
 
-export GOLANG_SAMPLES_SPANNER=projects/golang-samples-tests/instances/golang-samples-tests
-export GOLANG_SAMPLES_SERVICE_ACCOUNT_EMAIL=kokoro-$GOLANG_SAMPLES_PROJECT_ID@$GOLANG_SAMPLES_PROJECT_ID.iam.gserviceaccount.com
-export GOLANG_SAMPLES_BIGTABLE_PROJECT=golang-samples-tests
-export GOLANG_SAMPLES_BIGTABLE_INSTANCE=testing-instance
-
-go version
 date
 
 # Re-organize files
@@ -73,18 +89,30 @@ if [ -z ${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-} ]; then
   RUN_ALL_TESTS="1"
 fi
 
-# CHANGED_DIRS is the list of top-level directories that changed. CHANGED_DIRS will be empty when run on master.
-CHANGED_DIRS=$(git --no-pager diff --name-only HEAD..master | grep "/" | cut -d/ -f1 | sort | uniq || true)
+# CHANGED_DIRS is the list of significant top-level directories that changed.
+# CHANGED_DIRS will be empty when run on master.
+CHANGED_DIRS=$(echo $SIGNIFICANT_CHANGES | tr ' ' '\n' | grep "/" | cut -d/ -f1 | sort -u)
 # If test configuration is changed, run all tests.
 if [[ $CHANGED_DIRS =~ "testing" || $CHANGED_DIRS =~ "internal" ]]; then
   RUN_ALL_TESTS="1"
 fi
 
+# Filter out directories that don't exist (the current PR deleted them).
+TARGET_DIRS=""
+for d in "$CHANGED_DIRS"; do
+  if [ -d "$d" ]; then
+    TARGET_DIRS="$TARGET_DIRS $d"
+  fi
+done
+
 if [[ $RUN_ALL_TESTS = "1" ]]; then
   TARGET="./..."
   echo "Running all tests"
+elif [[ -z "${TARGET_DIRS// }" ]]; then
+  TARGET=""
+  echo "Only running root tests"
 else
-  TARGET=$(printf "./%s/... " $CHANGED_DIRS)
+  TARGET=$(printf "./%s/... " $TARGET_DIRS)
   echo "Running tests in modified directories: $TARGET"
 fi
 
@@ -98,10 +126,5 @@ date
 
 OUTFILE=gotest.out
 2>&1 go test -timeout $TIMEOUT -v . $TARGET | tee $OUTFILE
-
-# Clear the cache so Kokoro doesn't try to copy it.
-# Must happen before calling go-junit-report since it can cause a non-zero exit
-# code, stopping execution.
-go clean -modcache
 
 cat $OUTFILE | /go/bin/go-junit-report -set-exit-code > sponge_log.xml

--- a/testing/kokoro/system_tests.sh
+++ b/testing/kokoro/system_tests.sh
@@ -19,6 +19,13 @@ set -e
 go version
 date
 
+# Re-organize files
+export GOPATH=$PWD/gopath
+target=$GOPATH/src/github.com/GoogleCloudPlatform
+mkdir -p $target
+mv github/golang-samples $target
+cd $target/golang-samples
+
 CHANGES=$(git --no-pager diff --name-only HEAD..master)
 SIGNIFICANT_CHANGES=$(echo $CHANGES | tr ' ' '\n' | egrep -v '(\.md$|^\.github)')
 
@@ -67,14 +74,8 @@ export GOLANG_SAMPLES_SERVICE_ACCOUNT_EMAIL=kokoro-$GOLANG_SAMPLES_PROJECT_ID@$G
 
 set -x
 
+pwd
 date
-
-# Re-organize files
-export GOPATH=$PWD/gopath
-target=$GOPATH/src/github.com/GoogleCloudPlatform
-mkdir -p $target
-mv github/golang-samples $target
-cd $target/golang-samples
 
 if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"system-tests"* && -n $GOLANG_SAMPLES_GO_VET ]]; then
   echo "This test run will run end-to-end tests.";


### PR DESCRIPTION
- Don't run Go tests when we only change .md or .github files.
- Don't run tests on deleted files.
- Clean the cache in the trap. Before, a test timeout would cause cache
issues.
- Properly handle changes only in the root dir.