### PR TITLE
fix: use DELETE FROM for consistency

### DIFF
--- a/spanner/spanner_snippets/snippet.go
+++ b/spanner/spanner_snippets/snippet.go
@@ -1032,7 +1032,7 @@ func updateUsingDML(ctx context.Context, w io.Writer, client *spanner.Client) er
 
 func deleteUsingDML(ctx context.Context, w io.Writer, client *spanner.Client) error {
 	_, err := client.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
-		stmt := spanner.Statement{SQL: `DELETE Singers WHERE FirstName = 'Alice'`}
+		stmt := spanner.Statement{SQL: `DELETE FROM Singers WHERE FirstName = 'Alice'`}
 		rowCount, err := txn.Update(ctx, stmt)
 		if err != nil {
 			return err
@@ -1268,7 +1268,7 @@ func updateUsingPartitionedDML(ctx context.Context, w io.Writer, client *spanner
 // [START spanner_dml_partitioned_delete]
 
 func deleteUsingPartitionedDML(ctx context.Context, w io.Writer, client *spanner.Client) error {
-	stmt := spanner.Statement{SQL: "DELETE Singers WHERE SingerId > 10"}
+	stmt := spanner.Statement{SQL: "DELETE FROM Singers WHERE SingerId > 10"}
 	rowCount, err := client.PartitionedUpdate(ctx, stmt)
 	if err != nil {
 		return err


### PR DESCRIPTION
Being consistent with [docs](https://cloud.google.com/spanner/docs/dml-syntax#delete_examples).