### PR TITLE
testing: more logging, check changes before trampoline

### DIFF
--- a/testing/kokoro/system_tests.sh
+++ b/testing/kokoro/system_tests.sh
@@ -16,6 +16,8 @@
 
 set -e
 
+set -x
+
 go version
 date
 
@@ -26,17 +28,10 @@ mkdir -p $target
 mv github/golang-samples $target
 cd $target/golang-samples
 
-CHANGES=$(git --no-pager diff --name-only HEAD..master)
-SIGNIFICANT_CHANGES=$(echo $CHANGES | tr ' ' '\n' | egrep -v '(\.md$|^\.github)')
-
-# If this is a PR with only insignificant changes, don't run any tests.
-if [[ -n ${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-} ]] && [[ -z "$SIGNIFICANT_CHANGES" ]]; then
-  echo "No big changes. Not running any tests."
-  exit 0
-fi
-
 export GO111MODULE=on # Always use modules.
 export GOPROXY=https://proxy.golang.org
+
+set +x
 
 export GOLANG_SAMPLES_KMS_KEYRING=ring1
 export GOLANG_SAMPLES_KMS_CRYPTOKEY=key1
@@ -49,6 +44,8 @@ export GCLOUD_ORGANIZATION=1081635000895
 export GOLANG_SAMPLES_SPANNER=projects/golang-samples-tests/instances/golang-samples-tests
 export GOLANG_SAMPLES_BIGTABLE_PROJECT=golang-samples-tests
 export GOLANG_SAMPLES_BIGTABLE_INSTANCE=testing-instance
+
+set -x
 
 TIMEOUT=45m
 
@@ -66,6 +63,8 @@ echo "Running tests in project $GOLANG_SAMPLES_PROJECT_ID";
 # Always return the project and clean the cache so Kokoro doesn't try to copy
 # it when exiting.
 trap "go clean -modcache; gimmeproj -project golang-samples-tests done $GOLANG_SAMPLES_PROJECT_ID" EXIT
+
+set +x
 
 # Set application credentials to the project-specific account. Some APIs do not
 # allow the service account project and GOOGLE_CLOUD_PROJECT to be different.
@@ -92,7 +91,9 @@ fi
 
 # CHANGED_DIRS is the list of significant top-level directories that changed.
 # CHANGED_DIRS will be empty when run on master.
-CHANGED_DIRS=$(echo $SIGNIFICANT_CHANGES | tr ' ' '\n' | grep "/" | cut -d/ -f1 | sort -u)
+# Also see trampoline.sh - system_tests.sh is only run when there are
+# significant changes.
+CHANGED_DIRS=$(git --no-pager diff --name-only HEAD..master | egrep -v '(\.md$|^\.github)' | grep "/" | cut -d/ -f1 | sort -u)
 # If test configuration is changed, run all tests.
 if [[ $CHANGED_DIRS =~ "testing" || $CHANGED_DIRS =~ "internal" ]]; then
   RUN_ALL_TESTS="1"

--- a/testing/kokoro/system_tests.sh
+++ b/testing/kokoro/system_tests.sh
@@ -31,6 +31,8 @@ cd $target/golang-samples
 export GO111MODULE=on # Always use modules.
 export GOPROXY=https://proxy.golang.org
 
+# Don't print environment variables in case there are secrets.
+# If you need a secret, use a keystore_resource in common.cfg.
 set +x
 
 export GOLANG_SAMPLES_KMS_KEYRING=ring1

--- a/testing/kokoro/trampoline.sh
+++ b/testing/kokoro/trampoline.sh
@@ -14,4 +14,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -x
+
+date
+
+cd github/golang-samples
+
+# SIGNIFICANT_CHANGES="$(git --no-pager diff --name-only HEAD..master | egrep -v '(\.md$|^\.github)' || true)"
+SIGNIFICANT_CHANGES="$(echo ".github/renovate.json" | egrep -v '(\.md$|^\.github)' || true)" # DO NOT SUBMIT
+
+# If this is a PR with only insignificant changes, don't run any tests.
+if [[ -n ${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-} ]] && [[ -z "$SIGNIFICANT_CHANGES" ]]; then
+  echo "No big changes. Not running any tests."
+  exit 0
+fi
+
+cd -
+
 python3 "${KOKORO_GFILE_DIR}/trampoline_v1.py"

--- a/testing/kokoro/trampoline.sh
+++ b/testing/kokoro/trampoline.sh
@@ -20,8 +20,7 @@ date
 
 cd github/golang-samples
 
-# SIGNIFICANT_CHANGES="$(git --no-pager diff --name-only HEAD..master | egrep -v '(\.md$|^\.github)' || true)"
-SIGNIFICANT_CHANGES="$(echo ".github/renovate.json" | egrep -v '(\.md$|^\.github)' || true)" # DO NOT SUBMIT
+SIGNIFICANT_CHANGES="$(git --no-pager diff --name-only HEAD..master | egrep -v '(\.md$|^\.github)' || true)"
 
 # If this is a PR with only insignificant changes, don't run any tests.
 if [[ -n ${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-} ]] && [[ -z "$SIGNIFICANT_CHANGES" ]]; then


### PR DESCRIPTION
This reduces the test time of markdown-only changes by ~60 seconds (~62 seconds -> ~2 seconds). There is some extra time for Kokoro to start up and everything, though, so we won't see a 2 second status update on the PR.