### PR TITLE
spanner: fix DBs conflict in different tests.

### DIFF
--- a/spanner/spanner_leaderboard/leaderboard_test.go
+++ b/spanner/spanner_leaderboard/leaderboard_test.go
@@ -37,7 +37,9 @@ func TestSample(t *testing.T) {
 	if !strings.HasPrefix(instance, "projects/") {
 		t.Fatal("Spanner instance ref must be in the form of 'projects/PROJECT_ID/instances/INSTANCE_ID'")
 	}
-	dbName := fmt.Sprintf("%s/databases/test-%s", instance, tc.ProjectID)
+	// "test-l-" is different from the database name in snippet_test.go because
+	// this prevents from running against the same database.
+	dbName := fmt.Sprintf("%s/databases/test-l-%s", instance, tc.ProjectID)
 
 	ctx := context.Background()
 	adminClient, dataClient := createClients(ctx, dbName)


### PR DESCRIPTION
If there are different packages, "go test ./..." will run the tests in each package in parallel. This explains why there were double hyphens previously in `leaderboard_test.go`: https://github.com/GoogleCloudPlatform/golang-samples/commit/ea3d55341f40241bfaeccc9538df3fd4fa7286eb

I added a comment to explain the reason. 

Fixes #1387 & #1388 