### PR TITLE
refactor(functions/tips/contexttip): contexttip sample for pubsub publish

### DIFF
--- a/functions/tips/contexttip/context_tip.go
+++ b/functions/tips/contexttip/context_tip.go
@@ -53,22 +53,24 @@ func init() {
 
 // [START functions_pubsub_publish]
 
+type publishRequest struct {
+	Topic   string `json:"topic"`
+	Message string `json:"message"`
+}
+
 // PublishMessage publishes a message to Pub/Sub. PublishMessage only works
 // with topics that already exist.
 func PublishMessage(w http.ResponseWriter, r *http.Request) {
 	// Parse the request body to get the topic name and message.
-	var d struct {
-		Topic   string `json:"topic"`
-		Message string `json:"message"`
-	}
+	p := publishRequest{}
 
-	if err := json.NewDecoder(r.Body).Decode(&d); err != nil {
+	if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
 		log.Printf("json.NewDecoder: %v", err)
 		http.Error(w, "Error parsing request", http.StatusBadRequest)
 		return
 	}
 
-	if d.Topic == "" || d.Message == "" {
+	if p.Topic == "" || p.Message == "" {
 		s := "missing 'topic' or 'message' parameter"
 		log.Println(s)
 		http.Error(w, s, http.StatusBadRequest)
@@ -76,14 +78,14 @@ func PublishMessage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	m := &pubsub.Message{
-		Data: []byte(d.Message),
+		Data: []byte(p.Message),
 	}
 	// Publish and Get use r.Context() because they are only needed for this
 	// function invocation. If this were a background function, they would use
 	// the ctx passed as an argument.
-	id, err := client.Topic(d.Topic).Publish(r.Context(), m).Get(r.Context())
+	id, err := client.Topic(p.Topic).Publish(r.Context(), m).Get(r.Context())
 	if err != nil {
-		log.Printf("topic(%s).Publish.Get: %v", d.Topic, err)
+		log.Printf("topic(%s).Publish.Get: %v", p.Topic, err)
 		http.Error(w, "Error publishing message", http.StatusInternalServerError)
 		return
 	}

--- a/functions/tips/contexttip/context_tip_test.go
+++ b/functions/tips/contexttip/context_tip_test.go
@@ -26,8 +26,6 @@ import (
 	"cloud.google.com/go/pubsub"
 )
 
-const topicName = "functions-test-topic"
-
 func TestPublishMessage(t *testing.T) {
 	// TODO: Use testutil to get the project.
 	projectID = os.Getenv("GOLANG_SAMPLES_PROJECT_ID")
@@ -42,6 +40,11 @@ func TestPublishMessage(t *testing.T) {
 		t.Fatalf("pubsub.NewClient: %v", err)
 	}
 
+	topicName := os.Getenv("FUNCTIONS_TOPIC_NAME")
+	if topicName == "" {
+		topicName = "functions-test-topic"
+	}
+
 	topic := client.Topic(topicName)
 	exists, err := topic.Exists(ctx)
 	if err != nil {
@@ -54,16 +57,17 @@ func TestPublishMessage(t *testing.T) {
 		}
 	}
 
+	payload := strings.NewReader(fmt.Sprintf(`{"topic":%q, "message": %q}`, topicName, "my_message"))
 	rr := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/", strings.NewReader(fmt.Sprintf(`{"topic":%q}`, topicName)))
+	req := httptest.NewRequest("GET", "/", payload)
 	PublishMessage(rr, req)
 
 	if rr.Code != http.StatusOK {
-		t.Errorf("PublishMessage got response code %v, want %v", rr.Code, http.StatusOK)
+		t.Errorf("PublishMessage: got response code %v, want %v", rr.Code, http.StatusOK)
 	}
 
-	want := "Published"
+	want := "published"
 	if got := rr.Body.String(); !strings.Contains(got, want) {
-		t.Errorf("PublishMessage got %q, want to contain %q", got, want)
+		t.Errorf("PublishMessage: got %q, want to contain %q", got, want)
 	}
 }


### PR DESCRIPTION
Polishes the contexttip sample for use a third time across the functions docs.
By introducing a couple code patterns from the helloworld sample, I minimized adding length and increased focus on the use cases the sample is serving.