### PR TITLE
videointelligence: return annotated errors

### DIFF
--- a/videointelligence/annotate/object_tracking.go
+++ b/videointelligence/annotate/object_tracking.go
@@ -18,16 +18,13 @@ package annotate
 // [START videointelligence_object_tracking]
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
-
-	"context"
-
-	"github.com/golang/protobuf/ptypes"
 
 	video "cloud.google.com/go/videointelligence/apiv1"
+	"github.com/golang/protobuf/ptypes"
 	videopb "google.golang.org/genproto/googleapis/cloud/videointelligence/v1"
 )
 
@@ -40,7 +37,7 @@ func objectTracking(w io.Writer, filename string) error {
 	// Creates a client.
 	client, err := video.NewClient(ctx)
 	if err != nil {
-		log.Fatalf("Failed to create client: %v", err)
+		return fmt.Errorf("video.NewClient: %v", err)
 	}
 
 	fileBytes, err := ioutil.ReadFile(filename)
@@ -55,12 +52,12 @@ func objectTracking(w io.Writer, filename string) error {
 		},
 	})
 	if err != nil {
-		log.Fatalf("Failed to start annotation job: %v", err)
+		return fmt.Errorf("AnnotateVideo: %v", err)
 	}
 
 	resp, err := op.Wait(ctx)
 	if err != nil {
-		log.Fatalf("Failed to annotate: %v", err)
+		return fmt.Errorf("Wait: %v", err)
 	}
 
 	// Only one video was processed, so get the first result.

--- a/videointelligence/annotate/object_tracking_gcs.go
+++ b/videointelligence/annotate/object_tracking_gcs.go
@@ -18,15 +18,12 @@ package annotate
 // [START videointelligence_object_tracking_gcs]
 
 import (
+	"context"
 	"fmt"
 	"io"
-	"log"
-
-	"context"
-
-	"github.com/golang/protobuf/ptypes"
 
 	video "cloud.google.com/go/videointelligence/apiv1"
+	"github.com/golang/protobuf/ptypes"
 	videopb "google.golang.org/genproto/googleapis/cloud/videointelligence/v1"
 )
 
@@ -39,7 +36,7 @@ func objectTrackingGCS(w io.Writer, gcsURI string) error {
 	// Creates a client.
 	client, err := video.NewClient(ctx)
 	if err != nil {
-		log.Fatalf("Failed to create client: %v", err)
+		return fmt.Errorf("video.NewClient: %v", err)
 	}
 
 	op, err := client.AnnotateVideo(ctx, &videopb.AnnotateVideoRequest{
@@ -49,12 +46,12 @@ func objectTrackingGCS(w io.Writer, gcsURI string) error {
 		},
 	})
 	if err != nil {
-		log.Fatalf("Failed to start annotation job: %v", err)
+		return fmt.Errorf("AnnotateVideo: %v", err)
 	}
 
 	resp, err := op.Wait(ctx)
 	if err != nil {
-		log.Fatalf("Failed to annotate: %v", err)
+		return fmt.Errorf("Wait: %v", err)
 	}
 
 	// Only one video was processed, so get the first result.

--- a/videointelligence/annotate/text_detection.go
+++ b/videointelligence/annotate/text_detection.go
@@ -18,16 +18,13 @@ package annotate
 // [START videointelligence_text_detection]
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
-
-	"context"
-
-	"github.com/golang/protobuf/ptypes"
 
 	video "cloud.google.com/go/videointelligence/apiv1"
+	"github.com/golang/protobuf/ptypes"
 	videopb "google.golang.org/genproto/googleapis/cloud/videointelligence/v1"
 )
 
