### PR TITLE
datastore: fix namespace sample

### DIFF
--- a/datastore/snippets/snippet_test.go
+++ b/datastore/snippets/snippet_test.go
@@ -672,7 +672,7 @@ func metadataNamespaces(w io.Writer, projectID string) error {
 
 	fmt.Fprintln(w, "Namespaces:")
 	for _, k := range keys {
-		fmt.Fprintf(w, "\t%v", k.Namespace)
+		fmt.Fprintf(w, "\t%v", k.Name)
 	}
 	return nil
 }


### PR DESCRIPTION
Testing, this seems to need `.Name` not `.Namespace`

Fixes: #1330 