### PR TITLE
bigquery: add reservation quickstart

### DIFF
--- a/bigquery/bigquery_reservation_quickstart/main.go
+++ b/bigquery/bigquery_reservation_quickstart/main.go
@@ -1,0 +1,114 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START bigqueryreservation_quickstart]
+
+// The bigquery_reservation_quickstart application demonstrates usage of the
+// BigQuery reservation API by enumerating some of the resources that can be
+// associated with a cloud project.
+package main
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"log"
+
+	bqReservation "cloud.google.com/go/bigquery/reservation/apiv1"
+	"google.golang.org/api/iterator"
+	reservationpb "google.golang.org/genproto/googleapis/cloud/bigquery/reservation/v1"
+)
+
+// Define two command line flags for controlling the behavior of this quickstart.
+var (
+	projectID = flag.String("project_id", "",
+		"Cloud Project ID, used for session creation.")
+	location = flag.String("location", "US",
+		"BigQuery location used for interactions")
+)
+
+func main() {
+	flag.Parse()
+	ctx := context.Background()
+	bqResClient, err := bqReservation.NewClient(ctx)
+	if err != nil {
+		log.Fatalf("NewClient: %v", err)
+	}
+	defer bqResClient.Close()
+
+	b, err := printCapacityCommitments(ctx, bqResClient)
+	if err != nil {
+		log.Fatalf("printCapacityCommitments: %v", err)
+	}
+	fmt.Println(string(b))
+
+	b, err = printReservations(ctx, bqResClient)
+	if err != nil {
+		log.Fatalf("printReservations: %v", err)
+	}
+	fmt.Println(string(b))
+}
+
+// printCapacityCommitments iterates through the capacity commitments and returns a byte buffer with details.
+func printCapacityCommitments(ctx context.Context, client *bqReservation.Client) ([]byte, error) {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "Capacity commitments in project %s in location %s:\n", *projectID, *location)
+
+	req := &reservationpb.ListCapacityCommitmentsRequest{
+		Parent: fmt.Sprintf("projects/%s/locations/%s", *projectID, *location),
+	}
+	totalCommitments := 0
+	it := client.ListCapacityCommitments(ctx, req)
+	for {
+		commitment, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		fmt.Fprintf(&buf, "\tCommitment %s in state %s\n", commitment.GetName(), commitment.GetState().String())
+		totalCommitments++
+	}
+	fmt.Fprintf(&buf, "\n%d commitments processed.\n", totalCommitments)
+	return buf.Bytes(), nil
+}
+
+// printReservations iterates through reservations defined in an admin project.
+func printReservations(ctx context.Context, client *bqReservation.Client) ([]byte, error) {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "Reservations in project %s in location %s:\n", *projectID, *location)
+
+	req := &reservationpb.ListReservationsRequest{
+		Parent: fmt.Sprintf("projects/%s/locations/%s", *projectID, *location),
+	}
+	totalReservations := 0
+	it := client.ListReservations(ctx, req)
+	for {
+		reservation, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		fmt.Fprintf(&buf, "\tReservation %s has %d slot capacity.\n", reservation.GetName(), reservation.GetSlotCapacity())
+		totalReservations++
+	}
+	fmt.Fprintf(&buf, "\n%d reservations processed.\n", totalReservations)
+	return buf.Bytes(), nil
+}
+
+// [END bigqueryreservation_quickstart]

