### PR TITLE
firestore: use project-specific collection/doc names

### DIFF
--- a/firestore/firestore_snippets/collection_group_setup.go
+++ b/firestore/firestore_snippets/collection_group_setup.go
@@ -23,7 +23,7 @@ import (
 )
 
 // collectionGroupSetup sets up a collection group to query.
-func collectionGroupSetup(projectID string) error {
+func collectionGroupSetup(projectID, cityCollection string) error {
 	ctx := context.Background()
 
 	client, err := firestore.NewClient(ctx, projectID)
@@ -47,7 +47,7 @@ func collectionGroupSetup(projectID string) error {
 		{"BJ", "Beijing Ancient Observatory", "museum"},
 	}
 
-	cities := client.Collection("cities")
+	cities := client.Collection(cityCollection)
 	for _, l := range landmarks {
 		if _, err := cities.Doc(l.city).Collection("landmarks").NewDoc().Set(ctx, map[string]string{
 			"name": l.name,

--- a/firestore/firestore_snippets/collection_group_test.go
+++ b/firestore/firestore_snippets/collection_group_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestCollectionGroup(t *testing.T) {
-	testutil.EndToEndTest(t)
+	tc := testutil.SystemTest(t)
 	// TODO(#559): revert this to testutil.SystemTest(t).ProjectID
 	// when datastore and firestore can co-exist in a project.
 	projectID := os.Getenv("GOLANG_SAMPLES_FIRESTORE_PROJECT")
@@ -42,8 +42,10 @@ func TestCollectionGroup(t *testing.T) {
 	}
 	defer client.Close()
 
+	collection := tc.ProjectID + "-collection-group-cities"
+
 	// Delete all docs first to make sure collectionGroupSetup works.
-	docs, err := client.Collection("cities").DocumentRefs(ctx).GetAll()
+	docs, err := client.Collection(collection).DocumentRefs(ctx).GetAll()
 	// Ignore errors; this isn't essential.
 	if err == nil {
 		for _, d := range docs {
@@ -51,7 +53,7 @@ func TestCollectionGroup(t *testing.T) {
 		}
 	}
 
-	if err := collectionGroupSetup(projectID); err != nil {
+	if err := collectionGroupSetup(projectID, collection); err != nil {
 		t.Fatalf("collectionGroupSetup: %v", err)
 	}
 

--- a/firestore/firestore_snippets/increment.go
+++ b/firestore/firestore_snippets/increment.go
@@ -22,9 +22,9 @@ import (
 	"cloud.google.com/go/firestore"
 )
 
-// updateDocumentIncrement increments the population of the DC document in the
+// updateDocumentIncrement increments the population of the city document in the
 // cities collection by 50.
-func updateDocumentIncrement(projectID string) error {
+func updateDocumentIncrement(projectID, city string) error {
 	// projectID := "my-project"
 
 	ctx := context.Background()
@@ -34,7 +34,7 @@ func updateDocumentIncrement(projectID string) error {
 		return fmt.Errorf("firestore.NewClient: %v", err)
 	}
 
-	dc := client.Collection("cities").Doc("DC")
+	dc := client.Collection("cities").Doc(city)
 	_, err = dc.Update(ctx, []firestore.Update{
 		{Path: "population", Value: firestore.Increment(50)},
 	})

--- a/firestore/firestore_snippets/increment_test.go
+++ b/firestore/firestore_snippets/increment_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestUpdateDocumentIncrement(t *testing.T) {
-	testutil.EndToEndTest(t)
+	tc := testutil.SystemTest(t)
 	// TODO(#559): revert this to testutil.SystemTest(t).ProjectID
 	// when datastore and firestore can co-exist in a project.
 	projectID := os.Getenv("GOLANG_SAMPLES_FIRESTORE_PROJECT")
@@ -40,11 +40,12 @@ func TestUpdateDocumentIncrement(t *testing.T) {
 	}
 	defer client.Close()
 
-	dc := client.Collection("cities").Doc("DC")
+	city := tc.ProjectID + "-DC"
+	dc := client.Collection("cities").Doc(city)
 	data := map[string]int{"population": 100}
 	dc.Set(ctx, data)
 
-	if err := updateDocumentIncrement(projectID); err != nil {
+	if err := updateDocumentIncrement(projectID, city); err != nil {
 		t.Fatalf("updateDocumentIncrement: %v", err)
 	}
 


### PR DESCRIPTION
Tests in different packages can run in parallel. Also, E2E tests run in parallel.

There is at least one more use of `"cities"`, but it's hopefully OK as the only one using it. Those samples use `"cities"` extensively, so it's nice to keep it consistent.