### PR TITLE
.github: create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+#
+# For syntax help see:
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
+
+
+# The yoshi-go-admins team is the default owner for anything not
+# explicitly taken by someone else.
+*                               @googleapis/yoshi-go-admins
+
+/storage/        @GoogleCloudPlatform/storage-dpe @googleapis/yoshi-go-admins


### PR DESCRIPTION
@crwilcox requested teams for repo access across the board for SoDa teams. Adding a CODEOWNERS file with yoshi-go-admins as default and with the storage team.