### PR TITLE
all: skip vision, bigquerystorage for mTLS (known bad)

### DIFF
--- a/bigquery/bigquery_storage_quickstart/main_test.go
+++ b/bigquery/bigquery_storage_quickstart/main_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestApp(t *testing.T) {
+	testutil.KnownBadMTLS(t)
+
 	tc := testutil.SystemTest(t)
 	m := testutil.BuildMain(t)
 	defer m.Cleanup()

--- a/internal/mtls_smoketest/smoketest_test.go
+++ b/internal/mtls_smoketest/smoketest_test.go
@@ -1,0 +1,101 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mtls_smoketest
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	bqstorage "cloud.google.com/go/bigquery/storage/apiv1"
+	vision "cloud.google.com/go/vision/apiv1"
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+	"google.golang.org/api/option"
+	bqstoragepb "google.golang.org/genproto/googleapis/cloud/bigquery/storage/v1"
+)
+
+var shouldFail = os.Getenv("GOOGLE_API_USE_MTLS") == "always"
+
+// checkErr expects an error under mtls_smoketest, and no error otherwise.
+func checkErr(err error, t *testing.T) {
+	t.Helper()
+	if shouldFail && err == nil {
+		t.Fatalf("got no err when wanted one - this means you should delete this test and un-skip the tests it's referring to.")
+	}
+	if !shouldFail && err != nil {
+		t.Fatalf("got err when wanted no error: %v", err)
+	}
+}
+
+// When this test starts failing, delete it and uncomment the "testutil.KnownBadMTLS()" lines in these packages:
+// vision/detect
+// vision/label
+// vision/product_search (mtls_smoketest_test.go)
+func TestVision(t *testing.T) {
+	tc := testutil.EndToEndTest(t)
+
+	ctx := context.Background()
+	// NOTE(cbro): Observed successful and unsuccessful calls take under 1s.
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	client, err := vision.NewImageAnnotatorClient(ctx, option.WithQuotaProject(tc.ProjectID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	f, err := os.Open("../../vision/testdata/cat.jpg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	image, err := vision.NewImageFromReader(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.DetectLabels(ctx, image, nil, 10)
+	checkErr(err, t)
+}
+
+// When this test starts failing, delete it and uncomment the "testutil.KnownBadMTLS()" lines in these packages:
+// bigquery/bigquery_storage_quickstart
+func TestBigquerystorage(t *testing.T) {
+	tc := testutil.EndToEndTest(t)
+
+	ctx := context.Background()
+	// NOTE(cbro): Observed successful calls take around 1s. Unsuccessful calls hang indefinitely.
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	client, err := bqstorage.NewBigQueryReadClient(ctx)
+	if err != nil {
+		t.Fatalf("NewBigQueryStorageClient: %v", err)
+	}
+	defer client.Close()
+
+	createReadSessionRequest := &bqstoragepb.CreateReadSessionRequest{
+		Parent: "projects/" + tc.ProjectID,
+		ReadSession: &bqstoragepb.ReadSession{
+			Table:      "projects/bigquery-public-data/datasets/usa_names/tables/usa_1910_current",
+			DataFormat: bqstoragepb.DataFormat_AVRO,
+		},
+		MaxStreamCount: 1,
+	}
+
+	_, err = client.CreateReadSession(ctx, createReadSessionRequest)
+	checkErr(err, t)
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -64,6 +64,15 @@ func SystemTest(t *testing.T) Context {
 	return tc
 }
 
+// KnownBadMTLS skips the test in mtls_smoketest mode.
+// Any test skipped should have an equivalent test in internal/mtls_smoketest
+// that will start failing when the tests should be un-skipped.
+func KnownBadMTLS(t *testing.T) {
+	if os.Getenv("GOOGLE_API_USE_MTLS") == "always" {
+		t.Skip("Test is known to be bad when $GOOGLE_API_USE_MTLS=always")
+	}
+}
+
 // EndToEndTest gets the test context, and sets the test as Parallel.
 // The test is skipped if the GOLANG_SAMPLES_E2E_TEST environment variable is not set.
 func EndToEndTest(t *testing.T) Context {

--- a/vision/detect/detect_test.go
+++ b/vision/detect/detect_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestDetect(t *testing.T) {
+	testutil.KnownBadMTLS(t)
 	testutil.SystemTest(t)
 
 	tests := []struct {
@@ -84,6 +85,7 @@ func TestDetect(t *testing.T) {
 }
 
 func TestDetectAsyncDocument(t *testing.T) {
+	testutil.KnownBadMTLS(t)
 	tc := testutil.SystemTest(t)
 
 	ctx := context.Background()

--- a/vision/detect/set_endpoint_test.go
+++ b/vision/detect/set_endpoint_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestSetEndpoint(t *testing.T) {
+	testutil.KnownBadMTLS(t)
 	testutil.SystemTest(t)
 
 	const endpoint = "eu-vision.googleapis.com:443"

--- a/vision/product_search/mtls_smoketest_test.go
+++ b/vision/product_search/mtls_smoketest_test.go
@@ -12,23 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package productsearch
 
 import (
+	"log"
+	"os"
 	"testing"
-
-	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 )
 
-func TestLabel(t *testing.T) {
-	testutil.KnownBadMTLS(t)
-	testutil.SystemTest(t)
+// NOTE(cbro): delete me when mtls_smoketest indicates vision.mtls.googleapis.com is ready to use.
 
-	labels, err := findLabels("../testdata/cat.jpg")
-	if err != nil {
-		t.Fatalf("got %v, want nil err", err)
+func TestMain(m *testing.M) {
+	// Like testutil.KnownBadMTLS() but for the whole package.
+	if os.Getenv("GOOGLE_API_USE_MTLS") == "always" {
+		log.Print("SKIP - known bad when $GOOGLE_API_USE_MTLS=always")
+		os.Exit(0)
 	}
-	if len(labels) == 0 {
-		t.Fatalf("want non-empty slice of labels")
-	}
+	os.Exit(m.Run())
 }


### PR DESCRIPTION
Adds a test that fails when these endpoints are ready to use and the
test skipping can be removed.