### PR TITLE
fix(spanner): fix flaky leaderboard test

### DIFF
--- a/spanner/spanner_leaderboard/leaderboard_test.go
+++ b/spanner/spanner_leaderboard/leaderboard_test.go
@@ -61,7 +61,10 @@ func TestSample(t *testing.T) {
 	runCommand := func(t *testing.T, cmd string, dbName string, timespan int) string {
 		t.Helper()
 		var b bytes.Buffer
-		if err := run(context.Background(), adminClient, dataClient, &b, cmd, dbName, timespan); err != nil {
+		// Set timeout to 60s so it should avoid DeadlineExceeded error.
+		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
+		defer cancel()
+		if err := run(cctx, adminClient, dataClient, &b, cmd, dbName, timespan); err != nil {
 			t.Errorf("run(%q, %q): %v", cmd, dbName, err)
 		}
 		return b.String()


### PR DESCRIPTION
The error happens with `insertScores` sample. By default, `txn.BatchUpdate > ExecuteBatchDml`'s timeout is 30s so that I update it to 60s. 

Fixes #1726 