### PR TITLE
.github: switch back to Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "daily"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,16 @@
+{
+  "extends": [
+    "config:base",
+    "schedule:weekly"
+  ],
+  "semanticCommits": false,
+  "postUpdateOptions": [
+    "gomodTidy"
+  ],
+  "commitMessagePrefix": "all: ",
+  "commitMessageAction": "update",
+  "ignorePaths": [
+    "testing/docker/Dockerfile*"
+  ],
+  "groupName": "all"
+}

--- a/badfiles_test.go
+++ b/badfiles_test.go
@@ -97,7 +97,7 @@ var allowList = []string{
 
 	// GitHub configuration.
 	".github/blunderbuss.yml",
-	".github/dependabot.yml",
+	".github/renovate.json",
 	".github/CODEOWNERS",
 
 	// Getting Started on GCE systemd service file.


### PR DESCRIPTION
Dependabot cannot yet group updates into a single PR. Also, you have to
configure every go.mod you want to get updates for. I prototyped a
generator + test to make sure the config could stay up to date, but it
seems like too much hassle.

Also, it's hard to keep up with the individual PRs with only the root
go.mod receiving Dependabot updates. So, I don't want to imagine every
go.mod getting updates.

Renovate doesn't require a config for every go.mod and can be configured
to group all updates into a single PR.

Updates #1444.