### PR TITLE
testing: fix significant changes check

### DIFF
--- a/testing/kokoro/system_tests.sh
+++ b/testing/kokoro/system_tests.sh
@@ -100,9 +100,9 @@ if [ -z ${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-} ]; then
   RUN_ALL_TESTS="1"
 fi
 
-# Also see trampoline.sh - system_tests.sh is only run when there are
+# Also see trampoline.sh - system_tests.sh is only run for PRs when there are
 # significant changes.
-SIGNIFICANT_CHANGES=$(git --no-pager diff --name-only HEAD..master | egrep -v '(\.md$|^\.github)')
+SIGNIFICANT_CHANGES=$(git --no-pager diff --name-only HEAD..master | egrep -v '(\.md$|^\.github)' || true)
 # CHANGED_DIRS is the list of significant top-level directories that changed.
 # CHANGED_DIRS will be empty when run on master.
 CHANGED_DIRS=$(echo $SIGNIFICANT_CHANGES | tr ' ' '\n' | grep "/" | cut -d/ -f1 | sort -u | tr '\n' ' ')


### PR DESCRIPTION
When running nightly tests, there are no changes. So, the egrep call
sets a non-zero exit code and the script stops executing.