### PR TITLE
fix(profiler): close connections/clients in shakesapp to fix memory leak

### DIFF
--- a/profiler/shakesapp/shakesapp/client.go
+++ b/profiler/shakesapp/shakesapp/client.go
@@ -40,6 +40,7 @@ func SimulateClient(ctx context.Context, addr string, numReqs, reqsInFlight int)
 	if err != nil {
 		return err
 	}
+	defer conn.Close()
 	client := NewShakespeareServiceClient(conn)
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/profiler/shakesapp/shakesapp/server.go
+++ b/profiler/shakesapp/shakesapp/server.go
@@ -79,6 +79,7 @@ func readFiles(ctx context.Context, bucketName, prefix string) ([]string, error)
 	if err != nil {
 		return []string{}, fmt.Errorf("failed to create storage client: %s", err)
 	}
+	defer client.Close()
 
 	bucket := client.Bucket(bucketName)
 


### PR DESCRIPTION
TESTED= enabled heap profiler and compared profiles w/ and w/o fix. Profiles w/ fix showed less memory being used.

Since this application is run only for short intervals in Profiler's How-To, I don't think we need to retake screenshots there.