### PR TITLE
bigquery: update streaming insert snippet

### DIFF
--- a/bigquery/snippets/table/bigquery_table_insert_rows.go
+++ b/bigquery/snippets/table/bigquery_table_insert_rows.go
@@ -29,11 +29,12 @@ type Item struct {
 }
 
 // Save implements the ValueSaver interface.
+// This example disables best-effort de-duplication, which allows for higher throughput.
 func (i *Item) Save() (map[string]bigquery.Value, string, error) {
 	return map[string]bigquery.Value{
 		"full_name": i.Name,
 		"age":       i.Age,
-	}, "", nil
+	}, bigquery.NoDedupeID, nil
 }
 
 // insertRows demonstrates inserting data into a table using the streaming insert mechanism.


### PR DESCRIPTION
This snippet now demonstrates how to disable best effort deduplication,
which allows for higher quota/throughput in streaming insert usage.