### PR TITLE
testing: skip modules with a newer version than toolchain

### DIFF
--- a/internal/gomodversiontest/go.mod
+++ b/internal/gomodversiontest/go.mod
@@ -1,0 +1,3 @@
+module gomodversiontest
+
+go 1.14

--- a/internal/gomodversiontest/main.go
+++ b/internal/gomodversiontest/main.go
@@ -1,0 +1,24 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"go/build"
+	"log"
+)
+
+func main() {
+	log.Print(build.Default.Dir) // new in 1.14
+}

--- a/testing/kokoro/system_tests.sh
+++ b/testing/kokoro/system_tests.sh
@@ -185,6 +185,13 @@ set +e # Don't exit on errors to make sure we run all tests.
 # runTests runs the tests in the current directory. If an argument is specified,
 # it is used as the argument to `go test`.
 runTests() {
+  if goVersionShouldSkip; then
+    set +x
+    echo "SKIPPING: module's minimum version is newer than the current Go version."
+    set -x
+    return 0
+  fi
+
   set +x
   echo "Running 'go test' in '$(pwd)'..."
   set -x
@@ -195,6 +202,18 @@ runTests() {
   sampletests < raw_log.xml > sponge_log.xml
   rm raw_log.xml # No need to keep this around.
   set +x
+}
+
+# Returns 0 if the test should be skipped because the current Go
+# version is too old for the current module.
+goVersionShouldSkip() {
+  modVersion="$(go list -m -f '{{.GoVersion}}')"
+  if [ -z "$modVersion" ]; then
+    # Not in a module or minimum Go version not specified, don't skip.
+    return 1
+  fi
+
+  ! (go list -f "{{context.ReleaseTags}}" | grep -q "go$modVersion\b")
 }
 
 if [[ $RUN_ALL_TESTS = "1" ]]; then

--- a/testing/kokoro/system_tests.sh
+++ b/testing/kokoro/system_tests.sh
@@ -213,7 +213,7 @@ goVersionShouldSkip() {
     return 1
   fi
 
-  ! (go list -f "{{context.ReleaseTags}}" | grep -q "go$modVersion\b")
+  go list -f "{{context.ReleaseTags}}" | grep -q -v "go$modVersion\b"
 }
 
 if [[ $RUN_ALL_TESTS = "1" ]]; then


### PR DESCRIPTION
This allows newer language/toolchain features to be used.
Tests in that module are skipped if the installed Go version in Kokoro
is too old.