### PR TITLE
all: create testutil.CleanBucket, add storage retries

### DIFF
--- a/asset/quickstart/export-assets/main_test.go
+++ b/asset/quickstart/export-assets/main_test.go
@@ -22,9 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	"cloud.google.com/go/storage"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-	"google.golang.org/api/iterator"
 )
 
 func TestMain(t *testing.T) {
@@ -33,13 +31,9 @@ func TestMain(t *testing.T) {
 	os.Setenv("GOOGLE_CLOUD_PROJECT", tc.ProjectID)
 
 	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		t.Fatalf("failed to create storage client: %v", err)
-	}
 
 	// Delete the bucket (if it exists) then recreate it.
-	cleanBucket(ctx, t, client, tc.ProjectID, bucketName)
+	testutil.CleanBucket(ctx, t, tc.ProjectID, bucketName)
 
 	oldStdout := os.Stdout
 	r, w, _ := os.Pipe()
@@ -59,41 +53,5 @@ func TestMain(t *testing.T) {
 	want := fmt.Sprintf("output_config:<gcs_destination:<uri:\"gs://%s/my-assets.txt\" > >", bucketName)
 	if !strings.Contains(got, want) {
 		t.Errorf("stdout returned %s, wanted to contain %s", got, want)
-	}
-}
-
-func cleanBucket(ctx context.Context, t *testing.T, client *storage.Client, projectID, bucket string) {
-	deleteBucketIfExists(ctx, t, client, bucket)
-
-	b := client.Bucket(bucket)
-	// Now create it
-	if err := b.Create(ctx, projectID, nil); err != nil {
-		t.Fatalf("Bucket.Create(%q): %v", bucket, err)
-	}
-}
-
-func deleteBucketIfExists(ctx context.Context, t *testing.T, client *storage.Client, bucket string) {
-	b := client.Bucket(bucket)
-	if _, err := b.Attrs(ctx); err != nil {
-		return
-	}
-
-	// Delete all the elements in the already existent bucket
-	it := b.Objects(ctx, nil)
-	for {
-		attrs, err := it.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			t.Fatalf("Bucket.Objects(%q): %v", bucket, err)
-		}
-		if err := b.Object(attrs.Name).Delete(ctx); err != nil {
-			t.Fatalf("Bucket(%q).Object(%q).Delete: %v", bucket, attrs.Name, err)
-		}
-	}
-	// Then delete the bucket itself
-	if err := b.Delete(ctx); err != nil {
-		t.Fatalf("Bucket.Delete(%q): %v", bucket, err)
 	}
 }

--- a/internal/testutil/storage_cleaner.go
+++ b/internal/testutil/storage_cleaner.go
@@ -1,0 +1,88 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/iterator"
+)
+
+// CleanBucket creates a new bucket. If the bucket already exists, it will be
+// deleted and recreated.
+func CleanBucket(ctx context.Context, t *testing.T, projectID, bucket string) error {
+	t.Helper()
+
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		t.Fatalf("storage.NewClient: %v", err)
+	}
+
+	// Delete the bucket if it exists.
+	deleteBucketIfExists(ctx, t, client, bucket)
+
+	b := client.Bucket(bucket)
+
+	// Now create the bucket.
+	// Retry because the bucket can take time to fully delete.
+	Retry(t, 10, 10*time.Second, func(r *R) {
+		if err := b.Create(ctx, projectID, nil); err != nil {
+			r.Errorf("Bucket.Create(%q): %v", bucket, err)
+		}
+	})
+	return nil
+}
+
+func deleteBucketIfExists(ctx context.Context, t *testing.T, client *storage.Client, bucket string) {
+	t.Helper()
+
+	b := client.Bucket(bucket)
+
+	// Check if the bucket does not exist, return nil.
+	if _, err := b.Attrs(ctx); err != nil {
+		return
+	}
+
+	// Delete all of the elements in the already existent bucket.
+	it := b.Objects(ctx, nil)
+	for {
+		attrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			t.Errorf("Bucket.Objects(%q): %v", bucket, err)
+		}
+		if attrs.EventBasedHold || attrs.TemporaryHold {
+			if _, err := b.Object(attrs.Name).Update(ctx, storage.ObjectAttrsToUpdate{
+				TemporaryHold:  false,
+				EventBasedHold: false,
+			}); err != nil {
+				t.Errorf("Bucket(%q).Object(%q).Update: %v", bucket, attrs.Name, err)
+			}
+		}
+		if err := b.Object(attrs.Name).Delete(ctx); err != nil {
+			t.Errorf("Bucket(%q).Object(%q).Delete: %v", bucket, attrs.Name, err)
+		}
+	}
+
+	// Then delete the bucket itself.
+	if err := b.Delete(ctx); err != nil {
+		t.Errorf("Bucket.Delete(%q): %v", bucket, err)
+	}
+}

