### PR TITLE
Proper handling of concurrent pubsub pull in Go

### DIFF
--- a/pubsub/subscriptions/pull_concurrency.go
+++ b/pubsub/subscriptions/pull_concurrency.go
@@ -51,13 +51,12 @@ func pullMsgsConcurrenyControl(w io.Writer, projectID, subID string) error {
 	// Handle individual messages in a goroutine.
 	go func() {
 		for {
-			select {
-			case msg := <-cm:
-				fmt.Fprintf(w, "Got message :%q\n", string(msg.Data))
-				msg.Ack()
-			case <-ctx.Done():
+			msg, ok := <-cm
+			if !ok {
 				return
 			}
+			fmt.Fprintf(w, "Got message :%q\n", string(msg.Data))
+			msg.Ack()
 		}
 	}()
 


### PR DESCRIPTION
"Context.Done" need not be handled separately again. Let the Receiver
close the channel to notify the anonymous function about the end
of pull.

Github Issue: [1455](https://github.com/GoogleCloudPlatform/golang-samples/issues/1455)