### PR TITLE
functions/ci_cd: make region tags consistent across languages

### DIFF
--- a/functions/ci_cd/cloudbuild.yaml
+++ b/functions/ci_cd/cloudbuild.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START functions_ci_cd_cloud_build_go]
+# [START functions_ci_cd_cloud_build]
 steps:
   - name: 'mirror.gcr.io/library/golang'
     args: ['go', 'version']
@@ -22,4 +22,4 @@ steps:
   - name: 'gcr.io/cloud-builders/gcloud'
     args: ['functions', 'deploy', '[YOUR_DEPLOYED_FUNCTION_NAME]', '[YOUR_FUNCTION_TRIGGER]', '--runtime', '[YOUR_RUNTIME]', '--entry-point', '[YOUR_FUNCTION_NAME_IN_CODE]']
     dir: 'functions/autodeploy'
-# [END functions_ci_cd_cloud_build_go]
+# [END functions_ci_cd_cloud_build]


### PR DESCRIPTION
**Motivation:** we're adding [Java](https://github.com/GoogleCloudPlatform/java-docs-samples/pull/2615) and [Python](https://github.com/GoogleCloudPlatform/python-docs-samples/pull/3324) versions of this sample.

Related bug: b/153295209