### PR TITLE
testing/kokoro: use buildcop.sh script

### DIFF
--- a/testing/kokoro/buildcop.sh
+++ b/testing/kokoro/buildcop.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is manually copied to
+# gs://cloud-devrel-kokoro-resources/trampoline/buildcop.sh.
+
+# See https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop.
+
+type gcloud > /dev/null 2>&1 || { echo >&2 "gcloud is required! Not sending logs to the Build Cop Bot." && exit 1 }
+
+gcloud auth activate-service-account --key-file $KOKORO_GFILE_DIR/kokoro-trampoline.service-account.json
+
+REPO=$(echo $KOKORO_GITHUB_COMMIT_URL | cut -d/ -f 4,5)
+
+if [ -z ${INSTALLATION_ID+x} ]; then
+    if [ $REPO = *"GoogleCloudPlatform"* ]; then
+        INSTALLATION_ID=5943459
+    elif [ $REPO = *"googleapis"* ]; then
+        INSTALLATION_ID=6370238
+    else
+        echo >&2 "INSTALLATION_ID unset. If your repo is part of GoogleCloudPlatform or googleapis and you see this error,"
+        echo >&2 "file an issue at https://github.com/googleapis/repo-automation-bots/issues."
+        echo >&2 "Otherwise, set INSTALLATION_ID with the numeric installation ID before calling buildcop.sh"
+        echo >&2 "See https://github.com/apps/build-cop-bot/".
+        exit 1
+    fi
+fi
+
+# Loop over all sponge_log.xml files.
+shopt -s globstar
+for log in **/sponge_log.xml; do
+    XML=$(base64 -w 0 $log)
+
+    # See https://github.com/apps/build-cop-bot/installations/5943459.
+    MESSAGE=$(cat <<EOF
+    {
+        "Name": "buildcop",
+        "Type" : "function",
+        "Location": "us-central1",
+        "installation": {"id": "$INSTALLATION_ID"},
+        "repo": "$REPO",
+        "buildID": "$KOKORO_GIT_COMMIT",
+        "buildURL": "[Build Status](https://source.cloud.google.com/results/invocations/$KOKORO_BUILD_ID), [Sponge](http://sponge2/$KOKORO_BUILD_ID)",
+        "xunitXML": "$XML"
+    }
+EOF
+    )
+
+    gcloud pubsub topics publish passthrough --project=repo-automation-bots --message="$MESSAGE"
+done

--- a/testing/kokoro/system_tests.sh
+++ b/testing/kokoro/system_tests.sh
@@ -221,28 +221,8 @@ EXIT_CODE=$?
 # If we're running system tests, send the test log to the Build Cop Bot.
 # See https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop.
 if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"system-tests"* ]]; then
-  # Use the service account with access to the repo-automation-bots project.
-  gcloud auth activate-service-account --key-file $KOKORO_KEYSTORE_DIR/71386_kokoro-golang-samples-tests
-  gcloud config set project repo-automation-bots
-
-  XML=$(base64 -w 0 sponge_log.xml)
-
-  # See https://github.com/apps/build-cop-bot/installations/5943459.
-  MESSAGE=$(cat <<EOF
-  {
-      "Name": "buildcop",
-      "Type" : "function",
-      "Location": "us-central1",
-      "installation": {"id": "5943459"},
-      "repo": "GoogleCloudPlatform/golang-samples",
-      "buildID": "commit:$KOKORO_GIT_COMMIT",
-      "buildURL": "https://source.cloud.google.com/results/invocations/$KOKORO_BUILD_ID",
-      "xunitXML": "$XML"
-  }
-EOF
-  )
-
-  gcloud pubsub topics publish passthrough --message="$MESSAGE"
+  chmod +x $KOKORO_GFILE_DIR/buildcop.sh
+  $KOKORO_GFILE_DIR/buildcop.sh
 fi
 
 exit $EXIT_CODE


### PR DESCRIPTION
The testing for this PR will be a no-op because the buildcop script is only called for system tests.

The goal of this is to simplify sending logs to the Build Cop Bot. For most repos, calling the script (as in this example) should be enough to enable it.

I already copied the script to the Trampoline directory. I included it in this PR so it could get a code review.

I'm not 100% sure about the markdown syntax in the `buildURL` field. But, I'm hoping it will be passed through properly.