### PR TITLE
.github: assign dataproc issues to bradmiro

### DIFF
--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -11,6 +11,10 @@ assign_issues_by:
   to:
   - shollyman
 - labels:
+  - 'api: dataproc'
+  to:
+  - bradmiro
+- labels:
   - 'api: pubsub'
   to:
   - hongalex


### PR DESCRIPTION
Would auto-assign issues like https://github.com/GoogleCloudPlatform/golang-samples/issues/1569.