### PR TITLE
fix(functions/console_snippets/http): error handling and unit tests

### DIFF
--- a/functions/console_snippets/http/http.go
+++ b/functions/console_snippets/http/http.go
@@ -19,6 +19,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"html"
+	"io"
+	"log"
 	"net/http"
 )
 
@@ -28,13 +30,15 @@ func HelloWorld(w http.ResponseWriter, r *http.Request) {
 	var d struct {
 		Message string `json:"message"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&d); err != nil {
+
+	err := json.NewDecoder(r.Body).Decode(&d)
+	switch err {
+	case nil:
+		fmt.Fprint(w, html.EscapeString(d.Message))
+	case io.EOF:
 		fmt.Fprint(w, "Hello, World!")
-		return
+	default:
+		log.Printf("json.NewDecoder: %v", err)
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 	}
-	if d.Message == "" {
-		fmt.Fprint(w, "Hello, World!")
-		return
-	}
-	fmt.Fprint(w, html.EscapeString(d.Message))
 }

--- a/functions/console_snippets/http/http.go
+++ b/functions/console_snippets/http/http.go
@@ -31,14 +31,21 @@ func HelloWorld(w http.ResponseWriter, r *http.Request) {
 		Message string `json:"message"`
 	}
 
-	err := json.NewDecoder(r.Body).Decode(&d)
-	switch err {
-	case nil:
-		fmt.Fprint(w, html.EscapeString(d.Message))
-	case io.EOF:
-		fmt.Fprint(w, "Hello, World!")
-	default:
-		log.Printf("json.NewDecoder: %v", err)
-		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+	if err := json.NewDecoder(r.Body).Decode(&d); err != nil {
+		switch err {
+		case io.EOF:
+			fmt.Fprint(w, "Hello, World!")
+			return
+		default:
+			log.Printf("json.NewDecoder: %v", err)
+			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+			return
+		}
 	}
+
+	if d.Message == "" {
+		fmt.Fprint(w, "Hello, World!")
+		return
+	}
+	fmt.Fprint(w, html.EscapeString(d.Message))
 }

--- a/functions/console_snippets/http/http_test.go
+++ b/functions/console_snippets/http/http_test.go
@@ -1,0 +1,50 @@
+package p
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHelloWorld(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     string
+		want     string
+		wantCode int
+	}{
+		{
+			name:     "valid",
+			data:     `{"message": "Greetings, Ocean!"}`,
+			want:     "Greetings, Ocean!",
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "empty",
+			data:     "",
+			want:     "Hello, World!",
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "invalid",
+			data:     "not-valid-JSON",
+			want:     http.StatusText(http.StatusBadRequest) + "\n",
+			wantCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, test := range tests {
+		req := httptest.NewRequest("POST", "/", strings.NewReader(test.data))
+		rr := httptest.NewRecorder()
+		HelloWorld(rr, req)
+
+		if got := rr.Result().StatusCode; got != test.wantCode {
+			t.Errorf("HelloWorld(%s) Status: got '%d', want '%d'", test.name, got, test.wantCode)
+		}
+
+		if got := rr.Body.String(); got != test.want {
+			t.Errorf("HelloWorld(%s) Body: got %q, want %q", test.name, got, test.want)
+		}
+	}
+}

--- a/functions/console_snippets/http/http_test.go
+++ b/functions/console_snippets/http/http_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package p
 
 import (

--- a/functions/console_snippets/http/http_test.go
+++ b/functions/console_snippets/http/http_test.go
@@ -27,6 +27,18 @@ func TestHelloWorld(t *testing.T) {
 			wantCode: http.StatusOK,
 		},
 		{
+			name:     "empty+braces",
+			data:     "{}",
+			want:     "Hello, World!",
+			wantCode: http.StatusOK,
+		},
+		{
+			name:     "valid-no-message",
+			data:     `{"data": "unused"}`,
+			want:     "Hello, World!",
+			wantCode: http.StatusOK,
+		},
+		{
 			name:     "invalid",
 			data:     "not-valid-JSON",
 			want:     http.StatusText(http.StatusBadRequest) + "\n",


### PR DESCRIPTION
Fixes #1639 

1. Invalid JSON results in a BadRequest error.
2. No body / no message property results in default message.

This is a retry on #1642, in which I broke the branch. This version has further refinements, so should be preferred regardless.