### PR TITLE
dlp: update samples to include locations/global in parent field

### DIFF
--- a/dlp/quickstart/quickstart.go
+++ b/dlp/quickstart/quickstart.go
@@ -68,7 +68,7 @@ func main() {
 
 	// Construct request.
 	req := &dlppb.InspectContentRequest{
-		Parent: "projects/" + projectID,
+		Parent: fmt.Sprintf("projects/%s/locations/global", projectID),
 		InspectConfig: &dlppb.InspectConfig{
 			InfoTypes:     infoTypes,
 			MinLikelihood: minLikelihood,

--- a/dlp/snippets/deid/date_shift.go
+++ b/dlp/snippets/deid/date_shift.go
@@ -39,7 +39,7 @@ func deidentifyDateShift(w io.Writer, projectID string, lowerBoundDays, upperBou
 	}
 	// Create a configured request.
 	req := &dlppb.DeidentifyContentRequest{
-		Parent: "projects/" + projectID,
+		Parent: fmt.Sprintf("projects/%s/locations/global", projectID),
 		DeidentifyConfig: &dlppb.DeidentifyConfig{
 			Transformation: &dlppb.DeidentifyConfig_InfoTypeTransformations{
 				InfoTypeTransformations: &dlppb.InfoTypeTransformations{

--- a/dlp/snippets/deid/deid_fpe.go
+++ b/dlp/snippets/deid/deid_fpe.go
@@ -55,7 +55,7 @@ func deidentifyFPE(w io.Writer, projectID, input string, infoTypeNames []string,
 	}
 	// Create a configured request.
 	req := &dlppb.DeidentifyContentRequest{
-		Parent: "projects/" + projectID,
+		Parent: fmt.Sprintf("projects/%s/locations/global", projectID),
 		InspectConfig: &dlppb.InspectConfig{
 			InfoTypes: infoTypes,
 		},

--- a/dlp/snippets/deid/mask.go
+++ b/dlp/snippets/deid/mask.go
@@ -46,7 +46,7 @@ func mask(w io.Writer, projectID, input string, infoTypeNames []string, maskingC
 	}
 	// Create a configured request.
 	req := &dlppb.DeidentifyContentRequest{
-		Parent: "projects/" + projectID,
+		Parent: fmt.Sprintf("projects/%s/locations/global", projectID),
 		InspectConfig: &dlppb.InspectConfig{
 			InfoTypes: infoTypes,
 		},

--- a/dlp/snippets/deid/reid_fpe.go
+++ b/dlp/snippets/deid/reid_fpe.go
@@ -48,7 +48,7 @@ func reidentifyFPE(w io.Writer, projectID, input, keyFileName, cryptoKeyName, su
 	}
 	// Create a configured request.
 	req := &dlppb.ReidentifyContentRequest{
-		Parent: "projects/" + projectID,
+		Parent: fmt.Sprintf("projects/%s/locations/global", projectID),
 		ReidentifyConfig: &dlppb.DeidentifyConfig{
 			Transformation: &dlppb.DeidentifyConfig_InfoTypeTransformations{
 				InfoTypeTransformations: &dlppb.InfoTypeTransformations{

--- a/dlp/snippets/inspect/inspect_bigquery.go
+++ b/dlp/snippets/inspect/inspect_bigquery.go
@@ -115,7 +115,7 @@ func inspectBigquery(w io.Writer, projectID string, infoTypeNames []string, cust
 
 	// Create a configured request.
 	req := &dlppb.CreateDlpJobRequest{
-		Parent: "projects/" + projectID,
+		Parent: fmt.Sprintf("projects/%s/locations/global", projectID),
 		Job: &dlppb.CreateDlpJobRequest_InspectJob{
 			InspectJob: &dlppb.InspectJobConfig{
 				// StorageConfig describes where to find the data.

--- a/dlp/snippets/inspect/inspect_datastore.go
+++ b/dlp/snippets/inspect/inspect_datastore.go
@@ -113,7 +113,7 @@ func inspectDatastore(w io.Writer, projectID string, infoTypeNames []string, cus
 
 	// Create a configured request.
 	req := &dlppb.CreateDlpJobRequest{
-		Parent: "projects/" + projectID,
+		Parent: fmt.Sprintf("projects/%s/locations/global", projectID),
 		Job: &dlppb.CreateDlpJobRequest_InspectJob{
 			InspectJob: &dlppb.InspectJobConfig{
 				// StorageConfig describes where to find the data.

--- a/dlp/snippets/inspect/inspect_gcs.go
+++ b/dlp/snippets/inspect/inspect_gcs.go
@@ -113,7 +113,7 @@ func inspectGCSFile(w io.Writer, projectID string, infoTypeNames []string, custo
 
 	// Create a configured request.
 	req := &dlppb.CreateDlpJobRequest{
-		Parent: "projects/" + projectID,
+		Parent: fmt.Sprintf("projects/%s/locations/global", projectID),
 		Job: &dlppb.CreateDlpJobRequest_InspectJob{
 			InspectJob: &dlppb.InspectJobConfig{
 				// StorageConfig describes where to find the data.

--- a/dlp/snippets/inspect/inspect_string.go
+++ b/dlp/snippets/inspect/inspect_string.go
@@ -39,7 +39,7 @@ func inspectString(w io.Writer, projectID, textToInspect string) error {
 
 	// Create and send the request.
 	req := &dlppb.InspectContentRequest{
-		Parent: "projects/" + projectID,
+		Parent: fmt.Sprintf("projects/%s/locations/global", projectID),
 		Item: &dlppb.ContentItem{
 			DataItem: &dlppb.ContentItem_Value{
 				Value: textToInspect,

--- a/dlp/snippets/inspect/inspect_text_file.go
+++ b/dlp/snippets/inspect/inspect_text_file.go
@@ -46,7 +46,7 @@ func inspectTextFile(w io.Writer, projectID, filePath string) error {
 
 	// Create and send the request.
 	req := &dlppb.InspectContentRequest{
-		Parent: "projects/" + projectID,
+		Parent: fmt.Sprintf("projects/%s/locations/global", projectID),
 		Item: &dlppb.ContentItem{
 			DataItem: &dlppb.ContentItem_ByteItem{
 				ByteItem: &dlppb.ByteContentItem{

--- a/dlp/snippets/jobs/jobs_test.go
+++ b/dlp/snippets/jobs/jobs_test.go
@@ -84,7 +84,7 @@ func riskNumerical(projectID, dataProject, pubSubTopic, pubSubSub, datasetID, ta
 
 	// Create a configured request.
 	req := &dlppb.CreateDlpJobRequest{
-		Parent: "projects/" + projectID,
+		Parent: fmt.Sprintf("projects/%s/locations/global", projectID),
 		Job: &dlppb.CreateDlpJobRequest_RiskJob{
 			RiskJob: &dlppb.RiskAnalysisJobConfig{
 				// PrivacyMetric configures what to compute.

--- a/dlp/snippets/jobs/list.go
+++ b/dlp/snippets/jobs/list.go
@@ -38,7 +38,7 @@ func listJobs(w io.Writer, projectID, filter, jobType string) error {
 
 	// Create a configured request.
 	req := &dlppb.ListDlpJobsRequest{
-		Parent: "projects/" + projectID,
+		Parent: fmt.Sprintf("projects/%s/locations/global", projectID),
 		Filter: filter,
 		Type:   dlppb.DlpJobType(dlppb.DlpJobType_value[jobType]),
 	}

--- a/dlp/snippets/redact/redact.go
+++ b/dlp/snippets/redact/redact.go
@@ -65,7 +65,7 @@ func redactImage(w io.Writer, projectID string, infoTypeNames []string, bytesTyp
 
 	// Create a configured request.
 	req := &dlppb.RedactImageRequest{
-		Parent: "projects/" + projectID,
+		Parent: fmt.Sprintf("projects/%s/locations/global", projectID),
 		InspectConfig: &dlppb.InspectConfig{
 			InfoTypes:     infoTypes,
 			MinLikelihood: dlppb.Likelihood_POSSIBLE,

--- a/dlp/snippets/risk/categorical.go
+++ b/dlp/snippets/risk/categorical.go
@@ -58,7 +58,7 @@ func riskCategorical(w io.Writer, projectID, dataProject, pubSubTopic, pubSubSub
 
 	// Create a configured request.
 	req := &dlppb.CreateDlpJobRequest{
-		Parent: "projects/" + projectID,
+		Parent: fmt.Sprintf("projects/%s/locations/global", projectID),
 		Job: &dlppb.CreateDlpJobRequest_RiskJob{
 			RiskJob: &dlppb.RiskAnalysisJobConfig{
 				// PrivacyMetric configures what to compute.

--- a/dlp/snippets/risk/k_anonymity.go
+++ b/dlp/snippets/risk/k_anonymity.go
@@ -66,7 +66,7 @@ func riskKAnonymity(w io.Writer, projectID, dataProject, pubSubTopic, pubSubSub,
 
 	// Create a configured request.
 	req := &dlppb.CreateDlpJobRequest{
-		Parent: "projects/" + projectID,
+		Parent: fmt.Sprintf("projects/%s/locations/global", projectID),
 		Job: &dlppb.CreateDlpJobRequest_RiskJob{
 			RiskJob: &dlppb.RiskAnalysisJobConfig{
 				// PrivacyMetric configures what to compute.

--- a/dlp/snippets/risk/k_map.go
+++ b/dlp/snippets/risk/k_map.go
@@ -75,7 +75,7 @@ func riskKMap(w io.Writer, projectID, dataProject, pubSubTopic, pubSubSub, datas
 
 	// Create a configured request.
 	req := &dlppb.CreateDlpJobRequest{
-		Parent: "projects/" + projectID,
+		Parent: fmt.Sprintf("projects/%s/locations/global", projectID),
 		Job: &dlppb.CreateDlpJobRequest_RiskJob{
 			RiskJob: &dlppb.RiskAnalysisJobConfig{
 				// PrivacyMetric configures what to compute.

--- a/dlp/snippets/risk/l_diversity.go
+++ b/dlp/snippets/risk/l_diversity.go
@@ -67,7 +67,7 @@ func riskLDiversity(w io.Writer, projectID, dataProject, pubSubTopic, pubSubSub,
 
 	// Create a configured request.
 	req := &dlppb.CreateDlpJobRequest{
-		Parent: "projects/" + projectID,
+		Parent: fmt.Sprintf("projects/%s/locations/global", projectID),
 		Job: &dlppb.CreateDlpJobRequest_RiskJob{
 			RiskJob: &dlppb.RiskAnalysisJobConfig{
 				// PrivacyMetric configures what to compute.

--- a/dlp/snippets/risk/numerical.go
+++ b/dlp/snippets/risk/numerical.go
@@ -58,7 +58,7 @@ func riskNumerical(w io.Writer, projectID, dataProject, pubSubTopic, pubSubSub, 
 
 	// Create a configured request.
 	req := &dlppb.CreateDlpJobRequest{
-		Parent: "projects/" + projectID,
+		Parent: fmt.Sprintf("projects/%s/locations/global", projectID),
 		Job: &dlppb.CreateDlpJobRequest_RiskJob{
 			RiskJob: &dlppb.RiskAnalysisJobConfig{
 				// PrivacyMetric configures what to compute.

--- a/dlp/snippets/template/create.go
+++ b/dlp/snippets/template/create.go
@@ -47,7 +47,7 @@ func createInspectTemplate(w io.Writer, projectID string, templateID, displayNam
 
 	// Create a configured request.
 	req := &dlppb.CreateInspectTemplateRequest{
-		Parent:     "projects/" + projectID,
+		Parent: fmt.Sprintf("projects/%s/locations/global", projectID),
 		TemplateId: templateID,
 		InspectTemplate: &dlppb.InspectTemplate{
 			DisplayName: displayName,

--- a/dlp/snippets/template/create.go
+++ b/dlp/snippets/template/create.go
@@ -47,7 +47,7 @@ func createInspectTemplate(w io.Writer, projectID string, templateID, displayNam
 
 	// Create a configured request.
 	req := &dlppb.CreateInspectTemplateRequest{
-		Parent: fmt.Sprintf("projects/%s/locations/global", projectID),
+		Parent:     fmt.Sprintf("projects/%s/locations/global", projectID),
 		TemplateId: templateID,
 		InspectTemplate: &dlppb.InspectTemplate{
 			DisplayName: displayName,

--- a/dlp/snippets/template/list.go
+++ b/dlp/snippets/template/list.go
@@ -40,7 +40,7 @@ func listInspectTemplates(w io.Writer, projectID string) error {
 
 	// Create a configured request.
 	req := &dlppb.ListInspectTemplatesRequest{
-		Parent: "projects/" + projectID,
+		Parent: fmt.Sprintf("projects/%s/locations/global", projectID),
 	}
 
 	// Send the request and iterate over the results.

--- a/dlp/snippets/template/template_test.go
+++ b/dlp/snippets/template/template_test.go
@@ -26,7 +26,7 @@ func TestTemplateSamples(t *testing.T) {
 	tc := testutil.SystemTest(t)
 
 	buf := new(bytes.Buffer)
-	fullID := "projects/" + tc.ProjectID + "/inspectTemplates/golang-samples-test-template"
+	fullID := "projects/" + tc.ProjectID + "/locations/global/inspectTemplates/golang-samples-test-template"
 	// Delete template before trying to create it since the test uses the same name every time.
 	if err := listInspectTemplates(buf, tc.ProjectID); err != nil {
 		t.Errorf("listInspectTemplates: %v", err)

--- a/dlp/snippets/trigger/create.go
+++ b/dlp/snippets/trigger/create.go
@@ -49,7 +49,7 @@ func createTrigger(w io.Writer, projectID string, triggerID, displayName, descri
 
 	// Create a configured request.
 	req := &dlppb.CreateJobTriggerRequest{
-		Parent:    "projects/" + projectID,
+		Parent: fmt.Sprintf("projects/%s/locations/global", projectID),
 		TriggerId: triggerID,
 		JobTrigger: &dlppb.JobTrigger{
 			DisplayName: displayName,

--- a/dlp/snippets/trigger/create.go
+++ b/dlp/snippets/trigger/create.go
@@ -49,7 +49,7 @@ func createTrigger(w io.Writer, projectID string, triggerID, displayName, descri
 
 	// Create a configured request.
 	req := &dlppb.CreateJobTriggerRequest{
-		Parent: fmt.Sprintf("projects/%s/locations/global", projectID),
+		Parent:    fmt.Sprintf("projects/%s/locations/global", projectID),
 		TriggerId: triggerID,
 		JobTrigger: &dlppb.JobTrigger{
 			DisplayName: displayName,

--- a/dlp/snippets/trigger/list.go
+++ b/dlp/snippets/trigger/list.go
@@ -40,7 +40,7 @@ func listTriggers(w io.Writer, projectID string) error {
 
 	// Create a configured request.
 	req := &dlppb.ListJobTriggersRequest{
-		Parent: "projects/" + projectID,
+		Parent: fmt.Sprintf("projects/%s/locations/global", projectID),
 	}
 	// Send the request and iterate over the results.
 	it := client.ListJobTriggers(ctx, req)

--- a/dlp/snippets/trigger/trigger_test.go
+++ b/dlp/snippets/trigger/trigger_test.go
@@ -26,7 +26,7 @@ func TestTriggersSamples(t *testing.T) {
 	tc := testutil.SystemTest(t)
 	buf := new(bytes.Buffer)
 
-	fullID := "projects/" + tc.ProjectID + "/jobTriggers/my-trigger"
+	fullID := "projects/" + tc.ProjectID + "/locations/global/jobTriggers/my-trigger"
 
 	// Delete the trigger if it already exists since the same ID is used every
 	// time.


### PR DESCRIPTION
Update DLP samples to include "locations/global" in the parent field. This ensures that the job name returned by the API matches the job name used internally and (critically) in the pubsub message we match against. 

See internal bug b/158100365 for context.
