### PR TITLE
pubsub: fix error in the concurrency example.

### DIFF
--- a/pubsub/subscriptions/subscription_test.go
+++ b/pubsub/subscriptions/subscription_test.go
@@ -298,13 +298,13 @@ func TestPullMsgsConcurrencyControl(t *testing.T) {
 	const numMsgs = 5
 	publishMsgs(ctx, topic, numMsgs)
 
-	buf := new(bytes.Buffer)
-	if err := pullMsgsConcurrenyControl(buf, tc.ProjectID, subIDConc); err != nil {
+	var counter int32
+	if err := pullMsgsConcurrenyControl(&counter, tc.ProjectID, subIDConc); err != nil {
 		t.Fatalf("failed to pull messages: %v", err)
 	}
-	// Check for number of newlines, which should correspond with number of messages.
-	if got := strings.Count(buf.String(), "\n"); got != numMsgs {
-		t.Fatalf("pullMsgsConcurrencyControl got %d messages, want %d", got, numMsgs)
+	// Check the counter, it should correspond with number of messages.
+	if counter != numMsgs {
+		t.Fatalf("pullMsgsConcurrencyControl got %d messages, want %d", counter, numMsgs)
 	}
 }
 


### PR DESCRIPTION
The current example is processing all the messages in a single goroutine and is NOT concurrent.

 To make tests pass, use a counter that can be incremented concurrently.