--- a/bigquery/bigquery_reservation_quickstart/main.go
+++ b/bigquery/bigquery_reservation_quickstart/main.go
@@ -33,10 +33,8 @@ import (
 
 // Define two command line flags for controlling the behavior of this quickstart.
 var (
-	projectID = flag.String("project_id", "",
-		"Cloud Project ID, used for session creation.")
-	location = flag.String("location", "US",
-		"BigQuery location used for interactions")
+	projectID = flag.String("project_id", "", "Cloud Project ID, used for session creation.")
+	location  = flag.String("location", "US", "BigQuery location used for interactions")
 )
 
 func main() {

--- a/bigquery/bigquery_reservation_quickstart/main.go
+++ b/bigquery/bigquery_reservation_quickstart/main.go
@@ -26,22 +26,29 @@ import (
 	"fmt"
 	"log"
 
-	reservationapi "cloud.google.com/go/bigquery/reservation/apiv1"
+	reservation "cloud.google.com/go/bigquery/reservation/apiv1"
 	"google.golang.org/api/iterator"
 	reservationpb "google.golang.org/genproto/googleapis/cloud/bigquery/reservation/v1"
 )
 
-// Define two command line flags for controlling the behavior of this quickstart.
-var (
-	projectID = flag.String("project_id", "", "Cloud Project ID, used for session creation.")
-	location  = flag.String("location", "US", "BigQuery location used for interactions")
-)
-
 func main() {
+
+	// Define two command line flags for controlling the behavior of this quickstart.
+	var (
+		projectID = flag.String("project_id", "", "Cloud Project ID, used for session creation.")
+		location  = flag.String("location", "US", "BigQuery location used for interactions.")
+	)
+	// Parse flags and do some minimal validation.
 	flag.Parse()
-	validateFlags()
+	if *projectID == "" {
+		log.Fatal("empty --project_id specified, please provide a valid project ID")
+	}
+	if *location == "" {
+		log.Fatal("empty --location specified, please provide a valid location")
+	}
+
 	ctx := context.Background()
-	bqResClient, err := reservationapi.NewClient(ctx)
+	bqResClient, err := reservation.NewClient(ctx)
 	if err != nil {
 		log.Fatalf("NewClient: %v", err)
 	}
@@ -60,18 +67,8 @@ func main() {
 	fmt.Println(s)
 }
 
-// validateFlags does some basic validation of the command line flags.
-func validateFlags() {
-	if *projectID == "" {
-		log.Fatal("empty --project_id specified, please provide a valid project ID")
-	}
-	if *location == "" {
-		log.Fatal("empty --location specified, please provide a valid location")
-	}
-}
-
 // printCapacityCommitments iterates through the capacity commitments and returns a byte buffer with details.
-func reportCapacityCommitments(ctx context.Context, client *reservationapi.Client, projectID, location string) (string, error) {
+func reportCapacityCommitments(ctx context.Context, client *reservation.Client, projectID, location string) (string, error) {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "Capacity commitments in project %s in location %s:\n", projectID, location)
 
@@ -96,7 +93,7 @@ func reportCapacityCommitments(ctx context.Context, client *reservationapi.Clien
 }
 
 // printReservations iterates through reservations defined in an admin project.
-func reportReservations(ctx context.Context, client *reservationapi.Client, projectID, location string) (string, error) {
+func reportReservations(ctx context.Context, client *reservation.Client, projectID, location string) (string, error) {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "Reservations in project %s in location %s:\n", projectID, location)
 

--- a/bigquery/bigquery_reservation_quickstart/main_test.go
+++ b/bigquery/bigquery_reservation_quickstart/main_test.go
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+)
+
+func TestApp(t *testing.T) {
+	tc := testutil.SystemTest(t)
+	m := testutil.BuildMain(t)
+	defer m.Cleanup()
+
+	if !m.Built() {
+		t.Errorf("failed to build app")
+	}
+
+	stdOut, stdErr, err := m.Run(nil, 30*time.Second, fmt.Sprintf("--project_id=%s", tc.ProjectID))
+	if err != nil {
+		t.Errorf("execution failed: %v", err)
+	}
+
+	// Look for a known substring in the output
+	if !strings.Contains(string(stdOut), " reservations processed.") {
+		t.Errorf("Did not find expected output.  Stdout: %s", string(stdOut))
+	}
+
+	if len(stdErr) > 0 {
+		t.Errorf("did not expect stderr output, got %d bytes: %s", len(stdErr), string(stdErr))
+	}
+}


### PR DESCRIPTION
The BigQuery reservation API has the possibility to generate nontrivial
costs when creating resources, so this initial quickstart demonstrates
simple enumerations and does no resource creations.