### PR TITLE
fix: use valid run service name for e2e test

### DIFF
--- a/run/events_pubsub/e2e_test.go
+++ b/run/events_pubsub/e2e_test.go
@@ -27,7 +27,7 @@ import (
 func TestPubSubEventsService(t *testing.T) {
 	tc := testutil.EndToEndTest(t)
 
-	service := cloudrunci.NewService("run_events_pubsub", tc.ProjectID)
+	service := cloudrunci.NewService("run-events-pubsub", tc.ProjectID)
 	if err := service.Deploy(); err != nil {
 		t.Fatalf("service.Deploy %q: %v", service.Name, err)
 	}

--- a/run/events_storage/e2e_test.go
+++ b/run/events_storage/e2e_test.go
@@ -27,7 +27,7 @@ import (
 func TestPubSubEventsService(t *testing.T) {
 	tc := testutil.EndToEndTest(t)
 
-	service := cloudrunci.NewService("run_events_storage", tc.ProjectID)
+	service := cloudrunci.NewService("run-events-storage", tc.ProjectID)
 	if err := service.Deploy(); err != nil {
 		t.Fatalf("service.Deploy %q: %v", service.Name, err)
 	}


### PR DESCRIPTION
Fixes: https://github.com/GoogleCloudPlatform/golang-samples/issues/1647