### PR TITLE
trace/trace_quickstart: use Google Cloud propagation in server

### DIFF
--- a/trace/trace_quickstart/main.go
+++ b/trace/trace_quickstart/main.go
@@ -78,10 +78,10 @@ func main() {
 	}
 	log.Printf("Listening on port %s", port)
 
-    // Use this handler in server in order to instrument OpenCensus for 
-	// incoming requests
-	httpHandler := &ochttp.Handler {
-		// Use Google Cloud propagation format
+	// Use an ochttp.Handler in order to instrument OpenCensus for incoming
+	// requests.
+	httpHandler := &ochttp.Handler{
+		// Use the Google Cloud propagation format.
 		Propagation: &propagation.HTTPFormat{},
 	}
 	if err := http.ListenAndServe(":"+port, httpHandler); err != nil {

--- a/trace/trace_quickstart/main.go
+++ b/trace/trace_quickstart/main.go
@@ -77,7 +77,10 @@ func main() {
 		port = "8080"
 	}
 	log.Printf("Listening on port %s", port)
-	if err := http.ListenAndServe(":"+port, nil); err != nil {
+	if err := http.ListenAndServe(":"+port, &ochttp.Handler {
+        // Use Google Cloud propagation format.
+        Propagation: &propagation.HTTPFormat{},
+        }); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/trace/trace_quickstart/main.go
+++ b/trace/trace_quickstart/main.go
@@ -77,10 +77,14 @@ func main() {
 		port = "8080"
 	}
 	log.Printf("Listening on port %s", port)
-	if err := http.ListenAndServe(":"+port, &ochttp.Handler {
-        // Use Google Cloud propagation format.
-        Propagation: &propagation.HTTPFormat{},
-        }); err != nil {
+
+    // Use this handler in server in order to instrument OpenCensus for 
+	// incoming requests
+	httpHandler := &ochttp.Handler {
+		// Use Google Cloud propagation format
+		Propagation: &propagation.HTTPFormat{},
+	}
+	if err := http.ListenAndServe(":"+port, httpHandler); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
Enables tracing of incoming requests