### PR TITLE
testing: include gcloud on PATH

### DIFF
--- a/testing/kokoro/system_tests.sh
+++ b/testing/kokoro/system_tests.sh
@@ -90,7 +90,10 @@ date
 if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"system-tests"* && -n $GOLANG_SAMPLES_GO_VET ]]; then
   echo "This test run will run end-to-end tests.";
   export GOLANG_SAMPLES_E2E_TEST=1
-  export PATH="$PATH:/tmp/google-cloud-sdk/bin";
+fi
+
+export PATH="$PATH:/tmp/google-cloud-sdk/bin";
+if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"system-tests"* ]]; then
   ./testing/kokoro/configure_gcloud.bash;
 fi
 


### PR DESCRIPTION
We need gcloud for all system tests to be able to publish test results
to the Build Cop Bot.