### PR TITLE
translate: relax test condition

### DIFF
--- a/translate/v3/translate_text_test.go
+++ b/translate/v3/translate_text_test.go
@@ -34,7 +34,7 @@ func TestTranslateText(t *testing.T) {
 	if err := translateText(&buf, tc.ProjectID, sourceLang, targetLang, text); err != nil {
 		t.Fatalf("translateText: %v", err)
 	}
-	if got, want1, want2 := buf.String(), "Zdravo svet", "Pozdrav svijetu"; !strings.Contains(got, want1) && !strings.Contains(got, want2) {
+	if got, want1, want2 := buf.String(), "Zdravo", "Pozdrav"; !strings.Contains(got, want1) && !strings.Contains(got, want2) {
 		t.Errorf("translateText got:\n----\n%s----\nWant to contain:\n----\n%s\n----\nOR\n----\n%s\n----", got, want1, want2)
 	}
 }


### PR DESCRIPTION
Causing flake with changes in the translated text.

Example failure: https://source.cloud.google.com/results/invocations/ba0264fd-892a-4c10-8890-caaccc5e0c94/targets/cloud-devrel%2Fgo%2Fgolang-samples%2Fsystem-tests%2Fgo111/log