### PR TITLE
testing/kokoro: add mtls_smoketest config

### DIFF
--- a/testing/kokoro/mtls_smoketest.cfg
+++ b/testing/kokoro/mtls_smoketest.cfg
@@ -1,0 +1,17 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# NOTE(cbro): This build should not make any dashboard red. It's purely so we
+# can keep track of which APIs work on their mTLS hostnames and which do not.
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/golang-samples-tests/go114"
+}
+
+# NOTE(cbro): This environment variable forces the transport layer to use the
+# mTLS hostname (e.g., vision.mtls.googleapis.com).
+env_vars: {
+    key: "GOOGLE_API_USE_MTLS"
+    value: "always"
+}


### PR DESCRIPTION
THis is so we can understand and track which APIs respond on their mTLS
hostname and which do not.