### PR TITLE
run/events_pubsub: re-enable test

### DIFF
--- a/run/events_pubsub/go.mod
+++ b/run/events_pubsub/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/run/events-pubsub
 
-go 1.14
+go 1.13
 
 require (
 	github.com/GoogleCloudPlatform/golang-samples v0.0.0-20200709211204-5a809bd5cdc8

--- a/run/events_pubsub/main_test.go
+++ b/run/events_pubsub/main_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 func TestHelloPubSubCloudEvent(t *testing.T) {
-	t.Skip("test requires Go 1.13+. See: https://github.com/GoogleCloudPlatform/golang-samples/issues/1224")
 	pubsubEvent := &PubSub{
 		Message: PubSubMessage{
 			Data: []byte("foo"),


### PR DESCRIPTION
After #1224 was resolved, we can now re-enable.