### PR TITLE
testing: move set +e before running tests

### DIFF
--- a/testing/kokoro/system_tests.sh
+++ b/testing/kokoro/system_tests.sh
@@ -169,6 +169,7 @@ fi
 date
 
 exit_code=0
+set +e
 
 # runTests runs the tests in the current directory. If an argument is specified,
 # it is used as the argument to `go test`.
@@ -216,8 +217,6 @@ else
     fi
   done
 fi
-
-set +e
 
 # If we're running system tests, send the test log to the Build Cop Bot.
 # See https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop.

--- a/testing/kokoro/system_tests.sh
+++ b/testing/kokoro/system_tests.sh
@@ -168,8 +168,10 @@ fi
 
 date
 
+# exit_code collects all of the exit codes of the tests, and is used to set the
+# exit code at the end of the script.
 exit_code=0
-set +e
+set +e # Don't exit on errors to make sure we run all tests.
 
 # runTests runs the tests in the current directory. If an argument is specified,
 # it is used as the argument to `go test`.


### PR DESCRIPTION
This way, we run all tests and actually publish them to the Build Cop Bot.