### PR TITLE
chore: added examples of environment variable values to Cloud SQL samples

### DIFF
--- a/cloudsql/mysql/database-sql/cloudsql.go
+++ b/cloudsql/mysql/database-sql/cloudsql.go
@@ -231,10 +231,10 @@ func mustGetenv(k string) string {
 func initSocketConnectionPool() (*sql.DB, error) {
 	// [START cloud_sql_mysql_databasesql_create_socket]
 	var (
-		dbUser                 = mustGetenv("DB_USER")
-		dbPwd                  = mustGetenv("DB_PASS")
-		instanceConnectionName = mustGetenv("INSTANCE_CONNECTION_NAME")
-		dbName                 = mustGetenv("DB_NAME")
+		dbUser                 = mustGetenv("DB_USER")                  // e.g. 'my-db-user'
+		dbPwd                  = mustGetenv("DB_PASS")                  // e.g. 'my-db-password'
+		instanceConnectionName = mustGetenv("INSTANCE_CONNECTION_NAME") // e.g. 'project:region:instance'
+		dbName                 = mustGetenv("DB_NAME")                  // e.g. 'my-database'
 	)
 
 	socketDir, isSet := os.LookupEnv("DB_SOCKET_DIR")
@@ -264,11 +264,11 @@ func initSocketConnectionPool() (*sql.DB, error) {
 func initTCPConnectionPool() (*sql.DB, error) {
 	// [START cloud_sql_mysql_databasesql_create_tcp]
 	var (
-		dbUser    = mustGetenv("DB_USER")
-		dbPwd     = mustGetenv("DB_PASS")
-		dbTcpHost = mustGetenv("DB_TCP_HOST")
-		dbPort    = mustGetenv("DB_PORT")
-		dbName    = mustGetenv("DB_NAME")
+		dbUser    = mustGetenv("DB_USER")     // e.g. 'my-db-user'
+		dbPwd     = mustGetenv("DB_PASS")     // e.g. 'my-db-password'
+		dbTcpHost = mustGetenv("DB_TCP_HOST") // e.g. '127.0.0.1' ('172.17.0.1' if deployed to GAE Flex)
+		dbPort    = mustGetenv("DB_PORT")     // e.g. '3306'
+		dbName    = mustGetenv("DB_NAME")     // e.g. 'my-database'
 	)
 
 	var dbURI string

--- a/cloudsql/postgres/database-sql/cloudsql.go
+++ b/cloudsql/postgres/database-sql/cloudsql.go
@@ -235,10 +235,10 @@ func mustGetenv(k string) string {
 func initSocketConnectionPool() (*sql.DB, error) {
 	// [START cloud_sql_postgres_databasesql_create_socket]
 	var (
-		dbUser                 = mustGetenv("DB_USER")
-		dbPwd                  = mustGetenv("DB_PASS")
-		instanceConnectionName = mustGetenv("INSTANCE_CONNECTION_NAME")
-		dbName                 = mustGetenv("DB_NAME")
+		dbUser                 = mustGetenv("DB_USER")                  // e.g. 'my-db-user'
+		dbPwd                  = mustGetenv("DB_PASS")                  // e.g. 'my-db-password'
+		instanceConnectionName = mustGetenv("INSTANCE_CONNECTION_NAME") // e.g. 'project:region:instance'
+		dbName                 = mustGetenv("DB_NAME")                  // e.g. 'my-database'
 	)
 
 	socketDir, isSet := os.LookupEnv("DB_SOCKET_DIR")
@@ -268,11 +268,11 @@ func initSocketConnectionPool() (*sql.DB, error) {
 func initTCPConnectionPool() (*sql.DB, error) {
 	// [START cloud_sql_postgres_databasesql_create_tcp]
 	var (
-		dbUser    = mustGetenv("DB_USER")
-		dbPwd     = mustGetenv("DB_PASS")
-		dbTcpHost = mustGetenv("DB_TCP_HOST")
-		dbPort    = mustGetenv("DB_PORT")
-		dbName    = mustGetenv("DB_NAME")
+		dbUser    = mustGetenv("DB_USER")     // e.g. 'my-db-user'
+		dbPwd     = mustGetenv("DB_PASS")     // e.g. 'my-db-password'
+		dbTcpHost = mustGetenv("DB_TCP_HOST") // e.g. '127.0.0.1' ('172.17.0.1' if deployed to GAE Flex)
+		dbPort    = mustGetenv("DB_PORT")     // e.g. '5432'
+		dbName    = mustGetenv("DB_NAME")     // e.g. 'my-database'
 	)
 
 	var dbURI string

--- a/cloudsql/sqlserver/database-sql/cloudsql.go
+++ b/cloudsql/sqlserver/database-sql/cloudsql.go
@@ -225,11 +225,11 @@ func mustGetenv(k string) string {
 func initTCPConnectionPool() (*sql.DB, error) {
 	// [START cloud_sql_sqlserver_databasesql_create_tcp]
 	var (
-		dbUser    = mustGetenv("DB_USER")
-		dbPwd     = mustGetenv("DB_PASS")
-		dbTcpHost = mustGetenv("DB_TCP_HOST")
-		dbPort    = mustGetenv("DB_PORT")
-		dbName    = mustGetenv("DB_NAME")
+		dbUser    = mustGetenv("DB_USER")     // e.g. 'my-db-user'
+		dbPwd     = mustGetenv("DB_PASS")     // e.g. 'my-db-password'
+		dbTcpHost = mustGetenv("DB_TCP_HOST") // e.g. '127.0.0.1' ('172.17.0.1' if deployed to GAE Flex)
+		dbPort    = mustGetenv("DB_PORT")     // e.g. '1433'
+		dbName    = mustGetenv("DB_NAME")     // e.g. 'my-database'
 	)
 
 	var dbURI string


### PR DESCRIPTION
Improves clarity of Cloud SQL samples by adding comments that provide example values of the environment variables being set