### PR TITLE
firestore: make tests EndToEnd

### DIFF
--- a/firestore/firestore_snippets/collection_group_test.go
+++ b/firestore/firestore_snippets/collection_group_test.go
@@ -22,9 +22,11 @@ import (
 	"testing"
 
 	"cloud.google.com/go/firestore"
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 )
 
 func TestCollectionGroup(t *testing.T) {
+	testutil.EndToEndTest(t)
 	// TODO(#559): revert this to testutil.SystemTest(t).ProjectID
 	// when datastore and firestore can co-exist in a project.
 	projectID := os.Getenv("GOLANG_SAMPLES_FIRESTORE_PROJECT")

--- a/firestore/firestore_snippets/increment_test.go
+++ b/firestore/firestore_snippets/increment_test.go
@@ -20,9 +20,11 @@ import (
 	"testing"
 
 	"cloud.google.com/go/firestore"
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 )
 
 func TestUpdateDocumentIncrement(t *testing.T) {
+	testutil.EndToEndTest(t)
 	// TODO(#559): revert this to testutil.SystemTest(t).ProjectID
 	// when datastore and firestore can co-exist in a project.
 	projectID := os.Getenv("GOLANG_SAMPLES_FIRESTORE_PROJECT")

--- a/firestore/firestore_snippets/save_test.go
+++ b/firestore/firestore_snippets/save_test.go
@@ -22,9 +22,11 @@ import (
 	"testing"
 
 	"cloud.google.com/go/firestore"
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 )
 
 func TestSave(t *testing.T) {
+	testutil.EndToEndTest(t)
 	// TODO: revert this to testutil.SystemTest(t).ProjectID
 	// when datastore and firestore can co-exist in a project.
 	projectID := os.Getenv("GOLANG_SAMPLES_FIRESTORE_PROJECT")

--- a/firestore/firestore_snippets/solution_counters_test.go
+++ b/firestore/firestore_snippets/solution_counters_test.go
@@ -20,9 +20,11 @@ import (
 	"testing"
 
 	"cloud.google.com/go/firestore"
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 )
 
 func TestDistributedCounter(t *testing.T) {
+	testutil.EndToEndTest(t)
 	projectID := os.Getenv("GOLANG_SAMPLES_FIRESTORE_PROJECT")
 	if projectID == "" {
 		t.Skip("Skipping firestore test. Set GOLANG_SAMPLES_FIRESTORE_PROJECT.")


### PR DESCRIPTION
This way, they only run on one project at a time. Also, we don't have to
make the sample more complicated by customizing the collection name.

Fixes #1492.