### PR TITLE
testing: publish test log to Build Cop Bot

### DIFF
--- a/testing/kokoro/system_tests.sh
+++ b/testing/kokoro/system_tests.sh
@@ -141,4 +141,36 @@ date
 OUTFILE=gotest.out
 2>&1 go test -timeout $TIMEOUT -v . $TARGET | tee $OUTFILE
 
+set +x
+
 cat $OUTFILE | /go/bin/go-junit-report -set-exit-code > sponge_log.xml
+EXIT_CODE=$?
+
+# If we're running system tests, send the test log to the Build Cop Bot.
+# See https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop.
+if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"system-tests"* ]]; then
+  # Use the service account with access to the repo-automation-bots project.
+  gcloud auth activate-service-account --key-file $KOKORO_KEYSTORE_DIR/71386_kokoro-golang-samples-tests
+  gcloud config set project repo-automation-bots
+
+  XML=$(base64 -w 0 sponge_log.xml)
+
+  # See https://github.com/apps/build-cop-bot/installations/5943459.
+  MESSAGE=$(cat <<EOF
+  {
+      "Name": "buildcop",
+      "Type" : "function",
+      "Location": "us-central1",
+      "installation": {"id": "5943459"},
+      "repo": "GoogleCloudPlatform/golang-samples",
+      "buildID": "$KOKORO_BUILD_ID",
+      "buildURL": "https://source.cloud.google.com/results/invocations/$KOKORO_BUILD_ID",
+      "xunitXML": "$XML"
+  }
+EOF
+  )
+
+  gcloud pubsub topics publish passthrough --message="$MESSAGE"
+fi
+
+exit $EXIT_CODE

--- a/testing/kokoro/system_tests.sh
+++ b/testing/kokoro/system_tests.sh
@@ -141,7 +141,7 @@ date
 OUTFILE=gotest.out
 2>&1 go test -timeout $TIMEOUT -v . $TARGET | tee $OUTFILE
 
-set +x
+set +e
 
 cat $OUTFILE | /go/bin/go-junit-report -set-exit-code > sponge_log.xml
 EXIT_CODE=$?


### PR DESCRIPTION
This will automatically open/close issues for failing/passing tests ([example](https://github.com/GoogleCloudPlatform/golang-samples/issues/1146)). See https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop.