### PR TITLE
spanner: add create_clients sample

### DIFF
--- a/spanner/spanner_snippets/spanner/integration_test.go
+++ b/spanner/spanner_snippets/spanner/integration_test.go
@@ -115,6 +115,7 @@ func TestSample(t *testing.T) {
 
 	var out string
 	mustRunSample(t, createDatabase, dbName, "failed to create a database")
+	runSample(t, createClients, dbName, "failed to create clients")
 	runSample(t, write, dbName, "failed to insert data")
 	runSample(t, addNewColumn, dbName, "failed to add new column")
 	runSample(t, delete, dbName, "failed to delete data")

--- a/spanner/spanner_snippets/spanner/spanner_create_clients.go
+++ b/spanner/spanner_snippets/spanner/spanner_create_clients.go
@@ -1,0 +1,46 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanner
+
+// [START spanner_create_clients]
+
+import (
+	"context"
+	"io"
+
+	"cloud.google.com/go/spanner"
+	database "cloud.google.com/go/spanner/admin/database/apiv1"
+)
+
+func createClients(w io.Writer, db string) error {
+	ctx := context.Background()
+
+	adminClient, err := database.NewDatabaseAdminClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	dataClient, err := spanner.NewClient(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	_ = adminClient
+	_ = dataClient
+
+	return nil
+}
+
+// [END spanner_create_clients]

--- a/spanner/spanner_snippets/spanner/spanner_read_stale_data.go
+++ b/spanner/spanner_snippets/spanner/spanner_read_stale_data.go
@@ -14,6 +14,8 @@
 
 package spanner
 
+// [START spanner_read_stale_data]
+
 import (
 	"context"
 	"fmt"
@@ -23,8 +25,6 @@ import (
 	"cloud.google.com/go/spanner"
 	"google.golang.org/api/iterator"
 )
-
-// [START spanner_read_stale_data]
 
 func readStaleData(w io.Writer, db string) error {
 	ctx := context.Background()


### PR DESCRIPTION
Two changes are included: 
- add the create_clients sample
- fix a region tag issue in spanner_read_stale_data
