### PR TITLE
all, run: go mod tidy, don't use log.Writer (added in Go 1.13)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	cloud.google.com/go/spanner v1.1.0
 	cloud.google.com/go/storage v1.3.0
 	contrib.go.opencensus.io/exporter/stackdriver v0.12.9
-	firebase.google.com/go v3.12.0+incompatible
 	github.com/aws/aws-sdk-go v1.28.9
 	github.com/bmatcuk/doublestar v1.2.2
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,6 @@ cloud.google.com/go/storage v1.3.0/go.mod h1:9IAwXhoyBJ7z9LcAwkj0/7NnPzYaPeZxxVp
 contrib.go.opencensus.io/exporter/stackdriver v0.12.9 h1:ZRVpDigsb+nVI/yps/NLDOYzYjFFmm3OCsBhmYocxR0=
 contrib.go.opencensus.io/exporter/stackdriver v0.12.9/go.mod h1:XyyafDnFOsqoxHJgTFycKZMrRUrPThLh2iYTJF6uoO0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-firebase.google.com/go v3.12.0+incompatible h1:q70KCp/J0oOL8kJ8oV2j3646kV4TB8Y5IvxXC0WT1bo=
-firebase.google.com/go v3.12.0+incompatible/go.mod h1:xlah6XbEyW6tbfSklcfe5FHJIwjt8toICdV5Wh9ptHs=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=

--- a/run/logging-manual/main_test.go
+++ b/run/logging-manual/main_test.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 )
 
@@ -80,7 +81,7 @@ func callHandler(h func(w http.ResponseWriter, r *http.Request), rr http.Respons
 	var buf bytes.Buffer
 	writer := bufio.NewWriter(&buf)
 
-	originalWriter := log.Writer()
+	originalWriter := os.Stderr
 	log.SetOutput(writer)
 	defer log.SetOutput(originalWriter)
 


### PR DESCRIPTION
Example `log.Writer()` failure: https://source.cloud.google.com/results/invocations/eaa8e2f4-93f2-45d0-87ba-70d8bbabe8a6/targets/cloud-devrel%2Fgo%2Fgolang-samples%2Fpresubmit%2Fgo112/log