### PR TITLE
storage: add timeouts to samples

### DIFF
--- a/storage/buckets/get_bucket_metadata.go
+++ b/storage/buckets/get_bucket_metadata.go
@@ -41,7 +41,7 @@ func getBucketMetadata(w io.Writer, client *storage.Client, bucketName string) (
 	defer client.Close() // Closing the client safely cleans up background resources.
 
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	attrs, err := client.Bucket(bucketName).Attrs(ctx)
 	if err != nil {
 		return nil, err

--- a/storage/buckets/get_bucket_metadata.go
+++ b/storage/buckets/get_bucket_metadata.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"time"
 
 	"cloud.google.com/go/storage"
 )
@@ -39,6 +40,8 @@ func getBucketMetadata(w io.Writer, client *storage.Client, bucketName string) (
 	}
 	defer client.Close() // Closing the client safely cleans up background resources.
 
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	attrs, err := client.Bucket(bucketName).Attrs(ctx)
 	if err != nil {
 		return nil, err

--- a/storage/buckets/main.go
+++ b/storage/buckets/main.go
@@ -98,7 +98,7 @@ func create(client *storage.Client, projectID, bucketName string) error {
 	// [START create_bucket]
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	if err := client.Bucket(bucketName).Create(ctx, projectID, nil); err != nil {
 		return err
 	}
@@ -112,7 +112,7 @@ func createWithAttrs(client *storage.Client, projectID, bucketName string) error
 	bucket := client.Bucket(bucketName)
 
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	if err := bucket.Create(ctx, projectID, &storage.BucketAttrs{
 		StorageClass: "COLDLINE",
 		Location:     "asia",
@@ -129,7 +129,7 @@ func list(client *storage.Client, projectID string) ([]string, error) {
 
 	var buckets []string
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	it := client.Buckets(ctx, projectID)
 	for {
 		battrs, err := it.Next()
@@ -149,7 +149,7 @@ func deleteBucket(client *storage.Client, bucketName string) error {
 	// [START delete_bucket]
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	if err := client.Bucket(bucketName).Delete(ctx); err != nil {
 		return err
 	}
@@ -161,7 +161,7 @@ func getPolicy(c *storage.Client, bucketName string) (*iam.Policy, error) {
 	// [START storage_get_bucket_policy]
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	policy, err := c.Bucket(bucketName).IAM().Policy(ctx)
 	if err != nil {
 		return nil, err
@@ -177,7 +177,7 @@ func addUser(c *storage.Client, bucketName string) error {
 	// [START add_bucket_iam_member]
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	bucket := c.Bucket(bucketName)
 	policy, err := bucket.IAM().Policy(ctx)
 	if err != nil {
@@ -201,7 +201,7 @@ func removeUser(c *storage.Client, bucketName string) error {
 	// [START remove_bucket_iam_member]
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	bucket := c.Bucket(bucketName)
 	policy, err := bucket.IAM().Policy(ctx)
 	if err != nil {
@@ -232,7 +232,7 @@ func setRetentionPolicy(c *storage.Client, bucketName string, retentionPeriod ti
 		},
 	}
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	if _, err := bucket.Update(ctx, bucketAttrsToUpdate); err != nil {
 		return err
 	}
@@ -257,7 +257,7 @@ func removeRetentionPolicy(c *storage.Client, bucketName string) error {
 		RetentionPolicy: &storage.RetentionPolicy{},
 	}
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	if _, err := bucket.Update(ctx, bucketAttrsToUpdate); err != nil {
 		return err
 	}
@@ -271,7 +271,7 @@ func lockRetentionPolicy(c *storage.Client, bucketName string) error {
 	bucket := c.Bucket(bucketName)
 
 	ctx, cancel := context.WithTimeout(ctx, time.Second*50)
-	defer cancel() // Add a timeout for these actions.
+	defer cancel()
 	attrs, err := c.Bucket(bucketName).Attrs(ctx)
 	if err != nil {
 		return err
@@ -300,7 +300,7 @@ func getRetentionPolicy(c *storage.Client, bucketName string) (*storage.BucketAt
 	ctx := context.Background()
 
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	attrs, err := c.Bucket(bucketName).Attrs(ctx)
 	if err != nil {
 		return nil, err
@@ -324,7 +324,7 @@ func enableDefaultEventBasedHold(c *storage.Client, bucketName string) error {
 		DefaultEventBasedHold: true,
 	}
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	if _, err := bucket.Update(ctx, bucketAttrsToUpdate); err != nil {
 		return err
 	}
@@ -341,7 +341,7 @@ func disableDefaultEventBasedHold(c *storage.Client, bucketName string) error {
 		DefaultEventBasedHold: false,
 	}
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	if _, err := bucket.Update(ctx, bucketAttrsToUpdate); err != nil {
 		return err
 	}
@@ -353,7 +353,7 @@ func getDefaultEventBasedHold(c *storage.Client, bucketName string) (*storage.Bu
 	// [START storage_get_default_event_based_hold]
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	attrs, err := c.Bucket(bucketName).Attrs(ctx)
 	if err != nil {
 		return nil, err
@@ -373,7 +373,7 @@ func enableRequesterPays(c *storage.Client, bucketName string) error {
 		RequesterPays: true,
 	}
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	if _, err := bucket.Update(ctx, bucketAttrsToUpdate); err != nil {
 		return err
 	}
@@ -390,7 +390,7 @@ func disableRequesterPays(c *storage.Client, bucketName string) error {
 		RequesterPays: false,
 	}
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	if _, err := bucket.Update(ctx, bucketAttrsToUpdate); err != nil {
 		return err
 	}
@@ -402,7 +402,7 @@ func checkRequesterPays(c *storage.Client, bucketName string) error {
 	// [START get_requester_pays_status]
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	attrs, err := c.Bucket(bucketName).Attrs(ctx)
 	if err != nil {
 		return err
@@ -421,7 +421,7 @@ func setDefaultKMSkey(c *storage.Client, bucketName string, keyName string) erro
 		Encryption: &storage.BucketEncryption{DefaultKMSKeyName: keyName},
 	}
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	if _, err := bucket.Update(ctx, bucketAttrsToUpdate); err != nil {
 		return err
 	}
@@ -440,7 +440,7 @@ func enableUniformBucketLevelAccess(c *storage.Client, bucketName string) error 
 		},
 	}
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	if _, err := bucket.Update(ctx, enableUniformBucketLevelAccess); err != nil {
 		return err
 	}
@@ -459,7 +459,7 @@ func disableUniformBucketLevelAccess(c *storage.Client, bucketName string) error
 		},
 	}
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	if _, err := bucket.Update(ctx, disableUniformBucketLevelAccess); err != nil {
 		return err
 	}
@@ -471,7 +471,7 @@ func getUniformBucketLevelAccess(c *storage.Client, bucketName string) (*storage
 	// [START storage_get_uniform_bucket_level_access]
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	attrs, err := c.Bucket(bucketName).Attrs(ctx)
 	if err != nil {
 		return nil, err

--- a/storage/buckets/main.go
+++ b/storage/buckets/main.go
@@ -97,6 +97,7 @@ func main() {
 func create(client *storage.Client, projectID, bucketName string) error {
 	// [START create_bucket]
 	ctx := context.Background()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 	if err := client.Bucket(bucketName).Create(ctx, projectID, nil); err != nil {
@@ -148,6 +149,7 @@ func list(client *storage.Client, projectID string) ([]string, error) {
 func deleteBucket(client *storage.Client, bucketName string) error {
 	// [START delete_bucket]
 	ctx := context.Background()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 	if err := client.Bucket(bucketName).Delete(ctx); err != nil {
@@ -160,6 +162,7 @@ func deleteBucket(client *storage.Client, bucketName string) error {
 func getPolicy(c *storage.Client, bucketName string) (*iam.Policy, error) {
 	// [START storage_get_bucket_policy]
 	ctx := context.Background()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 	policy, err := c.Bucket(bucketName).IAM().Policy(ctx)
@@ -176,6 +179,7 @@ func getPolicy(c *storage.Client, bucketName string) (*iam.Policy, error) {
 func addUser(c *storage.Client, bucketName string) error {
 	// [START add_bucket_iam_member]
 	ctx := context.Background()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 	bucket := c.Bucket(bucketName)
@@ -200,6 +204,7 @@ func addUser(c *storage.Client, bucketName string) error {
 func removeUser(c *storage.Client, bucketName string) error {
 	// [START remove_bucket_iam_member]
 	ctx := context.Background()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 	bucket := c.Bucket(bucketName)
@@ -352,6 +357,7 @@ func disableDefaultEventBasedHold(c *storage.Client, bucketName string) error {
 func getDefaultEventBasedHold(c *storage.Client, bucketName string) (*storage.BucketAttrs, error) {
 	// [START storage_get_default_event_based_hold]
 	ctx := context.Background()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 	attrs, err := c.Bucket(bucketName).Attrs(ctx)
@@ -401,6 +407,7 @@ func disableRequesterPays(c *storage.Client, bucketName string) error {
 func checkRequesterPays(c *storage.Client, bucketName string) error {
 	// [START get_requester_pays_status]
 	ctx := context.Background()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 	attrs, err := c.Bucket(bucketName).Attrs(ctx)
@@ -470,6 +477,7 @@ func disableUniformBucketLevelAccess(c *storage.Client, bucketName string) error
 func getUniformBucketLevelAccess(c *storage.Client, bucketName string) (*storage.BucketAttrs, error) {
 	// [START storage_get_uniform_bucket_level_access]
 	ctx := context.Background()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 	attrs, err := c.Bucket(bucketName).Attrs(ctx)

--- a/storage/buckets/main.go
+++ b/storage/buckets/main.go
@@ -95,8 +95,10 @@ func main() {
 }
 
 func create(client *storage.Client, projectID, bucketName string) error {
-	ctx := context.Background()
 	// [START create_bucket]
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	if err := client.Bucket(bucketName).Create(ctx, projectID, nil); err != nil {
 		return err
 	}
@@ -105,9 +107,12 @@ func create(client *storage.Client, projectID, bucketName string) error {
 }
 
 func createWithAttrs(client *storage.Client, projectID, bucketName string) error {
-	ctx := context.Background()
 	// [START create_bucket_with_storageclass_and_location]
+	ctx := context.Background()
 	bucket := client.Bucket(bucketName)
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	if err := bucket.Create(ctx, projectID, &storage.BucketAttrs{
 		StorageClass: "COLDLINE",
 		Location:     "asia",
@@ -119,9 +124,12 @@ func createWithAttrs(client *storage.Client, projectID, bucketName string) error
 }
 
 func list(client *storage.Client, projectID string) ([]string, error) {
-	ctx := context.Background()
 	// [START list_buckets]
+	ctx := context.Background()
+
 	var buckets []string
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	it := client.Buckets(ctx, projectID)
 	for {
 		battrs, err := it.Next()
@@ -138,8 +146,10 @@ func list(client *storage.Client, projectID string) ([]string, error) {
 }
 
 func deleteBucket(client *storage.Client, bucketName string) error {
-	ctx := context.Background()
 	// [START delete_bucket]
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	if err := client.Bucket(bucketName).Delete(ctx); err != nil {
 		return err
 	}
@@ -148,9 +158,10 @@ func deleteBucket(client *storage.Client, bucketName string) error {
 }
 
 func getPolicy(c *storage.Client, bucketName string) (*iam.Policy, error) {
-	ctx := context.Background()
-
 	// [START storage_get_bucket_policy]
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	policy, err := c.Bucket(bucketName).IAM().Policy(ctx)
 	if err != nil {
 		return nil, err
@@ -163,9 +174,10 @@ func getPolicy(c *storage.Client, bucketName string) (*iam.Policy, error) {
 }
 
 func addUser(c *storage.Client, bucketName string) error {
-	ctx := context.Background()
-
 	// [START add_bucket_iam_member]
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	bucket := c.Bucket(bucketName)
 	policy, err := bucket.IAM().Policy(ctx)
 	if err != nil {
@@ -186,9 +198,10 @@ func addUser(c *storage.Client, bucketName string) error {
 }
 
 func removeUser(c *storage.Client, bucketName string) error {
-	ctx := context.Background()
-
 	// [START remove_bucket_iam_member]
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	bucket := c.Bucket(bucketName)
 	policy, err := bucket.IAM().Policy(ctx)
 	if err != nil {
@@ -209,15 +222,17 @@ func removeUser(c *storage.Client, bucketName string) error {
 }
 
 func setRetentionPolicy(c *storage.Client, bucketName string, retentionPeriod time.Duration) error {
+	// [START storage_set_retention_policy]
 	ctx := context.Background()
 
-	// [START storage_set_retention_policy]
 	bucket := c.Bucket(bucketName)
 	bucketAttrsToUpdate := storage.BucketAttrsToUpdate{
 		RetentionPolicy: &storage.RetentionPolicy{
 			RetentionPeriod: retentionPeriod,
 		},
 	}
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	if _, err := bucket.Update(ctx, bucketAttrsToUpdate); err != nil {
 		return err
 	}
@@ -226,9 +241,8 @@ func setRetentionPolicy(c *storage.Client, bucketName string, retentionPeriod ti
 }
 
 func removeRetentionPolicy(c *storage.Client, bucketName string) error {
-	ctx := context.Background()
-
 	// [START storage_remove_retention_policy]
+	ctx := context.Background()
 	bucket := c.Bucket(bucketName)
 
 	attrs, err := c.Bucket(bucketName).Attrs(ctx)
@@ -242,6 +256,8 @@ func removeRetentionPolicy(c *storage.Client, bucketName string) error {
 	bucketAttrsToUpdate := storage.BucketAttrsToUpdate{
 		RetentionPolicy: &storage.RetentionPolicy{},
 	}
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	if _, err := bucket.Update(ctx, bucketAttrsToUpdate); err != nil {
 		return err
 	}
@@ -250,10 +266,12 @@ func removeRetentionPolicy(c *storage.Client, bucketName string) error {
 }
 
 func lockRetentionPolicy(c *storage.Client, bucketName string) error {
-	ctx := context.Background()
-
 	// [START storage_lock_retention_policy]
+	ctx := context.Background()
 	bucket := c.Bucket(bucketName)
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*50)
+	defer cancel() // Add a timeout for these actions.
 	attrs, err := c.Bucket(bucketName).Attrs(ctx)
 	if err != nil {
 		return err
@@ -278,9 +296,11 @@ func lockRetentionPolicy(c *storage.Client, bucketName string) error {
 }
 
 func getRetentionPolicy(c *storage.Client, bucketName string) (*storage.BucketAttrs, error) {
+	// [START storage_get_retention_policy]
 	ctx := context.Background()
 
-	// [START storage_get_retention_policy]
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	attrs, err := c.Bucket(bucketName).Attrs(ctx)
 	if err != nil {
 		return nil, err
@@ -296,13 +316,15 @@ func getRetentionPolicy(c *storage.Client, bucketName string) (*storage.BucketAt
 }
 
 func enableDefaultEventBasedHold(c *storage.Client, bucketName string) error {
+	// [START storage_enable_default_event_based_hold]
 	ctx := context.Background()
 
-	// [START storage_enable_default_event_based_hold]
 	bucket := c.Bucket(bucketName)
 	bucketAttrsToUpdate := storage.BucketAttrsToUpdate{
 		DefaultEventBasedHold: true,
 	}
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	if _, err := bucket.Update(ctx, bucketAttrsToUpdate); err != nil {
 		return err
 	}
@@ -311,13 +333,15 @@ func enableDefaultEventBasedHold(c *storage.Client, bucketName string) error {
 }
 
 func disableDefaultEventBasedHold(c *storage.Client, bucketName string) error {
+	// [START storage_disable_default_event_based_hold]
 	ctx := context.Background()
 
-	// [START storage_disable_default_event_based_hold]
 	bucket := c.Bucket(bucketName)
 	bucketAttrsToUpdate := storage.BucketAttrsToUpdate{
 		DefaultEventBasedHold: false,
 	}
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	if _, err := bucket.Update(ctx, bucketAttrsToUpdate); err != nil {
 		return err
 	}
@@ -326,9 +350,10 @@ func disableDefaultEventBasedHold(c *storage.Client, bucketName string) error {
 }
 
 func getDefaultEventBasedHold(c *storage.Client, bucketName string) (*storage.BucketAttrs, error) {
-	ctx := context.Background()
-
 	// [START storage_get_default_event_based_hold]
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	attrs, err := c.Bucket(bucketName).Attrs(ctx)
 	if err != nil {
 		return nil, err
@@ -340,13 +365,15 @@ func getDefaultEventBasedHold(c *storage.Client, bucketName string) (*storage.Bu
 }
 
 func enableRequesterPays(c *storage.Client, bucketName string) error {
+	// [START enable_requester_pays]
 	ctx := context.Background()
 
-	// [START enable_requester_pays]
 	bucket := c.Bucket(bucketName)
 	bucketAttrsToUpdate := storage.BucketAttrsToUpdate{
 		RequesterPays: true,
 	}
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	if _, err := bucket.Update(ctx, bucketAttrsToUpdate); err != nil {
 		return err
 	}
@@ -355,13 +382,15 @@ func enableRequesterPays(c *storage.Client, bucketName string) error {
 }
 
 func disableRequesterPays(c *storage.Client, bucketName string) error {
+	// [START disable_requester_pays]
 	ctx := context.Background()
 
-	// [START disable_requester_pays]
 	bucket := c.Bucket(bucketName)
 	bucketAttrsToUpdate := storage.BucketAttrsToUpdate{
 		RequesterPays: false,
 	}
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	if _, err := bucket.Update(ctx, bucketAttrsToUpdate); err != nil {
 		return err
 	}
@@ -370,9 +399,10 @@ func disableRequesterPays(c *storage.Client, bucketName string) error {
 }
 
 func checkRequesterPays(c *storage.Client, bucketName string) error {
-	ctx := context.Background()
-
 	// [START get_requester_pays_status]
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	attrs, err := c.Bucket(bucketName).Attrs(ctx)
 	if err != nil {
 		return err
@@ -383,13 +413,15 @@ func checkRequesterPays(c *storage.Client, bucketName string) error {
 }
 
 func setDefaultKMSkey(c *storage.Client, bucketName string, keyName string) error {
+	// [START storage_set_bucket_default_kms_key]
 	ctx := context.Background()
 
-	// [START storage_set_bucket_default_kms_key]
 	bucket := c.Bucket(bucketName)
 	bucketAttrsToUpdate := storage.BucketAttrsToUpdate{
 		Encryption: &storage.BucketEncryption{DefaultKMSKeyName: keyName},
 	}
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	if _, err := bucket.Update(ctx, bucketAttrsToUpdate); err != nil {
 		return err
 	}
@@ -398,15 +430,17 @@ func setDefaultKMSkey(c *storage.Client, bucketName string, keyName string) erro
 }
 
 func enableUniformBucketLevelAccess(c *storage.Client, bucketName string) error {
+	// [START storage_enable_uniform_bucket_level_access]
 	ctx := context.Background()
 
-	// [START storage_enable_uniform_bucket_level_access]
 	bucket := c.Bucket(bucketName)
 	enableUniformBucketLevelAccess := storage.BucketAttrsToUpdate{
 		UniformBucketLevelAccess: &storage.UniformBucketLevelAccess{
 			Enabled: true,
 		},
 	}
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	if _, err := bucket.Update(ctx, enableUniformBucketLevelAccess); err != nil {
 		return err
 	}
@@ -415,15 +449,17 @@ func enableUniformBucketLevelAccess(c *storage.Client, bucketName string) error 
 }
 
 func disableUniformBucketLevelAccess(c *storage.Client, bucketName string) error {
+	// [START storage_disable_uniform_bucket_level_access]
 	ctx := context.Background()
 
-	// [START storage_disable_uniform_bucket_level_access]
 	bucket := c.Bucket(bucketName)
 	disableUniformBucketLevelAccess := storage.BucketAttrsToUpdate{
 		UniformBucketLevelAccess: &storage.UniformBucketLevelAccess{
 			Enabled: false,
 		},
 	}
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	if _, err := bucket.Update(ctx, disableUniformBucketLevelAccess); err != nil {
 		return err
 	}
@@ -432,9 +468,10 @@ func disableUniformBucketLevelAccess(c *storage.Client, bucketName string) error
 }
 
 func getUniformBucketLevelAccess(c *storage.Client, bucketName string) (*storage.BucketAttrs, error) {
-	ctx := context.Background()
-
 	// [START storage_get_uniform_bucket_level_access]
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	attrs, err := c.Bucket(bucketName).Attrs(ctx)
 	if err != nil {
 		return nil, err

--- a/storage/objects/main.go
+++ b/storage/objects/main.go
@@ -114,6 +114,7 @@ func write(client *storage.Client, bucket, object string) error {
 func list(w io.Writer, client *storage.Client, bucket string) error {
 	// [START storage_list_files]
 	ctx := context.Background()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 	it := client.Bucket(bucket).Objects(ctx, nil)
@@ -150,6 +151,7 @@ func listByPrefix(w io.Writer, client *storage.Client, bucket, prefix, delim str
 	// However, if you specify prefix="a/" and delim="/", you'll get back:
 	//   /a/1.txt
 	ctx := context.Background()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 	it := client.Bucket(bucket).Objects(ctx, &storage.Query{
@@ -173,6 +175,7 @@ func listByPrefix(w io.Writer, client *storage.Client, bucket, prefix, delim str
 func read(client *storage.Client, bucket, object string) ([]byte, error) {
 	// [START download_file]
 	ctx := context.Background()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*50)
 	defer cancel()
 	rc, err := client.Bucket(bucket).Object(object).NewReader(ctx)
@@ -192,6 +195,7 @@ func read(client *storage.Client, bucket, object string) ([]byte, error) {
 func attrs(client *storage.Client, bucket, object string) (*storage.ObjectAttrs, error) {
 	// [START get_metadata]
 	ctx := context.Background()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 	o := client.Bucket(bucket).Object(object)
@@ -231,6 +235,7 @@ func attrs(client *storage.Client, bucket, object string) (*storage.ObjectAttrs,
 func setEventBasedHold(client *storage.Client, bucket, object string) error {
 	// [START storage_set_event_based_hold]
 	ctx := context.Background()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 	o := client.Bucket(bucket).Object(object)
@@ -247,6 +252,7 @@ func setEventBasedHold(client *storage.Client, bucket, object string) error {
 func releaseEventBasedHold(client *storage.Client, bucket, object string) error {
 	// [START storage_release_event_based_hold]
 	ctx := context.Background()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 	o := client.Bucket(bucket).Object(object)
@@ -263,6 +269,7 @@ func releaseEventBasedHold(client *storage.Client, bucket, object string) error 
 func setTemporaryHold(client *storage.Client, bucket, object string) error {
 	// [START storage_set_temporary_hold]
 	ctx := context.Background()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 	o := client.Bucket(bucket).Object(object)
@@ -279,6 +286,7 @@ func setTemporaryHold(client *storage.Client, bucket, object string) error {
 func releaseTemporaryHold(client *storage.Client, bucket, object string) error {
 	// [START storage_release_temporary_hold]
 	ctx := context.Background()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 	o := client.Bucket(bucket).Object(object)
@@ -295,6 +303,7 @@ func releaseTemporaryHold(client *storage.Client, bucket, object string) error {
 func makePublic(client *storage.Client, bucket, object string) error {
 	// [START public]
 	ctx := context.Background()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 	acl := client.Bucket(bucket).Object(object).ACL()
@@ -308,6 +317,7 @@ func makePublic(client *storage.Client, bucket, object string) error {
 func move(client *storage.Client, bucket, object string) error {
 	// [START move_file]
 	ctx := context.Background()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 	dstName := object + "-rename"
@@ -328,6 +338,7 @@ func move(client *storage.Client, bucket, object string) error {
 func copyToBucket(client *storage.Client, dstBucket, srcBucket, srcObject string) error {
 	// [START copy_file]
 	ctx := context.Background()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 	dstObject := srcObject + "-copy"
@@ -344,6 +355,7 @@ func copyToBucket(client *storage.Client, dstBucket, srcBucket, srcObject string
 func delete(client *storage.Client, bucket, object string) error {
 	// [START delete_file]
 	ctx := context.Background()
+
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 	o := client.Bucket(bucket).Object(object)

--- a/storage/objects/main.go
+++ b/storage/objects/main.go
@@ -99,7 +99,7 @@ func write(client *storage.Client, bucket, object string) error {
 	defer f.Close()
 
 	ctx, cancel := context.WithTimeout(ctx, time.Second*50)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	wc := client.Bucket(bucket).Object(object).NewWriter(ctx)
 	if _, err = io.Copy(wc, f); err != nil {
 		return err
@@ -115,7 +115,7 @@ func list(w io.Writer, client *storage.Client, bucket string) error {
 	// [START storage_list_files]
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	it := client.Bucket(bucket).Objects(ctx, nil)
 	for {
 		attrs, err := it.Next()
@@ -151,7 +151,7 @@ func listByPrefix(w io.Writer, client *storage.Client, bucket, prefix, delim str
 	//   /a/1.txt
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	it := client.Bucket(bucket).Objects(ctx, &storage.Query{
 		Prefix:    prefix,
 		Delimiter: delim,
@@ -174,7 +174,7 @@ func read(client *storage.Client, bucket, object string) ([]byte, error) {
 	// [START download_file]
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second*50)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	rc, err := client.Bucket(bucket).Object(object).NewReader(ctx)
 	if err != nil {
 		return nil, err
@@ -193,7 +193,7 @@ func attrs(client *storage.Client, bucket, object string) (*storage.ObjectAttrs,
 	// [START get_metadata]
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	o := client.Bucket(bucket).Object(object)
 	attrs, err := o.Attrs(ctx)
 	if err != nil {
@@ -232,7 +232,7 @@ func setEventBasedHold(client *storage.Client, bucket, object string) error {
 	// [START storage_set_event_based_hold]
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	o := client.Bucket(bucket).Object(object)
 	objectAttrsToUpdate := storage.ObjectAttrsToUpdate{
 		EventBasedHold: true,
@@ -248,7 +248,7 @@ func releaseEventBasedHold(client *storage.Client, bucket, object string) error 
 	// [START storage_release_event_based_hold]
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	o := client.Bucket(bucket).Object(object)
 	objectAttrsToUpdate := storage.ObjectAttrsToUpdate{
 		EventBasedHold: false,
@@ -264,7 +264,7 @@ func setTemporaryHold(client *storage.Client, bucket, object string) error {
 	// [START storage_set_temporary_hold]
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	o := client.Bucket(bucket).Object(object)
 	objectAttrsToUpdate := storage.ObjectAttrsToUpdate{
 		TemporaryHold: true,
@@ -280,7 +280,7 @@ func releaseTemporaryHold(client *storage.Client, bucket, object string) error {
 	// [START storage_release_temporary_hold]
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	o := client.Bucket(bucket).Object(object)
 	objectAttrsToUpdate := storage.ObjectAttrsToUpdate{
 		TemporaryHold: false,
@@ -296,7 +296,7 @@ func makePublic(client *storage.Client, bucket, object string) error {
 	// [START public]
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	acl := client.Bucket(bucket).Object(object).ACL()
 	if err := acl.Set(ctx, storage.AllUsers, storage.RoleReader); err != nil {
 		return err
@@ -309,7 +309,7 @@ func move(client *storage.Client, bucket, object string) error {
 	// [START move_file]
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	dstName := object + "-rename"
 
 	src := client.Bucket(bucket).Object(object)
@@ -329,7 +329,7 @@ func copyToBucket(client *storage.Client, dstBucket, srcBucket, srcObject string
 	// [START copy_file]
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	dstObject := srcObject + "-copy"
 	src := client.Bucket(srcBucket).Object(srcObject)
 	dst := client.Bucket(dstBucket).Object(dstObject)
@@ -345,7 +345,7 @@ func delete(client *storage.Client, bucket, object string) error {
 	// [START delete_file]
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	o := client.Bucket(bucket).Object(object)
 	if err := o.Delete(ctx); err != nil {
 		return err
@@ -361,7 +361,7 @@ func writeEncryptedObject(client *storage.Client, bucket, object string, secretK
 	obj := client.Bucket(bucket).Object(object)
 
 	ctx, cancel := context.WithTimeout(ctx, time.Second*50)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 
 	// Encrypt the object's contents.
 	wc := obj.Key(secretKey).NewWriter(ctx)
@@ -382,7 +382,7 @@ func writeWithKMSKey(client *storage.Client, bucket, object string, keyName stri
 	obj := client.Bucket(bucket).Object(object)
 
 	ctx, cancel := context.WithTimeout(ctx, time.Second*50)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 
 	// Encrypt the object's contents
 	wc := obj.NewWriter(ctx)
@@ -403,7 +403,7 @@ func readEncryptedObject(client *storage.Client, bucket, object string, secretKe
 	obj := client.Bucket(bucket).Object(object)
 
 	ctx, cancel := context.WithTimeout(ctx, time.Second*50)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	rc, err := obj.Key(secretKey).NewReader(ctx)
 	if err != nil {
 		return nil, err
@@ -429,7 +429,7 @@ func rotateEncryptionKey(client *storage.Client, bucket, object string, key, new
 	obj := client.Bucket(bucket).Object(object)
 
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	// obj is encrypted with key, we are encrypting it with the newKey.
 	_, err = obj.Key(newKey).CopierFrom(obj.Key(key)).Run(ctx)
 	if err != nil {
@@ -452,7 +452,7 @@ func downloadUsingRequesterPays(client *storage.Client, object, bucketName, loca
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, time.Second*50)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	rc, err := src.NewReader(ctx)
 	if err != nil {
 		return err

--- a/storage/objects/main.go
+++ b/storage/objects/main.go
@@ -90,14 +90,16 @@ func main() {
 }
 
 func write(client *storage.Client, bucket, object string) error {
-	ctx := context.Background()
 	// [START upload_file]
+	ctx := context.Background()
 	f, err := os.Open("notes.txt")
 	if err != nil {
 		return err
 	}
 	defer f.Close()
 
+	ctx, cancel := context.WithTimeout(ctx, time.Second*50)
+	defer cancel() // Add a timeout for this call.
 	wc := client.Bucket(bucket).Object(object).NewWriter(ctx)
 	if _, err = io.Copy(wc, f); err != nil {
 		return err
@@ -110,8 +112,10 @@ func write(client *storage.Client, bucket, object string) error {
 }
 
 func list(w io.Writer, client *storage.Client, bucket string) error {
-	ctx := context.Background()
 	// [START storage_list_files]
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	it := client.Bucket(bucket).Objects(ctx, nil)
 	for {
 		attrs, err := it.Next()
@@ -128,7 +132,6 @@ func list(w io.Writer, client *storage.Client, bucket string) error {
 }
 
 func listByPrefix(w io.Writer, client *storage.Client, bucket, prefix, delim string) error {
-	ctx := context.Background()
 	// [START storage_list_files_with_prefix]
 	// Prefixes and delimiters can be used to emulate directory listings.
 	// Prefixes can be used filter objects starting with prefix.
@@ -146,6 +149,9 @@ func listByPrefix(w io.Writer, client *storage.Client, bucket, prefix, delim str
 	//
 	// However, if you specify prefix="a/" and delim="/", you'll get back:
 	//   /a/1.txt
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	it := client.Bucket(bucket).Objects(ctx, &storage.Query{
 		Prefix:    prefix,
 		Delimiter: delim,
@@ -165,8 +171,10 @@ func listByPrefix(w io.Writer, client *storage.Client, bucket, prefix, delim str
 }
 
 func read(client *storage.Client, bucket, object string) ([]byte, error) {
-	ctx := context.Background()
 	// [START download_file]
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*50)
+	defer cancel() // Add a timeout for this call.
 	rc, err := client.Bucket(bucket).Object(object).NewReader(ctx)
 	if err != nil {
 		return nil, err
@@ -182,8 +190,10 @@ func read(client *storage.Client, bucket, object string) ([]byte, error) {
 }
 
 func attrs(client *storage.Client, bucket, object string) (*storage.ObjectAttrs, error) {
-	ctx := context.Background()
 	// [START get_metadata]
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	o := client.Bucket(bucket).Object(object)
 	attrs, err := o.Attrs(ctx)
 	if err != nil {
@@ -219,8 +229,10 @@ func attrs(client *storage.Client, bucket, object string) (*storage.ObjectAttrs,
 }
 
 func setEventBasedHold(client *storage.Client, bucket, object string) error {
-	ctx := context.Background()
 	// [START storage_set_event_based_hold]
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	o := client.Bucket(bucket).Object(object)
 	objectAttrsToUpdate := storage.ObjectAttrsToUpdate{
 		EventBasedHold: true,
@@ -233,8 +245,10 @@ func setEventBasedHold(client *storage.Client, bucket, object string) error {
 }
 
 func releaseEventBasedHold(client *storage.Client, bucket, object string) error {
-	ctx := context.Background()
 	// [START storage_release_event_based_hold]
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	o := client.Bucket(bucket).Object(object)
 	objectAttrsToUpdate := storage.ObjectAttrsToUpdate{
 		EventBasedHold: false,
@@ -247,8 +261,10 @@ func releaseEventBasedHold(client *storage.Client, bucket, object string) error 
 }
 
 func setTemporaryHold(client *storage.Client, bucket, object string) error {
-	ctx := context.Background()
 	// [START storage_set_temporary_hold]
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	o := client.Bucket(bucket).Object(object)
 	objectAttrsToUpdate := storage.ObjectAttrsToUpdate{
 		TemporaryHold: true,
@@ -261,8 +277,10 @@ func setTemporaryHold(client *storage.Client, bucket, object string) error {
 }
 
 func releaseTemporaryHold(client *storage.Client, bucket, object string) error {
-	ctx := context.Background()
 	// [START storage_release_temporary_hold]
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	o := client.Bucket(bucket).Object(object)
 	objectAttrsToUpdate := storage.ObjectAttrsToUpdate{
 		TemporaryHold: false,
@@ -275,8 +293,10 @@ func releaseTemporaryHold(client *storage.Client, bucket, object string) error {
 }
 
 func makePublic(client *storage.Client, bucket, object string) error {
-	ctx := context.Background()
 	// [START public]
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	acl := client.Bucket(bucket).Object(object).ACL()
 	if err := acl.Set(ctx, storage.AllUsers, storage.RoleReader); err != nil {
 		return err
@@ -286,8 +306,10 @@ func makePublic(client *storage.Client, bucket, object string) error {
 }
 
 func move(client *storage.Client, bucket, object string) error {
-	ctx := context.Background()
 	// [START move_file]
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	dstName := object + "-rename"
 
 	src := client.Bucket(bucket).Object(object)
@@ -304,8 +326,10 @@ func move(client *storage.Client, bucket, object string) error {
 }
 
 func copyToBucket(client *storage.Client, dstBucket, srcBucket, srcObject string) error {
-	ctx := context.Background()
 	// [START copy_file]
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	dstObject := srcObject + "-copy"
 	src := client.Bucket(srcBucket).Object(srcObject)
 	dst := client.Bucket(dstBucket).Object(dstObject)
@@ -318,8 +342,10 @@ func copyToBucket(client *storage.Client, dstBucket, srcBucket, srcObject string
 }
 
 func delete(client *storage.Client, bucket, object string) error {
-	ctx := context.Background()
 	// [START delete_file]
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	o := client.Bucket(bucket).Object(object)
 	if err := o.Delete(ctx); err != nil {
 		return err
@@ -330,10 +356,13 @@ func delete(client *storage.Client, bucket, object string) error {
 
 // writeEncryptedObject writes an object encrypted with user-provided AES key to a bucket.
 func writeEncryptedObject(client *storage.Client, bucket, object string, secretKey []byte) error {
-	ctx := context.Background()
-
 	// [START storage_upload_encrypted_file]
+	ctx := context.Background()
 	obj := client.Bucket(bucket).Object(object)
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*50)
+	defer cancel() // Add a timeout for this call.
+
 	// Encrypt the object's contents.
 	wc := obj.Key(secretKey).NewWriter(ctx)
 	if _, err := wc.Write([]byte("top secret")); err != nil {
@@ -348,10 +377,13 @@ func writeEncryptedObject(client *storage.Client, bucket, object string, secretK
 
 // writeWithKMSKey writes an object encrypted with KMS-provided key to a bucket.
 func writeWithKMSKey(client *storage.Client, bucket, object string, keyName string) error {
-	ctx := context.Background()
-
 	// [START storage_upload_with_kms_key]
+	ctx := context.Background()
 	obj := client.Bucket(bucket).Object(object)
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*50)
+	defer cancel() // Add a timeout for this call.
+
 	// Encrypt the object's contents
 	wc := obj.NewWriter(ctx)
 	wc.KMSKeyName = keyName
@@ -366,10 +398,12 @@ func writeWithKMSKey(client *storage.Client, bucket, object string, keyName stri
 }
 
 func readEncryptedObject(client *storage.Client, bucket, object string, secretKey []byte) ([]byte, error) {
-	ctx := context.Background()
-
 	// [START storage_download_encrypted_file]
+	ctx := context.Background()
 	obj := client.Bucket(bucket).Object(object)
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*50)
+	defer cancel() // Add a timeout for this call.
 	rc, err := obj.Key(secretKey).NewReader(ctx)
 	if err != nil {
 		return nil, err
@@ -385,13 +419,17 @@ func readEncryptedObject(client *storage.Client, bucket, object string, secretKe
 }
 
 func rotateEncryptionKey(client *storage.Client, bucket, object string, key, newKey []byte) error {
-	ctx := context.Background()
 	// [START storage_rotate_encryption_key]
+	ctx := context.Background()
+
 	client, err := storage.NewClient(ctx)
 	if err != nil {
 		return err
 	}
 	obj := client.Bucket(bucket).Object(object)
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	// obj is encrypted with key, we are encrypting it with the newKey.
 	_, err = obj.Key(newKey).CopierFrom(obj.Key(key)).Run(ctx)
 	if err != nil {
@@ -402,8 +440,9 @@ func rotateEncryptionKey(client *storage.Client, bucket, object string, key, new
 }
 
 func downloadUsingRequesterPays(client *storage.Client, object, bucketName, localpath, billingProjectID string) error {
-	ctx := context.Background()
 	// [START storage_download_file_requester_pays]
+	ctx := context.Background()
+
 	bucket := client.Bucket(bucketName).UserProject(billingProjectID)
 	src := bucket.Object(object)
 
@@ -411,6 +450,9 @@ func downloadUsingRequesterPays(client *storage.Client, object, bucketName, loca
 	if err != nil {
 		return err
 	}
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*50)
+	defer cancel() // Add a timeout for this call.
 	rc, err := src.NewReader(ctx)
 	if err != nil {
 		return err

--- a/storage/s3_sdk/list_gcs_buckets.go
+++ b/storage/s3_sdk/list_gcs_buckets.go
@@ -42,7 +42,7 @@ func listGCSBuckets(w io.Writer, googleAccessKeyID string, googleAccessKeySecret
 	ctx := context.Background()
 
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	result, err := client.ListBucketsWithContext(ctx, &s3.ListBucketsInput{})
 	if err != nil {
 		return nil, err

--- a/storage/s3_sdk/list_gcs_buckets.go
+++ b/storage/s3_sdk/list_gcs_buckets.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -40,6 +41,8 @@ func listGCSBuckets(w io.Writer, googleAccessKeyID string, googleAccessKeySecret
 	client := s3.New(sess)
 	ctx := context.Background()
 
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	result, err := client.ListBucketsWithContext(ctx, &s3.ListBucketsInput{})
 	if err != nil {
 		return nil, err

--- a/storage/service_account/hmac/activate.go
+++ b/storage/service_account/hmac/activate.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"time"
 )
 
 // activateHMACKey activates the HMAC key with the given access ID.
@@ -34,6 +35,8 @@ func activateHMACKey(w io.Writer, accessID string, projectID string) (*storage.H
 	defer client.Close() // Closing the client safely cleans up background resources.
 
 	handle := client.HMACKeyHandle(projectID, accessID)
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	key, err := handle.Update(ctx, storage.HMACKeyAttrsToUpdate{State: "ACTIVE"})
 	if err != nil {
 		return nil, fmt.Errorf("Update: %v", err)

--- a/storage/service_account/hmac/activate.go
+++ b/storage/service_account/hmac/activate.go
@@ -36,7 +36,7 @@ func activateHMACKey(w io.Writer, accessID string, projectID string) (*storage.H
 
 	handle := client.HMACKeyHandle(projectID, accessID)
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	key, err := handle.Update(ctx, storage.HMACKeyAttrsToUpdate{State: "ACTIVE"})
 	if err != nil {
 		return nil, fmt.Errorf("Update: %v", err)

--- a/storage/service_account/hmac/create.go
+++ b/storage/service_account/hmac/create.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"time"
 )
 
 // createHMACKey creates a new HMAC key using the given project and service account.
@@ -33,6 +34,8 @@ func createHMACKey(w io.Writer, projectID string, serviceAccountEmail string) (*
 	}
 	defer client.Close() // Closing the client safely cleans up background resources.
 
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	key, err := client.CreateHMACKey(ctx, projectID, serviceAccountEmail)
 	if err != nil {
 		return nil, fmt.Errorf("CreateHMACKey: %v", err)

--- a/storage/service_account/hmac/create.go
+++ b/storage/service_account/hmac/create.go
@@ -35,7 +35,7 @@ func createHMACKey(w io.Writer, projectID string, serviceAccountEmail string) (*
 	defer client.Close() // Closing the client safely cleans up background resources.
 
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	key, err := client.CreateHMACKey(ctx, projectID, serviceAccountEmail)
 	if err != nil {
 		return nil, fmt.Errorf("CreateHMACKey: %v", err)

--- a/storage/service_account/hmac/deactivate.go
+++ b/storage/service_account/hmac/deactivate.go
@@ -35,7 +35,7 @@ func deactivateHMACKey(w io.Writer, accessID string, projectID string) (*storage
 	defer client.Close() // Closing the client safely cleans up background resources.
 
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	handle := client.HMACKeyHandle(projectID, accessID)
 	key, err := handle.Update(ctx, storage.HMACKeyAttrsToUpdate{State: "INACTIVE"})
 	if err != nil {

--- a/storage/service_account/hmac/deactivate.go
+++ b/storage/service_account/hmac/deactivate.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"time"
 )
 
 // deactivateHMACKey deactivates the HMAC key with the given access ID.
@@ -33,6 +34,8 @@ func deactivateHMACKey(w io.Writer, accessID string, projectID string) (*storage
 	}
 	defer client.Close() // Closing the client safely cleans up background resources.
 
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	handle := client.HMACKeyHandle(projectID, accessID)
 	key, err := handle.Update(ctx, storage.HMACKeyAttrsToUpdate{State: "INACTIVE"})
 	if err != nil {

--- a/storage/service_account/hmac/delete.go
+++ b/storage/service_account/hmac/delete.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"time"
 )
 
 // deleteHMACKey deletes the HMAC key with the given access ID. Key must have state
@@ -35,6 +36,8 @@ func deleteHMACKey(w io.Writer, accessID string, projectID string) error {
 	defer client.Close() // Closing the client safely cleans up background resources.
 
 	handle := client.HMACKeyHandle(projectID, accessID)
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	if err = handle.Delete(ctx); err != nil {
 		return fmt.Errorf("Delete: %v", err)
 	}

--- a/storage/service_account/hmac/delete.go
+++ b/storage/service_account/hmac/delete.go
@@ -37,7 +37,7 @@ func deleteHMACKey(w io.Writer, accessID string, projectID string) error {
 
 	handle := client.HMACKeyHandle(projectID, accessID)
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	if err = handle.Delete(ctx); err != nil {
 		return fmt.Errorf("Delete: %v", err)
 	}

--- a/storage/service_account/hmac/get.go
+++ b/storage/service_account/hmac/get.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"time"
 )
 
 // getHMACKey retrieves the HMACKeyMetadata with the given access id.
@@ -34,6 +35,8 @@ func getHMACKey(w io.Writer, accessID string, projectID string) (*storage.HMACKe
 	defer client.Close() // Closing the client safely cleans up background resources.
 
 	handle := client.HMACKeyHandle(projectID, accessID)
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	key, err := handle.Get(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("Get: %v", err)

--- a/storage/service_account/hmac/get.go
+++ b/storage/service_account/hmac/get.go
@@ -36,7 +36,7 @@ func getHMACKey(w io.Writer, accessID string, projectID string) (*storage.HMACKe
 
 	handle := client.HMACKeyHandle(projectID, accessID)
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	key, err := handle.Get(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("Get: %v", err)

--- a/storage/service_account/hmac/list.go
+++ b/storage/service_account/hmac/list.go
@@ -36,7 +36,7 @@ func listHMACKeys(w io.Writer, projectID string) ([]*storage.HMACKey, error) {
 	defer client.Close() // Closing the client safely cleans up background resources.
 
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	iter := client.ListHMACKeys(ctx, projectID)
 	var keys []*storage.HMACKey
 	for {

--- a/storage/service_account/hmac/list.go
+++ b/storage/service_account/hmac/list.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"google.golang.org/api/iterator"
 	"io"
+	"time"
 )
 
 // listHMACKeys lists all HMAC keys associated with the project.
@@ -34,6 +35,8 @@ func listHMACKeys(w io.Writer, projectID string) ([]*storage.HMACKey, error) {
 	}
 	defer client.Close() // Closing the client safely cleans up background resources.
 
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	iter := client.ListHMACKeys(ctx, projectID)
 	var keys []*storage.HMACKey
 	for {

--- a/storage/storage_quickstart/main.go
+++ b/storage/storage_quickstart/main.go
@@ -46,7 +46,7 @@ func main() {
 
 	// Creates the new bucket.
 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-	defer cancel() // Add a timeout for this call.
+	defer cancel()
 	if err := bucket.Create(ctx, projectID, nil); err != nil {
 		log.Fatalf("Failed to create bucket: %v", err)
 	}

--- a/storage/storage_quickstart/main.go
+++ b/storage/storage_quickstart/main.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	"cloud.google.com/go/storage"
 )
@@ -44,6 +45,8 @@ func main() {
 	bucket := client.Bucket(bucketName)
 
 	// Creates the new bucket.
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel() // Add a timeout for this call.
 	if err := bucket.Create(ctx, projectID, nil); err != nil {
 		log.Fatalf("Failed to create bucket: %v", err)
 	}


### PR DESCRIPTION
The storage client doesn't automatically include timeouts by default,
and users are expected to set their own. This should be included
in sample code.