### PR TITLE
functions: use GOOGLE_CLOUD_PROJECT, not GCLOUD_PROJECT

### DIFF
--- a/functions/firebase/upper/upper.go
+++ b/functions/firebase/upper/upper.go
@@ -57,8 +57,8 @@ type MyData struct {
 	} `json:"original"`
 }
 
-// GCLOUD_PROJECT is automatically set by the Cloud Functions runtime.
-var projectID = os.Getenv("GCLOUD_PROJECT")
+// GOOGLE_CLOUD_PROJECT is automatically set by the Cloud Functions runtime.
+var projectID = os.Getenv("GOOGLE_CLOUD_PROJECT")
 
 // client is a Firestore client, reused between function invocations.
 var client *firestore.Client


### PR DESCRIPTION
See https://cloud.google.com/functions/docs/env-var#nodejs_6_nodejs_8_python_37_and_go_111
b/145818614