### PR TITLE
refactor(logging): debrand stackdriver logging in favor of cloud logging

### DIFF
--- a/functions/log/process_log_entry.go
+++ b/functions/log/process_log_entry.go
@@ -27,7 +27,7 @@ type PubSubMessage struct {
 	Data []byte `json:"data"`
 }
 
-// ProcessLogEntry processes a Pub/Sub message from Stackdriver.
+// ProcessLogEntry processes a Pub/Sub message from Cloud Logging.
 func ProcessLogEntry(ctx context.Context, m PubSubMessage) error {
 	log.Printf("Log entry data: %s", string(m.Data))
 	return nil

--- a/getting-started/bookshelf/bookshelf.go
+++ b/getting-started/bookshelf/bookshelf.go
@@ -62,8 +62,8 @@ type Bookshelf struct {
 	// logWriter is used for request logging and can be overridden for tests.
 	//
 	// See https://cloud.google.com/logging/docs/setup/go for how to use the
-	// Stackdriver logging client. Output to stdout and stderr is automaticaly
-	// sent to Stackdriver when running on App Engine.
+	// Cloud logging client. Output to stdout and stderr is automaticaly
+	// sent to Cloud Logging when running on App Engine.
 	logWriter io.Writer
 
 	errorClient *errorreporting.Client

--- a/getting-started/bookshelf/bookshelf.go
+++ b/getting-started/bookshelf/bookshelf.go
@@ -62,7 +62,7 @@ type Bookshelf struct {
 	// logWriter is used for request logging and can be overridden for tests.
 	//
 	// See https://cloud.google.com/logging/docs/setup/go for how to use the
-	// Cloud logging client. Output to stdout and stderr is automaticaly
+	// Cloud Logging client. Output to stdout and stderr is automaticaly
 	// sent to Cloud Logging when running on App Engine.
 	logWriter io.Writer
 

--- a/logging/logging_quickstart/main.go
+++ b/logging/logging_quickstart/main.go
@@ -14,7 +14,7 @@
 
 // [START logging_quickstart]
 
-// Sample logging-quickstart writes a log entry to Stackdriver Logging.
+// Sample logging-quickstart writes a log entry to Cloud Logging.
 package main
 
 import (
@@ -49,7 +49,7 @@ func main() {
 	// Adds an entry to the log buffer.
 	logger.Log(logging.Entry{Payload: text})
 
-	// Closes the client and flushes the buffer to the Stackdriver Logging
+	// Closes the client and flushes the buffer to the Cloud Logging
 	// service.
 	if err := client.Close(); err != nil {
 		log.Fatalf("Failed to close client: %v", err)

--- a/logging/stdlogging/main.go
+++ b/logging/stdlogging/main.go
@@ -14,7 +14,7 @@
 
 // [START logging_stdlogging]
 
-// Sample stdlogging writes log.Logger logs to the Stackdriver Logging.
+// Sample stdlogging writes log.Logger logs to the Cloud Logging.
 package main
 
 import (
@@ -43,7 +43,7 @@ func main() {
 	logger := client.Logger(logName).StandardLogger(logging.Info)
 
 	// Logs "hello world", log entry is visible at
-	// Stackdriver Logs.
+	// Cloud Logs.
 	logger.Println("hello world")
 }
 

--- a/run/hello-broken/main.go
+++ b/run/hello-broken/main.go
@@ -50,7 +50,7 @@ func helloHandler(w http.ResponseWriter, r *http.Request) {
 	name := os.Getenv("NAME")
 	if name == "" {
 		log.Printf("Missing required server parameter")
-		// The panic stack trace appears in Stackdriver Error Reporting.
+		// The panic stack trace appears in Cloud Error Reporting.
 		panic("Missing required server parameter")
 	}
 	// [END run_broken_service_problem]

--- a/run/logging-manual/main.go
+++ b/run/logging-manual/main.go
@@ -59,11 +59,11 @@ type Entry struct {
 	Severity string `json:"severity,omitempty"`
 	Trace    string `json:"logging.googleapis.com/trace,omitempty"`
 
-	// Stackdriver Log Viewer allows filtering and display of this as `jsonPayload.component`.
+	// Cloud Log Viewer allows filtering and display of this as `jsonPayload.component`.
 	Component string `json:"component,omitempty"`
 }
 
-// String renders an entry structure to the JSON format expected by Stackdriver.
+// String renders an entry structure to the JSON format expected by Cloud Logging.
 func (e Entry) String() string {
 	if e.Severity == "" {
 		e.Severity = "INFO"
@@ -81,7 +81,7 @@ func (e Entry) String() string {
 func init() {
 	// Disable log prefixes such as the default timestamp.
 	// Prefix text prevents the message from being parsed as JSON.
-	// A timestamp is added when shipping logs to Stackdriver.
+	// A timestamp is added when shipping logs to Cloud Logging.
 	log.SetFlags(0)
 }
 


### PR DESCRIPTION
Requested by product team, Stackdriver Logging was renamed to Cloud Logging and we shouldn't use "Stackdriver" as a brand name anymore. 

Update: Created a [CL](https://critique-ng.corp.google.com/cl/337147495) to update accompanying documentation to these samples