### PR TITLE
testing/sampletests: work with function references

### DIFF
--- a/testing/sampletests/fakesamples/hello.go
+++ b/testing/sampletests/fakesamples/hello.go
@@ -44,3 +44,12 @@ func notTested() string {
 }
 
 // [END fakesamples_not_tested]
+
+// [START fakesamples_indirect_test]
+
+// IndirectlyTested returns a string. Only for testing. May change at any time.
+func IndirectlyTested() string {
+	return "This function is tested via a function reference rather than a direct call"
+}
+
+// [END fakesamples_indirect_test]

--- a/testing/sampletests/fakesamples/hello_test.go
+++ b/testing/sampletests/fakesamples/hello_test.go
@@ -15,6 +15,7 @@
 package hello_test
 
 import (
+	"strings"
 	"testing"
 
 	hello "github.com/GoogleCloudPlatform/golang-samples/testing/sampletests/fakesamples"
@@ -23,5 +24,22 @@ import (
 func TestHello(t *testing.T) {
 	if got, want := hello.Hello(), "Hello!"; got != want {
 		t.Errorf("hello got %q, want %q", got, want)
+	}
+}
+
+func TestIndirectlyTested(t *testing.T) {
+	tests := []struct {
+		indirectFunc func() string
+		want         string
+	}{
+		{
+			indirectFunc: hello.IndirectlyTested,
+			want:         "This",
+		},
+	}
+	for _, test := range tests {
+		if got := test.indirectFunc(); !strings.HasPrefix(got, test.want) {
+			t.Errorf("indirectlyTested got %q, want prefix %q", got, test.want)
+		}
 	}
 }


### PR DESCRIPTION
Results:
Directory | Before | After | Diff
------------ | --------- | ------ | -----
root | `547/1161` | `613/1162` | `+66ish`
`vision` | `26/53` | `49/53` | `+23`
`bigtable` | `11/44` | `34/44` | `+23`

The root denominator went up by 1 because I added a new (tested) region tag to test against.

Spanner stays the same.

Updates #1402.