### PR TITLE
fix(run/system_package): correct minor typos of comment in code.

### DIFF
--- a/run/system_package/graphviz.go
+++ b/run/system_package/graphviz.go
@@ -27,7 +27,7 @@ import (
 )
 
 func main() {
-	// Verify the the dot utility is available at startup
+	// Verify the dot utility is available at startup
 	// instead of waiting for a first request.
 	fileInfo, err := os.Stat("/usr/bin/dot")
 	if err != nil {


### PR DESCRIPTION
Same as the title. This sample code is referred by [this doc "Using system packages tutorial"](https://cloud.google.com/run/docs/tutorials/system-packages )