### PR TITLE
test(storage): add retry to hmac TestGetKey

### DIFF
--- a/storage/service_account/hmac/hmac_test.go
+++ b/storage/service_account/hmac/hmac_test.go
@@ -125,13 +125,15 @@ func TestGetKey(t *testing.T) {
 		t.Errorf("Error in key creation: %s", err)
 	}
 
-	key, err = getHMACKey(ioutil.Discard, key.AccessID, key.ProjectID)
-	if err != nil {
-		t.Errorf("Error in getHMACKey: %s", err)
-	}
-	if key == nil {
-		t.Errorf("Returned nil key.")
-	}
+	testutil.Retry(t, 10, 10*time.Second, func(r *testutil.R) {
+		key, err = getHMACKey(ioutil.Discard, key.AccessID, key.ProjectID)
+		if err != nil {
+			t.Errorf("Error in getHMACKey: %s", err)
+		}
+		if key == nil {
+			t.Errorf("Returned nil key.")
+		}
+	})
 }
 
 func TestDeleteKey(t *testing.T) {

--- a/storage/service_account/hmac/hmac_test.go
+++ b/storage/service_account/hmac/hmac_test.go
@@ -128,10 +128,11 @@ func TestGetKey(t *testing.T) {
 	testutil.Retry(t, 10, 10*time.Second, func(r *testutil.R) {
 		key, err = getHMACKey(ioutil.Discard, key.AccessID, key.ProjectID)
 		if err != nil {
-			t.Errorf("Error in getHMACKey: %s", err)
+			r.Errorf("Error in getHMACKey: %s", err)
+			return
 		}
 		if key == nil {
-			t.Errorf("Returned nil key.")
+			r.Errorf("Returned nil key.")
 		}
 	})
 }


### PR DESCRIPTION
This can occasionally have transient failures due to eventual
consistency issues upon key creation. Add a retry similar to
what we have for TestListKeys (which has the same issue).

Fixes #1716