### PR TITLE
docs: Update securitycenter notification samples to v1

### DIFF
--- a/securitycenter/notifications/create_notification_config.go
+++ b/securitycenter/notifications/create_notification_config.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 	"io"
 
-	securitycenter "cloud.google.com/go/securitycenter/apiv1p1beta1"
-	securitycenterpb "google.golang.org/genproto/googleapis/cloud/securitycenter/v1p1beta1"
+	securitycenter "cloud.google.com/go/securitycenter/apiv1"
+	securitycenterpb "google.golang.org/genproto/googleapis/cloud/securitycenter/v1"
 )
 
 func createNotificationConfig(w io.Writer, orgID string, pubsubTopic string, notificationConfigID string) error {
@@ -42,7 +42,6 @@ func createNotificationConfig(w io.Writer, orgID string, pubsubTopic string, not
 		NotificationConfig: &securitycenterpb.NotificationConfig{
 			Description: "Go sample config",
 			PubsubTopic: pubsubTopic,
-			EventType:   securitycenterpb.NotificationConfig_FINDING,
 			NotifyConfig: &securitycenterpb.NotificationConfig_StreamingConfig_{
 				StreamingConfig: &securitycenterpb.NotificationConfig_StreamingConfig{
 					Filter: `state = "ACTIVE"`,

--- a/securitycenter/notifications/delete_notification_config.go
+++ b/securitycenter/notifications/delete_notification_config.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 	"io"
 
-	securitycenter "cloud.google.com/go/securitycenter/apiv1p1beta1"
-	securitycenterpb "google.golang.org/genproto/googleapis/cloud/securitycenter/v1p1beta1"
+	securitycenter "cloud.google.com/go/securitycenter/apiv1"
+	securitycenterpb "google.golang.org/genproto/googleapis/cloud/securitycenter/v1"
 )
 
 func deleteNotificationConfig(w io.Writer, orgID string, notificationConfigID string) error {

--- a/securitycenter/notifications/get_notification_config.go
+++ b/securitycenter/notifications/get_notification_config.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 	"io"
 
-	securitycenter "cloud.google.com/go/securitycenter/apiv1p1beta1"
-	securitycenterpb "google.golang.org/genproto/googleapis/cloud/securitycenter/v1p1beta1"
+	securitycenter "cloud.google.com/go/securitycenter/apiv1"
+	securitycenterpb "google.golang.org/genproto/googleapis/cloud/securitycenter/v1"
 )
 
 func getNotificationConfig(w io.Writer, orgID string, notificationConfigID string) error {

--- a/securitycenter/notifications/list_notification_configs.go
+++ b/securitycenter/notifications/list_notification_configs.go
@@ -19,9 +19,9 @@ import (
 	"fmt"
 	"io"
 
-	securitycenter "cloud.google.com/go/securitycenter/apiv1p1beta1"
+	securitycenter "cloud.google.com/go/securitycenter/apiv1"
 	"google.golang.org/api/iterator"
-	securitycenterpb "google.golang.org/genproto/googleapis/cloud/securitycenter/v1p1beta1"
+	securitycenterpb "google.golang.org/genproto/googleapis/cloud/securitycenter/v1"
 )
 
 func listNotificationConfigs(w io.Writer, orgID string) error {

--- a/securitycenter/notifications/notifications_test.go
+++ b/securitycenter/notifications/notifications_test.go
@@ -21,9 +21,9 @@ import (
 	"strings"
 	"testing"
 
-	securitycenter "cloud.google.com/go/securitycenter/apiv1p1beta1"
+	securitycenter "cloud.google.com/go/securitycenter/apiv1"
 	"github.com/google/uuid"
-	securitycenterpb "google.golang.org/genproto/googleapis/cloud/securitycenter/v1p1beta1"
+	securitycenterpb "google.golang.org/genproto/googleapis/cloud/securitycenter/v1"
 )
 
 func orgID(t *testing.T) string {

--- a/securitycenter/notifications/receive_notifications.go
+++ b/securitycenter/notifications/receive_notifications.go
@@ -22,7 +22,7 @@ import (
 
 	"cloud.google.com/go/pubsub"
 	"github.com/golang/protobuf/jsonpb"
-	securitycenterpb "google.golang.org/genproto/googleapis/cloud/securitycenter/v1p1beta1"
+	securitycenterpb "google.golang.org/genproto/googleapis/cloud/securitycenter/v1"
 )
 
 func receiveMessages(w io.Writer, projectID string, subscriptionName string) error {

--- a/securitycenter/notifications/update_notification_config.go
+++ b/securitycenter/notifications/update_notification_config.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 	"io"
 
-	securitycenter "cloud.google.com/go/securitycenter/apiv1p1beta1"
-	securitycenterpb "google.golang.org/genproto/googleapis/cloud/securitycenter/v1p1beta1"
+	securitycenter "cloud.google.com/go/securitycenter/apiv1"
+	securitycenterpb "google.golang.org/genproto/googleapis/cloud/securitycenter/v1"
 	"google.golang.org/genproto/protobuf/field_mask"
 )
 


### PR DESCRIPTION
Notification feature work has been merged into v1, so we need to update the samples to match the updated version.
