### PR TITLE
speech: use different check for auto punctuation

### DIFF
--- a/speech/snippets/auto_punctuation_test.go
+++ b/speech/snippets/auto_punctuation_test.go
@@ -31,7 +31,7 @@ func TestAutoPunctuation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got := buf.String(); !strings.Contains(got, "Okay. Sure.") {
-		t.Fatalf(`autoPunctuation(../testdata/commercial_mono.wav) = %q; want "Okay. Sure"`, got)
+	if got, want := buf.String(), "I'm here"; !strings.Contains(got, want) {
+		t.Fatalf(`autoPunctuation(../testdata/commercial_mono.wav) = %q; want %q`, got, want)
 	}
 }


### PR DESCRIPTION
Causing builds to fail right now.

Fixes #1107.