@@ -40,12 +37,12 @@ func textDetection(w io.Writer, filename string) error {
 	// Creates a client.
 	client, err := video.NewClient(ctx)
 	if err != nil {
-		log.Fatalf("Failed to create client: %v", err)
+		return fmt.Errorf("video.NewClient: %v", err)
 	}
 
 	fileBytes, err := ioutil.ReadFile(filename)
 	if err != nil {
-		return err
+		return fmt.Errorf("ioutil.ReadFile: %v", err)
 	}
 
 	op, err := client.AnnotateVideo(ctx, &videopb.AnnotateVideoRequest{
@@ -55,12 +52,12 @@ func textDetection(w io.Writer, filename string) error {
 		},
 	})
 	if err != nil {
-		log.Fatalf("Failed to start annotation job: %v", err)
+		return fmt.Errorf("AnnotateVideo: %v", err)
 	}
 
 	resp, err := op.Wait(ctx)
 	if err != nil {
-		log.Fatalf("Failed to annotate: %v", err)
+		return fmt.Errorf("Wait: %v", err)
 	}
 
 	// Only one video was processed, so get the first result.

--- a/videointelligence/annotate/text_detection_gcs.go
+++ b/videointelligence/annotate/text_detection_gcs.go
@@ -18,15 +18,12 @@ package annotate
 // [START videointelligence_text_detection_gcs]
 
 import (
+	"context"
 	"fmt"
 	"io"
-	"log"
-
-	"context"
-
-	"github.com/golang/protobuf/ptypes"
 
 	video "cloud.google.com/go/videointelligence/apiv1"
+	"github.com/golang/protobuf/ptypes"
 	videopb "google.golang.org/genproto/googleapis/cloud/videointelligence/v1"
 )
 
@@ -39,7 +36,7 @@ func textDetectionGCS(w io.Writer, gcsURI string) error {
 	// Creates a client.
 	client, err := video.NewClient(ctx)
 	if err != nil {
-		log.Fatalf("Failed to create client: %v", err)
+		return fmt.Errorf("video.NewClient: %v", err)
 	}
 
 	op, err := client.AnnotateVideo(ctx, &videopb.AnnotateVideoRequest{
@@ -49,12 +46,12 @@ func textDetectionGCS(w io.Writer, gcsURI string) error {
 		},
 	})
 	if err != nil {
-		log.Fatalf("Failed to start annotation job: %v", err)
+		return fmt.Errorf("AnnotateVideo: %v", err)
 	}
 
 	resp, err := op.Wait(ctx)
 	if err != nil {
-		log.Fatalf("Failed to annotate: %v", err)
+		return fmt.Errorf("Wait: %v", err)
 	}
 
 	// Only one video was processed, so get the first result.

--- a/videointelligence/video_analyze/video_analyze.go
+++ b/videointelligence/video_analyze/video_analyze.go
@@ -31,7 +31,7 @@ func label(w io.Writer, file string) error {
 	ctx := context.Background()
 	client, err := video.NewClient(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("video.NewClient: %v", err)
 	}
 
 	fileBytes, err := ioutil.ReadFile(file)
@@ -46,11 +46,12 @@ func label(w io.Writer, file string) error {
 		InputContent: fileBytes,
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("AnnotateVideo: %v", err)
 	}
+
 	resp, err := op.Wait(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("Wait: %v", err)
 	}
 
 	printLabels := func(labels []*videopb.LabelAnnotation) {

--- a/videointelligence/video_analyze/video_analyze_gcs.go
+++ b/videointelligence/video_analyze/video_analyze_gcs.go
@@ -30,7 +30,7 @@ func labelURI(w io.Writer, file string) error {
 	ctx := context.Background()
 	client, err := video.NewClient(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("video.NewClient: %v", err)
 	}
 
 	op, err := client.AnnotateVideo(ctx, &videopb.AnnotateVideoRequest{
@@ -40,11 +40,12 @@ func labelURI(w io.Writer, file string) error {
 		InputUri: file,
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("AnnotateVideo: %v", err)
 	}
+
 	resp, err := op.Wait(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("Wait: %v", err)
 	}
 
 	printLabels := func(labels []*videopb.LabelAnnotation) {


### PR DESCRIPTION
Calls to `log.Fatal` stop tests before they can retry.