### PR TITLE
all: remove legacy health check handlers

### DIFF
--- a/appengine_flexible/helloworld/helloworld.go
+++ b/appengine_flexible/helloworld/helloworld.go
@@ -24,7 +24,6 @@ import (
 
 func main() {
 	http.HandleFunc("/", handle)
-	http.HandleFunc("/_ah/health", healthCheckHandler)
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"
@@ -41,8 +40,4 @@ func handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	fmt.Fprint(w, "Hello world!")
-}
-
-func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprint(w, "ok")
 }

--- a/appengine_flexible/websockets/main.go
+++ b/appengine_flexible/websockets/main.go
@@ -18,7 +18,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -29,7 +28,6 @@ import (
 func main() {
 	http.Handle("/", http.FileServer(http.Dir("static")))
 	http.HandleFunc("/ws", socketHandler)
-	http.HandleFunc("/_ah/health", healthCheckHandler)
 
 	port := os.Getenv("PORT")
 	if port == "" {
@@ -68,11 +66,6 @@ func socketHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-}
-
-// healthCheckHandler is used by App Engine Flex to check instance health.
-func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprint(w, "ok")
 }
 
 // [END gae_flex_websockets_app]

--- a/appengine_flexible/websockets/main_test.go
+++ b/appengine_flexible/websockets/main_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/gorilla/websocket"
@@ -50,16 +49,5 @@ func TestSocketHandler(t *testing.T) {
 	}
 	if !bytes.Equal(got, message) {
 		t.Errorf("got %q, want %q", got, message)
-	}
-}
-
-func TestHealthCheckHandler(t *testing.T) {
-	req := httptest.NewRequest("GET", "/", strings.NewReader(""))
-
-	rr := httptest.NewRecorder()
-	healthCheckHandler(rr, req)
-
-	if got, want := rr.Body.String(), "ok"; got != want {
-		t.Errorf("got %q, want %q", got, want)
 	}
 }

--- a/getting-started/bookshelf/main.go
+++ b/getting-started/bookshelf/main.go
@@ -100,13 +100,6 @@ func (b *Bookshelf) registerHandlers() {
 	r.Methods("POST").Path("/books/{id:[0-9a-zA-Z_\\-]+}:delete").
 		Handler(appHandler(b.deleteHandler)).Name("delete")
 
-	// Respond to App Engine and Compute Engine health checks.
-	// Indicate the server is healthy.
-	r.Methods("GET").Path("/_ah/health").HandlerFunc(
-		func(w http.ResponseWriter, r *http.Request) {
-			w.Write([]byte("ok"))
-		})
-
 	r.Methods("GET").Path("/logs").Handler(appHandler(b.sendLog))
 	r.Methods("GET").Path("/errors").Handler(appHandler(b.sendError))
 

--- a/getting-started/devflowapp/devflowapp.go
+++ b/getting-started/devflowapp/devflowapp.go
@@ -96,7 +96,6 @@ func main() {
 	http.HandleFunc("/", handleDefault)
 	http.HandleFunc("/messages", handleCheckMessages)
 	http.HandleFunc("/send", handleSend)
-	http.HandleFunc("/_ah/health", healthCheckHandler)
 
 	port := os.Getenv("PORT")
 	if port == "" {
@@ -106,9 +105,4 @@ func main() {
 	if err := http.ListenAndServe(":"+port, nil); err != nil {
 		log.Fatal(err)
 	}
-}
-
-// Health check for the load balancer
-func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprint(w, "ok")
 }

--- a/getting-started/helloworld/helloworld.go
+++ b/getting-started/helloworld/helloworld.go
@@ -24,7 +24,6 @@ import (
 
 func main() {
 	http.HandleFunc("/", handle)
-	http.HandleFunc("/_ah/health", healthCheckHandler)
 
 	port := os.Getenv("PORT")
 	if port == "" {
@@ -42,8 +41,4 @@ func handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	fmt.Fprint(w, "Hello world!")
-}
-
-func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprint(w, "ok")
 }


### PR DESCRIPTION
Legacy health checks migrated to split health checks, which are now the
default. Split health checks are not sent to apps by default, so these
handlers are not working as intended.

None of the app.yaml files have health checks configured, so I chose not
to add new split handlers & configuration. I'm open to adding them
if we decide we should.

Fixes #977.