### PR TITLE
pubsub: fix inconsistent variable names

### DIFF
--- a/pubsub/topics/publish.go
+++ b/pubsub/topics/publish.go
@@ -24,7 +24,7 @@ import (
 	"cloud.google.com/go/pubsub"
 )
 
-func publish(w io.Writer, projectID, topic, msg string) error {
+func publish(w io.Writer, projectID, topicID, msg string) error {
 	// projectID := "my-project-id"
 	// topicID := "my-topic"
 	// msg := "Hello World"
@@ -34,7 +34,7 @@ func publish(w io.Writer, projectID, topic, msg string) error {
 		return fmt.Errorf("pubsub.NewClient: %v", err)
 	}
 
-	t := client.Topic(topic)
+	t := client.Topic(topicID)
 	result := t.Publish(ctx, &pubsub.Message{
 		Data: []byte(msg),
 	})

--- a/pubsub/topics/publish_single.go
+++ b/pubsub/topics/publish_single.go
@@ -23,7 +23,7 @@ import (
 	"cloud.google.com/go/pubsub"
 )
 
-func publishSingleGoroutine(w io.Writer, projectID, topic, msg string) error {
+func publishSingleGoroutine(w io.Writer, projectID, topicID, msg string) error {
 	// projectID := "my-project-id"
 	// topicID := "my-topic"
 	// msg := "Hello World"
@@ -33,7 +33,7 @@ func publishSingleGoroutine(w io.Writer, projectID, topic, msg string) error {
 		return fmt.Errorf("pubsub.NewClient: %v", err)
 	}
 
-	t := client.Topic(topic)
+	t := client.Topic(topicID)
 	t.PublishSettings.NumGoroutines = 1
 
 	result := t.Publish(ctx, &pubsub.Message{Data: []byte(msg)})


### PR DESCRIPTION
The function argument and comment were not consistent, so this standardizes everything to use `topicID`.

internal tracking: 144785008