### PR TITLE
internal/cloudrunci: add AllowUnauthenticated

### DIFF
--- a/internal/cloudrunci/cloudrunci.go
+++ b/internal/cloudrunci/cloudrunci.go
@@ -48,6 +48,9 @@ type Service struct {
 	// The project to deploy to.
 	ProjectID string
 
+	// Allow unauthenticated request.
+	AllowUnauthenticated bool
+
 	// The platform to deploy to.
 	Platform Platform
 
@@ -268,6 +271,9 @@ func (s *Service) deployCmd() *exec.Cmd {
 		for k := range s.Env {
 			args = append(args, "--set-env-vars", s.Env.Variable(k))
 		}
+	}
+	if s.AllowUnauthenticated {
+		args = append(args, "--allow-unauthenticated")
 	}
 
 	// NOTE: if the "beta" component is not available, and this is run in parallel,

--- a/run/grpc-ping/e2e_test.go
+++ b/run/grpc-ping/e2e_test.go
@@ -39,7 +39,9 @@ func TestGRPCPingService(t *testing.T) {
 
 	// Prepare the container image for both services.
 	pingService := cloudrunci.NewService("grpc-ping", tc.ProjectID)
-	pingService.Build()
+	if err := pingService.Build(); err != nil {
+		t.Fatalf("Service.Build %q: %v", pingService.Name, err)
+	}
 
 	// Deploy the ping-upstream service.
 	upstreamService := cloudrunci.NewService("grpc-ping-upstream", tc.ProjectID)
@@ -53,7 +55,7 @@ func TestGRPCPingService(t *testing.T) {
 	// Deploy the ping service.
 	upstreamHost, err := upstreamService.Host()
 	if err != nil {
-		t.Errorf("Service.Host %q: %v", upstreamService.Name, err)
+		t.Fatalf("Service.Host %q: %v", upstreamService.Name, err)
 	}
 	pingService.Env = cloudrunci.EnvVars{
 		"GRPC_PING_HOST": upstreamHost,
@@ -66,7 +68,7 @@ func TestGRPCPingService(t *testing.T) {
 	// Test a gRPC Request.
 	pingURL, err := pingService.ParsedURL()
 	if err != nil {
-		t.Errorf("Service.ParsedURL %q: %v", pingService.Name, err)
+		t.Fatalf("Service.ParsedURL %q: %v", pingService.Name, err)
 	}
 
 	message := "Hello Tester"


### PR DESCRIPTION
Adding an integration test option for deploying public Cloud Run services.

Also fixing unhandled errors and fatal errors in run/grpc-ping sample
that are relevant.