### PR TITLE
functions: import time in hello_cloud_storage.go

### DIFF
--- a/functions/helloworld/hello_cloud_storage.go
+++ b/functions/helloworld/hello_cloud_storage.go
@@ -20,6 +20,7 @@ package helloworld
 import (
 	"context"
 	"log"
+	"time"
 )
 
 // GCSEvent is the payload of a GCS event.


### PR DESCRIPTION
this will fix the following error

```
ERROR: (gcloud.functions.deploy) OperationError: code=3, message=Build failed: go: finding github.com/GoogleCloudPlatform/golang-samples/functions/helloworld v0.0.0
# github.com/GoogleCloudPlatform/golang-samples/functions/helloworld
files/hello_cloud_storage.go:35:26: undefined: time
files/hello_cloud_storage.go:36:26: undefined: time
files/hello_cloud_storage.go:39:26: undefined: time
files/hello_cloud_storage.go:41:26: undefined: time
```