### PR TITLE
logging/simplelog: enable test, increase retry pauses

### DIFF
--- a/logging/simplelog/simplelog_test.go
+++ b/logging/simplelog/simplelog_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 func TestSimplelog(t *testing.T) {
-	t.Skip("Flaky https://github.com/GoogleCloudPlatform/golang-samples/issues/696")
 	tc := testutil.SystemTest(t)
 	ctx := context.Background()
 
@@ -47,7 +46,7 @@ func TestSimplelog(t *testing.T) {
 	}()
 
 	defer func() {
-		testutil.Retry(t, 10, time.Second, func(r *testutil.R) {
+		testutil.Retry(t, 10, 5*time.Second, func(r *testutil.R) {
 			if err := deleteLog(adminClient); err != nil {
 				r.Errorf("deleteLog: %v", err)
 			}
@@ -61,7 +60,7 @@ func TestSimplelog(t *testing.T) {
 	writeEntry(client)
 	structuredWrite(client)
 
-	testutil.Retry(t, 20, 2*time.Second, func(r *testutil.R) {
+	testutil.Retry(t, 20, 10*time.Second, func(r *testutil.R) {
 		entries, err := getEntries(adminClient, tc.ProjectID)
 		if err != nil {
 			r.Errorf("getEntries: %v", err)


### PR DESCRIPTION
`go test -count 10` passed locally.

Fixes #696.