--- a/storage/acl/acl_test.go
+++ b/storage/acl/acl_test.go
@@ -23,9 +23,6 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-	"google.golang.org/api/iterator"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // TestACL runs all of the package tests.
@@ -44,7 +41,7 @@ func TestACL(t *testing.T) {
 		allAuthenticatedUsers = storage.AllAuthenticatedUsers
 	)
 
-	cleanBucket(t, ctx, client, tc.ProjectID, bucket)
+	testutil.CleanBucket(ctx, t, tc.ProjectID, bucket)
 
 	b := client.Bucket(bucket)
 
@@ -100,39 +97,4 @@ func TestACL(t *testing.T) {
 			r.Errorf("Bucket(%q).Delete: %v", bucket, err)
 		}
 	})
-}
-
-// cleanBucket ensures there's a fresh bucket with a given name, deleting the existing bucket if it already exists.
-func cleanBucket(t *testing.T, ctx context.Context, client *storage.Client, projectID, bucket string) {
-	b := client.Bucket(bucket)
-	_, err := b.Attrs(ctx)
-	if err == nil {
-		it := b.Objects(ctx, nil)
-		for {
-			attrs, err := it.Next()
-			if err == iterator.Done {
-				break
-			}
-			if err != nil {
-				t.Fatalf("Bucket(%q).Objects: %v", bucket, err)
-			}
-			if attrs.EventBasedHold || attrs.TemporaryHold {
-				if _, err := b.Object(attrs.Name).Update(ctx, storage.ObjectAttrsToUpdate{
-					TemporaryHold:  false,
-					EventBasedHold: false,
-				}); err != nil {
-					t.Fatalf("Bucket(%q).Object(%q).Update: %v", bucket, attrs.Name, err)
-				}
-			}
-			if err := b.Object(attrs.Name).Delete(ctx); err != nil {
-				t.Fatalf("Bucket(%q).Object(%q).Delete: %v", bucket, attrs.Name, err)
-			}
-		}
-		if err := b.Delete(ctx); err != nil {
-			t.Fatalf("Bucket(%q).Delete: %v", bucket, err)
-		}
-	}
-	if err := b.Create(ctx, projectID, nil); err != nil && status.Code(err) != codes.AlreadyExists {
-		t.Fatalf("Bucket(%q).Create: %v", bucket, err)
-	}
 }

--- a/storage/buckets/set_bucket_default_kms_key.go
+++ b/storage/buckets/set_bucket_default_kms_key.go
@@ -24,8 +24,8 @@ import (
 	"cloud.google.com/go/storage"
 )
 
