### PR TITLE
appengine: added closure of client to avoid memory spike

### DIFF
--- a/appengine/go11x/tasks/create_task/create_task.go
+++ b/appengine/go11x/tasks/create_task/create_task.go
@@ -61,6 +61,9 @@ func createTask(projectID, locationID, queueID, message string) (*taskspb.Task, 
 		return nil, fmt.Errorf("cloudtasks.CreateTask: %v", err)
 	}
 
+	// Closing the client is important, if not done then it will result in Memory spike
+	defer client.Close()
+
 	return createdTask, nil
 }
 

--- a/appengine/go11x/tasks/create_task/create_task.go
+++ b/appengine/go11x/tasks/create_task/create_task.go
@@ -34,6 +34,7 @@ func createTask(projectID, locationID, queueID, message string) (*taskspb.Task, 
 	if err != nil {
 		return nil, fmt.Errorf("NewClient: %v", err)
 	}
+	defer client.Close()
 
 	// Build the Task queue path.
 	queuePath := fmt.Sprintf("projects/%s/locations/%s/queues/%s", projectID, locationID, queueID)
@@ -60,9 +61,6 @@ func createTask(projectID, locationID, queueID, message string) (*taskspb.Task, 
 	if err != nil {
 		return nil, fmt.Errorf("cloudtasks.CreateTask: %v", err)
 	}
-
-	// Closing the client is important, if not done then it will result in Memory spike
-	defer client.Close()
 
 	return createdTask, nil
 }


### PR DESCRIPTION
While using golang create task example, I experienced there was a spike in memory since the client was not closed.

Added closure of client to allow go clean the memory and to avoid production memory spike.

Thanks.