### PR TITLE
testing: skip cloud run e2e tests for mtls_smoketest

### DIFF
--- a/testing/kokoro/mtls_smoketest.bash
+++ b/testing/kokoro/mtls_smoketest.bash
@@ -46,5 +46,9 @@ skip=(
   vision/product_search
 )
 for pkg in "${skip[@]}"; do
-  rm "$pkg"/*_test.go
+  rm -f "$pkg"/*_test.go
 done
+
+# E2E tests that build with mod=readonly, which conflicts with the "go get @master" commands above.
+rm run/**/e2e_test.go
+rm run/**/**/e2e_test.go


### PR DESCRIPTION
These are failing because of the mod=readonly go commands in the Docker
build, which conflicts with the "go get @master" we use for mtls_smoketest.

These wouldn't be actually helpful for the mTLS tests, anyway, because
the GOOGLE_API_USE_MTLS isn't set to "always" as part of the deployment.