### PR TITLE
container_registry, storage: goimports, fix tests, and rename package main

### DIFF
--- a/container_registry/container_analysis/create_note.go
+++ b/container_registry/container_analysis/create_note.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package containeranalysis
 
 // [START containeranalysis_create_note]
 

--- a/container_registry/container_analysis/create_occurrence.go
+++ b/container_registry/container_analysis/create_occurrence.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package containeranalysis
 
 // [START containeranalysis_create_occurrence]
 

--- a/container_registry/container_analysis/delete_note.go
+++ b/container_registry/container_analysis/delete_note.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package containeranalysis
 
 // [START containeranalysis_delete_note]
 

--- a/container_registry/container_analysis/delete_occurrence.go
+++ b/container_registry/container_analysis/delete_occurrence.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package containeranalysis
 
 // [START containeranalysis_delete_occurrence]
 

--- a/container_registry/container_analysis/filter_vulnerability_occurrences.go
+++ b/container_registry/container_analysis/filter_vulnerability_occurrences.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package containeranalysis
 
 // [START containeranalysis_filter_vulnerability_occurrences]
 

--- a/container_registry/container_analysis/get_discovery_info.go
+++ b/container_registry/container_analysis/get_discovery_info.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package containeranalysis
 
 // [START containeranalysis_discovery_info]
 

--- a/container_registry/container_analysis/get_note.go
+++ b/container_registry/container_analysis/get_note.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package containeranalysis
 
 // [START containeranalysis_get_note]
 

--- a/container_registry/container_analysis/get_occurrence.go
+++ b/container_registry/container_analysis/get_occurrence.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package containeranalysis
 
 // [START containeranalysis_get_occurrence]
 

--- a/container_registry/container_analysis/occurrences_for_image.go
+++ b/container_registry/container_analysis/occurrences_for_image.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package containeranalysis
 
 // [START containeranalysis_occurrences_for_image]
 

--- a/container_registry/container_analysis/occurrences_for_note.go
+++ b/container_registry/container_analysis/occurrences_for_note.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package containeranalysis
 
 // [START containeranalysis_occurrences_for_note]
 

--- a/container_registry/container_analysis/poll_discovery_finished.go
+++ b/container_registry/container_analysis/poll_discovery_finished.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package containeranalysis
 
 // [START containeranalysis_poll_discovery_occurrence_finished]
 

--- a/container_registry/container_analysis/samples_test.go
+++ b/container_registry/container_analysis/samples_test.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package sample provides code samples for the Container Analysis libraries: https://cloud.google.com/container-registry/docs/container-analysis
-package main
+package containeranalysis
 
 import (
 	"bytes"

--- a/container_registry/container_analysis/subscriptions.go
+++ b/container_registry/container_analysis/subscriptions.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package containeranalysis
 
 // [START containeranalysis_pubsub]
 

--- a/container_registry/container_analysis/vulnerability_occurrences_for_image.go
+++ b/container_registry/container_analysis/vulnerability_occurrences_for_image.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package containeranalysis
 
 // [START containeranalysis_vulnerability_occurrences_for_image]
 

--- a/storage/acl/acl_test.go
+++ b/storage/acl/acl_test.go
@@ -39,7 +39,7 @@ func TestACL(t *testing.T) {
 	defer client.Close()
 
 	var (
-		bucket                = tc.ProjectID + "-samples-object-bucket-1"
+		bucket                = tc.ProjectID + "-samples-acl-bucket-1"
 		object                = "foo.txt"
 		allAuthenticatedUsers = storage.AllAuthenticatedUsers
 	)

--- a/storage/objects/objects_test.go
+++ b/storage/objects/objects_test.go
@@ -28,6 +28,8 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 	"google.golang.org/api/iterator"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // TestObjects runs all samples tests of the package.
@@ -359,7 +361,7 @@ func cleanBucket(t *testing.T, ctx context.Context, client *storage.Client, proj
 			t.Fatalf("Bucket(%q).Delete: %v", bucket, err)
 		}
 	}
-	if err := b.Create(ctx, projectID, nil); err != nil {
+	if err := b.Create(ctx, projectID, nil); err != nil && status.Code(err) != codes.AlreadyExists {
 		t.Fatalf("Bucket(%q).Create: %v", bucket, err)
 	}
 }

--- a/storage/s3_sdk/list_gcs_buckets_test.go
+++ b/storage/s3_sdk/list_gcs_buckets_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 )
 
-
 func TestList(t *testing.T) {
 	ctx := context.Background()
 	tc := testutil.SystemTest(t)
@@ -49,7 +48,7 @@ func TestList(t *testing.T) {
 	buf := new(bytes.Buffer)
 	// New HMAC key may take up to 15s to propagate, so we need to retry for up
 	// to that amount of time.
-	testutil.Retry(t, 75, time.Millisecond*200, func (r *testutil.R) {
+	testutil.Retry(t, 75, time.Millisecond*200, func(r *testutil.R) {
 		buf.Reset()
 		if _, err := listGCSBuckets(buf, key.AccessID, key.Secret); err != nil {
 			r.Errorf("listGCSBuckets: %v", err)

--- a/storage/service_account/hmac/hmac_test.go
+++ b/storage/service_account/hmac/hmac_test.go
@@ -31,7 +31,7 @@ var storageClient *storage.Client
 
 func TestMain(m *testing.M) {
 	if serviceAccountEmail == "" {
-		fmt.Fprint(os.Stderr, "GOLANG_SAMPLES_SERVICE_ACCOUNT_EMAIL not set. Skipping.")
+		fmt.Fprintln(os.Stderr, "GOLANG_SAMPLES_SERVICE_ACCOUNT_EMAIL not set. Skipping.")
 		return
 	}
 	ctx := context.Background()


### PR DESCRIPTION
The container_analysis used package main, but didn't have a func main.

This should fix the build for #1267.