### PR TITLE
datastore: make dst slice for GetMulti

### DIFF
--- a/datastore/snippets/snippet_test.go
+++ b/datastore/snippets/snippet_test.go
@@ -260,9 +260,9 @@ func SnippetClient_PutMulti() {
 func SnippetClient_GetMulti() {
 	ctx := context.Background()
 	client, _ := datastore.NewClient(ctx, "my-proj")
-	var taskKeys []*datastore.Key // Populated with incomplete keys.
 	// [START datastore_batch_lookup]
-	var tasks []*Task
+	var taskKeys []*datastore.Key // Populated with incomplete keys.
+	tasks := make([]*Task, len(taskKeys))
 	err := client.GetMulti(ctx, taskKeys, &tasks)
 	// [END datastore_batch_lookup]
 	_ = err // Make sure you check err.


### PR DESCRIPTION
I moved `taskKeys` into the snippet since it's referenced by the new `tasks` declaration.

Thanks to @rumsrami for finding & reporting this!

Fixes #1362.