### PR TITLE
kms: skip, don't fail, when GOLANG_SAMPLES_PROJECT_ID is unset

### DIFF
--- a/kms/kms_test.go
+++ b/kms/kms_test.go
@@ -40,7 +40,8 @@ var fixture *kmsFixture
 func TestMain(m *testing.M) {
 	tc, ok := testutil.ContextMain(m)
 	if !ok {
-		log.Fatal("failed to set up kms tests - missing GOLANG_SAMPLES_PROJECT_ID?")
+		log.Print("skipping - unset GOLANG_SAMPLES_PROJECT_ID?")
+		return
 	}
 
 	var err error


### PR DESCRIPTION
Fixes #1370