-// setBucketDefaultKmsKey sets the Cloud KMS encryption key for the bucket.
-func setBucketDefaultKmsKey(w io.Writer, bucketName, keyName string) error {
+// setBucketDefaultKMSKey sets the Cloud KMS encryption key for the bucket.
+func setBucketDefaultKMSKey(w io.Writer, bucketName, keyName string) error {
 	// bucketName := "bucket-name"
 	// keyName := "key"
 	ctx := context.Background()

--- a/storage/gcsupload/gcsupload_test.go
+++ b/storage/gcsupload/gcsupload_test.go
@@ -21,10 +21,6 @@ import (
 	"strings"
 	"testing"
 
-	"google.golang.org/api/iterator"
-
-	"cloud.google.com/go/storage"
-
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 )
 
@@ -32,15 +28,10 @@ func TestUpload(t *testing.T) {
 	tc := testutil.SystemTest(t)
 
 	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		t.Fatalf("Creating client: %v", err)
-	}
 	projectID := tc.ProjectID
 	bucket := projectID + "-gcsupload"
 
-	cleanBucket(t, ctx, client, projectID, bucket)
-	defer deleteBucketIfExists(t, ctx, client, bucket)
+	testutil.CleanBucket(ctx, t, projectID, bucket)
 
 	input := strings.Repeat("GCS test\n", 30)
 	r := strings.NewReader(input)
@@ -65,41 +56,5 @@ func TestUpload(t *testing.T) {
 	h.Write([]byte(input))
 	if g, w := objAttrs.MD5, h.Sum(nil); !bytes.Equal(g, w) {
 		t.Errorf("md5: got=%x want=%x", g, w)
-	}
-}
-
-func cleanBucket(t *testing.T, ctx context.Context, client *storage.Client, projectID, bucket string) {
-	deleteBucketIfExists(t, ctx, client, bucket)
-
-	b := client.Bucket(bucket)
-	// Now create it
-	if err := b.Create(ctx, projectID, nil); err != nil {
-		t.Fatalf("Bucket.Create(%q): %v", bucket, err)
-	}
-}
-
-func deleteBucketIfExists(t *testing.T, ctx context.Context, client *storage.Client, bucket string) {
-	b := client.Bucket(bucket)
-	if _, err := b.Attrs(ctx); err != nil {
-		return
-	}
-
-	// Delete all the elements in the already existent bucket
-	it := b.Objects(ctx, nil)
-	for {
-		attrs, err := it.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			t.Fatalf("Bucket.Objects(%q): %v", bucket, err)
-		}
-		if err := b.Object(attrs.Name).Delete(ctx); err != nil {
-			t.Fatalf("Bucket(%q).Object(%q).Delete: %v", bucket, attrs.Name, err)
-		}
-	}
-	// Then delete the bucket itself
-	if err := b.Delete(ctx); err != nil {
-		t.Fatalf("Bucket.Delete(%q): %v", bucket, err)
 	}
 }

--- a/storage/service_account/hmac/hmac_test.go
+++ b/storage/service_account/hmac/hmac_test.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 
@@ -46,16 +47,18 @@ func TestListKeys(t *testing.T) {
 	key, err := createTestKey(tc.ProjectID)
 	defer deleteTestKey(key)
 	if err != nil {
-		t.Errorf("Error in key creation: %s", err)
+		t.Fatalf("Error in key creation: %s", err)
 	}
 
-	keys, err := listHMACKeys(ioutil.Discard, tc.ProjectID)
-	if err != nil {
-		t.Errorf("listHMACKeys raised error: %s", err)
-	}
-	if len(keys) < 1 {
-		t.Errorf("Should have at least one key listed.")
-	}
+	testutil.Retry(t, 10, 10*time.Second, func(r *testutil.R) {
+		keys, err := listHMACKeys(ioutil.Discard, tc.ProjectID)
+		if err != nil {
+			r.Errorf("listHMACKeys raised error: %s", err)
+		}
+		if len(keys) < 1 {
+			r.Errorf("Should have at least one key listed.")
+		}
+	})
 }
 
 func TestCreateKey(t *testing.T) {

--- a/vision/detect/detect_test.go
+++ b/vision/detect/detect_test.go
@@ -24,7 +24,6 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-	"google.golang.org/api/iterator"
 )
 
 func TestDetect(t *testing.T) {
@@ -96,7 +95,7 @@ func TestDetectAsyncDocument(t *testing.T) {
 
 	bucketName := fmt.Sprintf("%s-vision", tc.ProjectID)
 	bucket := client.Bucket(bucketName)
-	cleanBucket(ctx, t, client, tc.ProjectID, bucketName)
+	testutil.CleanBucket(ctx, t, tc.ProjectID, bucketName)
 
 	var buf bytes.Buffer
 	gcsSourceURI := "gs://python-docs-samples-tests/HodgeConj.pdf"
@@ -117,41 +116,5 @@ func TestDetectAsyncDocument(t *testing.T) {
 		if err != nil {
 			t.Fatalf("wanted object %q, got error: %v", filename, err)
 		}
-	}
-}
-
-func cleanBucket(ctx context.Context, t *testing.T, client *storage.Client, projectID, bucket string) {
-	deleteBucketIfExists(ctx, t, client, bucket)
-
-	b := client.Bucket(bucket)
-	// Now create it
-	if err := b.Create(ctx, projectID, nil); err != nil {
-		t.Fatalf("Bucket.Create(%q): %v", bucket, err)
-	}
-}
-
-func deleteBucketIfExists(ctx context.Context, t *testing.T, client *storage.Client, bucket string) {
-	b := client.Bucket(bucket)
-	if _, err := b.Attrs(ctx); err != nil {
-		return
-	}
-
-	// Delete all the elements in the already existent bucket
-	it := b.Objects(ctx, nil)
-	for {
-		attrs, err := it.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			t.Fatalf("Bucket.Objects(%q): %v", bucket, err)
-		}
-		if err := b.Object(attrs.Name).Delete(ctx); err != nil {
-			t.Fatalf("Bucket(%q).Object(%q).Delete: %v", bucket, attrs.Name, err)
-		}
-	}
-	// Then delete the bucket itself
-	if err := b.Delete(ctx); err != nil {
-		t.Fatalf("Bucket.Delete(%q): %v", bucket, err)
 	}
 }


### PR DESCRIPTION
We've copied this code around to several locations -- it's time to put
it in a shared location.

I chose testutil rather than a new package because it's only used for
tests.

We've been running into some flakiness recently with Storage quota
for creating and deleting buckets, so hopefully some retries will help.

Fixes #1309.