### PR TITLE
all: fix licenses, always run license test for PRs

### DIFF
--- a/license_test.go
+++ b/license_test.go
@@ -44,7 +44,10 @@ var skip = map[string]bool{
 	"endpoints/getting-started-grpc/client/main.go":              true,
 	"endpoints/getting-started-grpc/server/main.go":              true,
 	"endpoints/getting-started-grpc/helloworld/helloworld.pb.go": true,
-	"run/grpc-ping/pkg/api/v1/message.pb.go":                     true,
+
+	// Generated .pg.go files.
+	"run/grpc-ping/pkg/api/v1/message.pb.go":       true,
+	"profiler/shakesapp/shakesapp/shakesapp.pb.go": true,
 }
 
 func TestLicense(t *testing.T) {

--- a/profiler/shakesapp/main.go
+++ b/profiler/shakesapp/main.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/profiler/shakesapp/shakesapp/client.go
+++ b/profiler/shakesapp/shakesapp/client.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/profiler/shakesapp/shakesapp/server.go
+++ b/profiler/shakesapp/shakesapp/server.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/profiler/shakesapp/shakesapp/shakesapp.proto
+++ b/profiler/shakesapp/shakesapp/shakesapp.proto
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/testing/kokoro/system_tests.sh
+++ b/testing/kokoro/system_tests.sh
@@ -173,6 +173,7 @@ exit_code=0
 # runTests runs the tests in the current directory. If an argument is specified,
 # it is used as the argument to `go test`.
 runTests() {
+  set +x
   echo "Running 'go test' in '$(pwd)'..."
   set -x
   2>&1 go test -timeout $TIMEOUT -v ${1:-./...} | tee sponge_log.log
@@ -192,6 +193,7 @@ elif [[ -z "${CHANGED_DIRS// }" ]]; then
   echo "Only running root tests"
   runTests .
 else
+  runTests . # Always run root tests.
   echo "Running tests in modified directories: $CHANGED_DIRS"
   for d in $CHANGED_DIRS; do
     mods="$(find $d -name go.mod)"


### PR DESCRIPTION
We weren't running the root tests for PRs. So, these incorrect license
headers were not caught before merging the PR.