### PR TITLE
.config, testing: add Blunderbuss config

### DIFF
--- a/.config/blunderbuss.yml
+++ b/.config/blunderbuss.yml
@@ -1,0 +1,7 @@
+assign_issues_by:
+- labels: ['api: storage']
+  to:
+  - tritone
+- labels: ['api: bigquery']
+  to:
+  - shollyman

--- a/badfiles_test.go
+++ b/badfiles_test.go
@@ -99,6 +99,9 @@ var allowList = []string{
 	".github/dependabot.yml",
 	".github/CODEOWNERS",
 
+	// Bot configuration.
+	".config/*",
+
 	// Getting Started on GCE systemd service file.
 	"**/gce/**/*.service",
 

--- a/testing/kokoro/system_tests.sh
+++ b/testing/kokoro/system_tests.sh
@@ -39,7 +39,7 @@ TIMEOUT=60m
 
 # Also see trampoline.sh - system_tests.sh is only run for PRs when there are
 # significant changes.
-SIGNIFICANT_CHANGES=$(git --no-pager diff --name-only master..HEAD | grep -Ev '(\.md$|^\.github)' || true)
+SIGNIFICANT_CHANGES=$(git --no-pager diff --name-only master..HEAD | grep -Ev '(\.md$|^\.github|^\.config)' || true)
 # CHANGED_DIRS is the list of significant top-level directories that changed,
 # but weren't deleted by the current PR.
 # CHANGED_DIRS will be empty when run on master.

--- a/testing/kokoro/trampoline.sh
+++ b/testing/kokoro/trampoline.sh
@@ -20,7 +20,7 @@ date
 
 cd github/golang-samples || exit 1
 
-SIGNIFICANT_CHANGES="$(git --no-pager diff --name-only master..HEAD | grep -Ev '(\.md$|^\.github)' || true)"
+SIGNIFICANT_CHANGES="$(git --no-pager diff --name-only master..HEAD | grep -Ev '(\.md$|^\.github|^\.config)' || true)"
 
 # If this is a PR with only insignificant changes, don't run any tests.
 if [[ -n ${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-} ]] && [[ -z "$SIGNIFICANT_CHANGES" ]]; then


### PR DESCRIPTION
This starts with Storage and BigQuery, but we can add more later.

I updated the test scripts to make Kokoro fast for .config changes.