### PR TITLE
testing: skip bad mtls by removing go files

### DIFF
--- a/internal/mtls_smoketest/smoketest_test.go
+++ b/internal/mtls_smoketest/smoketest_test.go
@@ -43,12 +43,13 @@ func checkErr(err error, t *testing.T) {
 	}
 }
 
-// When this test starts failing, delete it and the corresponding lines in system_tests.bash
+// When this test starts failing, delete it and the corresponding lines in mtls_smoketest.bash
 //
+// run/image-processing/imagemagick
+// functions/imagemagick
 // vision/detect
 // vision/label
 // vision/product_search
-// run/image-processing/imagemagick
 func TestVision(t *testing.T) {
 	tc := testutil.EndToEndTest(t)
 
@@ -76,7 +77,7 @@ func TestVision(t *testing.T) {
 	checkErr(err, t)
 }
 
-// When this test starts failing, delete it and the corresponding lines in system_tests.bash
+// When this test starts failing, delete it and the corresponding lines in mtls_smoketest.bash
 //
 // bigquery/bigquery_storage_quickstart
 func TestBigquerystorage(t *testing.T) {
@@ -106,7 +107,7 @@ func TestBigquerystorage(t *testing.T) {
 	checkErr(err, t)
 }
 
-// When this test starts failing, delete it and the corresponding lines in system_tests.bash
+// When this test starts failing, delete it and the corresponding lines in mtls_smoketest.bash
 //
 // gaming/servers
 func TestGameservices(t *testing.T) {

--- a/testing/kokoro/mtls_smoketest.bash
+++ b/testing/kokoro/mtls_smoketest.bash
@@ -26,3 +26,19 @@ for f in $(find . -name go.mod); do
     go get cloud.google.com/go@master
   popd
 done
+
+# List of tests to skip during mtls_smoketest.
+# Any test skipped should have an equivalent test in internal/mtls_smoketest
+# that will start failing when the tests should be un-skipped.
+skip=(
+  bigquery/bigquery_storage_quickstart
+  gaming/servers
+  run/image-processing/imagemagick
+  functions/imagemagick
+  vision/detect
+  vision/label
+  vision/product_search
+)
+for pkg in "${skip[@]}"; do
+  rm "$pkg"/*_test.go
+done

--- a/testing/kokoro/system_tests.sh
+++ b/testing/kokoro/system_tests.sh
@@ -132,18 +132,6 @@ fi
 # only set with mtls_smoketest
 # TODO(cbro): remove with mtls_smoketest.cfg
 if [[ $GOOGLE_API_USE_MTLS = "always" ]]; then
-  RUN_ALL_TESTS="0"
-  # List of tests to skip during mtls_smoketest.
-  # Any test skipped should have an equivalent test in internal/mtls_smoketest
-  # that will start failing when the tests should be un-skipped.
-  CHANGED_DIRS="$(find . -type d \
-  | grep -v 'bigquery/bigquery_storage_quickstart$' \
-  | grep -v 'gaming/servers$' \
-  | grep -v 'run/image-processing/imagemagick$' \
-  | grep -v 'vision/detect$' \
-  | grep -v 'vision/label$' \
-  | grep -v 'vision/product_search$' \
-  )"
   ./testing/kokoro/mtls_smoketest.bash
 fi
 


### PR DESCRIPTION
system_tests.sh is a bit over-aggressive (but rightly so) in deciding
which tests to run.

Skip them by deleting them at the beginning of the CI run.

Also adds functions/imagemagick to the skiplist.