### PR TITLE
storage: extend timeouts for SA HMAC samples

### DIFF
--- a/storage/service_account/hmac/activate.go
+++ b/storage/service_account/hmac/activate.go
@@ -36,7 +36,7 @@ func activateHMACKey(w io.Writer, accessID string, projectID string) (*storage.H
 	defer client.Close() // Closing the client safely cleans up background resources.
 
 	handle := client.HMACKeyHandle(projectID, accessID)
-	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 	key, err := handle.Update(ctx, storage.HMACKeyAttrsToUpdate{State: "ACTIVE"})
 	if err != nil {

--- a/storage/service_account/hmac/create.go
+++ b/storage/service_account/hmac/create.go
@@ -35,7 +35,7 @@ func createHMACKey(w io.Writer, projectID string, serviceAccountEmail string) (*
 	}
 	defer client.Close() // Closing the client safely cleans up background resources.
 
-	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 	key, err := client.CreateHMACKey(ctx, projectID, serviceAccountEmail)
 	if err != nil {

--- a/storage/service_account/hmac/deactivate.go
+++ b/storage/service_account/hmac/deactivate.go
@@ -35,7 +35,7 @@ func deactivateHMACKey(w io.Writer, accessID string, projectID string) (*storage
 	}
 	defer client.Close() // Closing the client safely cleans up background resources.
 
-	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 	handle := client.HMACKeyHandle(projectID, accessID)
 	key, err := handle.Update(ctx, storage.HMACKeyAttrsToUpdate{State: "INACTIVE"})

--- a/storage/service_account/hmac/delete.go
+++ b/storage/service_account/hmac/delete.go
@@ -37,7 +37,7 @@ func deleteHMACKey(w io.Writer, accessID string, projectID string) error {
 	defer client.Close() // Closing the client safely cleans up background resources.
 
 	handle := client.HMACKeyHandle(projectID, accessID)
-	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 	if err = handle.Delete(ctx); err != nil {
 		return fmt.Errorf("Delete: %v", err)

--- a/storage/service_account/hmac/get.go
+++ b/storage/service_account/hmac/get.go
@@ -36,7 +36,7 @@ func getHMACKey(w io.Writer, accessID string, projectID string) (*storage.HMACKe
 	defer client.Close() // Closing the client safely cleans up background resources.
 
 	handle := client.HMACKeyHandle(projectID, accessID)
-	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 	key, err := handle.Get(ctx)
 	if err != nil {

--- a/storage/service_account/hmac/list.go
+++ b/storage/service_account/hmac/list.go
@@ -36,7 +36,7 @@ func listHMACKeys(w io.Writer, projectID string) ([]*storage.HMACKey, error) {
 	}
 	defer client.Close() // Closing the client safely cleans up background resources.
 
-	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 	iter := client.ListHMACKeys(ctx, projectID)
 	var keys []*storage.HMACKey


### PR DESCRIPTION
This is necessary in order to address flakiness in the tests for
these samples.

Fixes #1347