### PR TITLE
dlp: only wait for 1 minute for risk jobs

### DIFF
--- a/dlp/snippets/risk/categorical.go
+++ b/dlp/snippets/risk/categorical.go
@@ -98,7 +98,10 @@ func riskCategorical(w io.Writer, projectID, dataProject, pubSubTopic, pubSubSub
 	fmt.Fprintf(w, "Created job: %v\n", j.GetName())
 
 	// Wait for the risk job to finish by waiting for a PubSub message.
-	ctx, cancel := context.WithCancel(ctx)
+	// This only waits for 1 minute. For long jobs, consider using a truly
+	// asynchronous execution model such as Cloud Functions.
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
 	err = s.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
 		// If this is the wrong job, do not process the result.
 		if msg.Attributes["DlpJobName"] != j.GetName() {
@@ -128,7 +131,7 @@ func riskCategorical(w io.Writer, projectID, dataProject, pubSubTopic, pubSubSub
 		cancel()
 	})
 	if err != nil {
-		return fmt.Errorf("Recieve: %v", err)
+		return fmt.Errorf("Receive: %v", err)
 	}
 	return nil
 }

--- a/dlp/snippets/risk/k_anonymity.go
+++ b/dlp/snippets/risk/k_anonymity.go
@@ -104,7 +104,10 @@ func riskKAnonymity(w io.Writer, projectID, dataProject, pubSubTopic, pubSubSub,
 	fmt.Fprintf(w, "Created job: %v\n", j.GetName())
 
 	// Wait for the risk job to finish by waiting for a PubSub message.
-	ctx, cancel := context.WithCancel(ctx)
+	// This only waits for 1 minute. For long jobs, consider using a truly
+	// asynchronous execution model such as Cloud Functions.
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
 	err = s.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
 		// If this is the wrong job, do not process the result.
 		if msg.Attributes["DlpJobName"] != j.GetName() {

--- a/dlp/snippets/risk/k_map.go
+++ b/dlp/snippets/risk/k_map.go
@@ -114,7 +114,10 @@ func riskKMap(w io.Writer, projectID, dataProject, pubSubTopic, pubSubSub, datas
 	fmt.Fprintf(w, "Created job: %v\n", j.GetName())
 
 	// Wait for the risk job to finish by waiting for a PubSub message.
-	ctx, cancel := context.WithCancel(ctx)
+	// This only waits for 1 minute. For long jobs, consider using a truly
+	// asynchronous execution model such as Cloud Functions.
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
 	err = s.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
 		// If this is the wrong job, do not process the result.
 		if msg.Attributes["DlpJobName"] != j.GetName() {

--- a/dlp/snippets/risk/l_diversity.go
+++ b/dlp/snippets/risk/l_diversity.go
@@ -108,7 +108,10 @@ func riskLDiversity(w io.Writer, projectID, dataProject, pubSubTopic, pubSubSub,
 	fmt.Fprintf(w, "Created job: %v\n", j.GetName())
 
 	// Wait for the risk job to finish by waiting for a PubSub message.
-	ctx, cancel := context.WithCancel(ctx)
+	// This only waits for 1 minute. For long jobs, consider using a truly
+	// asynchronous execution model such as Cloud Functions.
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
 	err = s.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
 		// If this is the wrong job, do not process the result.
 		if msg.Attributes["DlpJobName"] != j.GetName() {

--- a/dlp/snippets/risk/numerical.go
+++ b/dlp/snippets/risk/numerical.go
@@ -98,7 +98,10 @@ func riskNumerical(w io.Writer, projectID, dataProject, pubSubTopic, pubSubSub, 
 	fmt.Fprintf(w, "Created job: %v\n", j.GetName())
 
 	// Wait for the risk job to finish by waiting for a PubSub message.
-	ctx, cancel := context.WithCancel(ctx)
+	// This only waits for 1 minute. For long jobs, consider using a truly
+	// asynchronous execution model such as Cloud Functions.
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
 	err = s.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
 		// If this is the wrong job, do not process the result.
 		if msg.Attributes["DlpJobName"] != j.GetName() {

--- a/dlp/snippets/risk/risk_test.go
+++ b/dlp/snippets/risk/risk_test.go
@@ -39,13 +39,13 @@ func TestRisk(t *testing.T) {
 			name: "Numerical",
 			fn: func(r *testutil.R) {
 				buf := new(bytes.Buffer)
-				riskNumerical(buf, tc.ProjectID, "bigquery-public-data", riskTopicName, riskSubscriptionName, "nhtsa_traffic_fatalities", "accident_2015", "state_number")
-				wants := []string{"Created job", "Value range", "Value at"}
-				got := buf.String()
-				for _, want := range wants {
-					if !strings.Contains(got, want) {
-						r.Errorf("riskNumerical got %s, want substring %q", got, want)
-					}
+				err := riskNumerical(buf, tc.ProjectID, "bigquery-public-data", riskTopicName, riskSubscriptionName, "nhtsa_traffic_fatalities", "accident_2015", "state_number")
+				if err != nil {
+					r.Errorf("riskNumerical got err: %v", err)
+					return
+				}
+				if got, want := buf.String(), "Created job"; !strings.Contains(got, want) {
+					r.Errorf("riskNumerical got %s, want substring %q", got, want)
 				}
 			},
 		},
@@ -53,13 +53,13 @@ func TestRisk(t *testing.T) {
 			name: "Categorical",
 			fn: func(r *testutil.R) {
 				buf := new(bytes.Buffer)
-				riskCategorical(buf, tc.ProjectID, "bigquery-public-data", riskTopicName, riskSubscriptionName, "nhtsa_traffic_fatalities", "accident_2015", "state_number")
-				wants := []string{"Created job", "Histogram bucket", "Most common value occurs"}
-				got := buf.String()
-				for _, want := range wants {
-					if !strings.Contains(got, want) {
-						r.Errorf("riskCategorical got %s, want substring %q", got, want)
-					}
+				err := riskCategorical(buf, tc.ProjectID, "bigquery-public-data", riskTopicName, riskSubscriptionName, "nhtsa_traffic_fatalities", "accident_2015", "state_number")
+				if err != nil {
+					r.Errorf("riskCategorical got err: %v", err)
+					return
+				}
+				if got, want := buf.String(), "Created job"; !strings.Contains(got, want) {
+					r.Errorf("riskCategorical got %s, want substring %q", got, want)
 				}
 			},
 		},
@@ -67,13 +67,13 @@ func TestRisk(t *testing.T) {
 			name: "K Anonymity",
 			fn: func(r *testutil.R) {
 				buf := new(bytes.Buffer)
-				riskKAnonymity(buf, tc.ProjectID, "bigquery-public-data", riskTopicName, riskSubscriptionName, "nhtsa_traffic_fatalities", "accident_2015", "state_number", "county")
-				wants := []string{"Created job", "Histogram bucket", "Size range"}
-				got := buf.String()
-				for _, want := range wants {
-					if !strings.Contains(got, want) {
-						r.Errorf("riskKAnonymity got %s, want substring %q", got, want)
-					}
+				err := riskKAnonymity(buf, tc.ProjectID, "bigquery-public-data", riskTopicName, riskSubscriptionName, "nhtsa_traffic_fatalities", "accident_2015", "state_number", "county")
+				if err != nil {
+					r.Errorf("riskKAnonymity got err: %v", err)
+					return
+				}
+				if got, want := buf.String(), "Created job"; !strings.Contains(got, want) {
+					r.Errorf("riskKAnonymity got %s, want substring %q", got, want)
 				}
 			},
 		},
@@ -81,13 +81,13 @@ func TestRisk(t *testing.T) {
 			name: "L Diversity",
 			fn: func(r *testutil.R) {
 				buf := new(bytes.Buffer)
-				riskLDiversity(buf, tc.ProjectID, "bigquery-public-data", riskTopicName, riskSubscriptionName, "nhtsa_traffic_fatalities", "accident_2015", "city", "state_number", "county")
-				wants := []string{"Created job", "Histogram bucket", "Size range"}
-				got := buf.String()
-				for _, want := range wants {
-					if !strings.Contains(got, want) {
-						r.Errorf("riskLDiversity got %s, want substring %q", got, want)
-					}
+				err := riskLDiversity(buf, tc.ProjectID, "bigquery-public-data", riskTopicName, riskSubscriptionName, "nhtsa_traffic_fatalities", "accident_2015", "city", "state_number", "county")
+				if err != nil {
+					r.Errorf("riskLDiversity got err: %v", err)
+					return
+				}
+				if got, want := buf.String(), "Created job"; !strings.Contains(got, want) {
+					r.Errorf("riskLDiversity got %s, want substring %q", got, want)
 				}
 			},
 		},
@@ -96,12 +96,8 @@ func TestRisk(t *testing.T) {
 			fn: func(r *testutil.R) {
 				buf := new(bytes.Buffer)
 				riskKMap(buf, tc.ProjectID, "bigquery-public-data", riskTopicName, riskSubscriptionName, "san_francisco", "bikeshare_trips", "US", "zip_code")
-				wants := []string{"Created job", "Histogram bucket", "Anonymity range"}
-				got := buf.String()
-				for _, want := range wants {
-					if !strings.Contains(got, want) {
-						r.Errorf("riskKMap got %s, want substring %q", got, want)
-					}
+				if got, want := buf.String(), "Created job"; !strings.Contains(got, want) {
+					r.Errorf("riskKMap got %s, want substring %q", got, want)
 				}
 			},
 		},


### PR DESCRIPTION
These have been timing out after 1 hour recently. Switch to only waiting
for one minute for the job to finish and only having the test check the
job was created.

Alternatively, we could pass a context.Context as an argument. But,
users have found that confusing. So, I'm not sure if it's better to do
that or to inline the deadline in the sample. I inlined with an
explanatory comment copied from Java but am open to other ideas.

Also, errors weren't checked before, so I added checks.

Fixes #1337.