### PR TITLE
.github: expand Blunderbuss config

### DIFF
--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -1,7 +1,20 @@
 assign_issues_by:
-- labels: ['api: storage']
+- labels:
+  - 'api: bigtable'
+  - 'api: datastore'
+  - 'api: firestore'
+  - 'api: storage'
   to:
   - tritone
-- labels: ['api: bigquery']
+- labels:
+  - 'api: bigquery'
   to:
   - shollyman
+- labels:
+  - 'api: pubsub'
+  to:
+  - hongalex
+- labels:
+  - 'api: spanner'
+  to:
+  - skuruppu


### PR DESCRIPTION
Copied from https://github.com/googleapis/google-cloud-go/blob/master/.github/blunderbuss.yml.