### PR TITLE
feat: add eventarc generic snippet

### DIFF
--- a/eventarc/generic/Dockerfile
+++ b/eventarc/generic/Dockerfile
@@ -1,0 +1,51 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START eventarc_generic_dockerfile]
+
+# Use the offical golang image to create a binary.
+# This is based on Debian and sets the GOPATH to /go.
+# https://hub.docker.com/_/golang
+FROM golang:1.15-buster as builder
+
+# Create and change to the app directory.
+WORKDIR /app
+
+# Retrieve application dependencies.
+# This allows the container build to reuse cached dependencies.
+# Expecting to copy go.mod and if present go.sum.
+COPY go.* ./
+RUN go mod download
+
+# Copy local code to the container image.
+COPY . ./
+
+# Build the binary.
+RUN go build -mod=readonly -v -o server
+
+# Use the official Debian slim image for a lean production container.
+# https://hub.docker.com/_/debian
+# https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
+FROM debian:buster-slim
+RUN set -x && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy the binary to the production image from the builder stage.
+COPY --from=builder /app/server /server
+
+# Run the web service on container startup.
+CMD ["/server"]
+
+# [END eventarc_generic_dockerfile]

--- a/eventarc/generic/go.mod
+++ b/eventarc/generic/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleCloudPlatform/golang-samples/run/events-pubsub
+
+go 1.13

--- a/eventarc/generic/main.go
+++ b/eventarc/generic/main.go
@@ -1,0 +1,90 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START eventarc_generic_handler]
+
+// Sample run-events-pubsub is a Cloud Run service which handles Pub/Sub messages.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+)
+
+func logAndRespond(w http.ResponseWriter, msg string) {
+	log.Println(msg)
+	fmt.Fprintln(w, msg)
+}
+
+// GenericHandler receives and echos a HTTP request's headers and body.
+func GenericHandler(w http.ResponseWriter, r *http.Request) {
+	logAndRespond(w, "Event received!")
+
+	// Log all headers besides authorization header
+	logAndRespond(w, "HEADERS:")
+	delete(r.Header, "Authorization")
+	headerMap := make(map[string]string)
+	for k, v := range r.Header {
+		headerMap[k] = string(v[0])
+		logAndRespond(w, fmt.Sprintf("%q: %q\n", k, v[0]))
+	}
+
+	// Log body
+	logAndRespond(w, "BODY:")
+	bodyBytes, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("error parsing body: %v", err)
+	}
+	body := string(bodyBytes)
+	logAndRespond(w, body)
+
+	// Format and print full output
+	type result struct {
+		Headers map[string]string `json:"headers"`
+		Body    string            `json:"body"`
+	}
+	res := &result{
+		Headers: headerMap,
+		Body:    body,
+	}
+	out, err := json.Marshal(res)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Fprintln(w, string(out))
+}
+
+// [END eventarc_generic_handler]
+// [START eventarc_generic_server]
+
+func main() {
+	http.HandleFunc("/", GenericHandler)
+	// Determine port for HTTP service.
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+		log.Printf("Defaulting to port %s", port)
+	}
+	// Start HTTP server.
+	log.Printf("Listening on port %s", port)
+	if err := http.ListenAndServe(":"+port, nil); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// [END eventarc_generic_server]

--- a/eventarc/generic/main.go
+++ b/eventarc/generic/main.go
@@ -14,7 +14,7 @@
 
 // [START eventarc_generic_handler]
 
-// Sample run-events-pubsub is a Cloud Run service which handles Pub/Sub messages.
+// Sample eventarc-generic is a Cloud Run service which logs and echos received requests.
 package main
 
 import (

--- a/eventarc/generic/main_test.go
+++ b/eventarc/generic/main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import (
 
 func TestGenericCloudEvent(t *testing.T) {
 	tests := []struct {
-		data string
 		want string
 	}{
 		{want: "Event received!"},
@@ -52,16 +51,15 @@ func TestGenericCloudEvent(t *testing.T) {
 		w.Close()
 
 		if code := rr.Result().StatusCode; code == http.StatusBadRequest {
-			t.Errorf("GenericHandler(%q) invalid input, status code (%q)", test.data, code)
+			t.Errorf("GenericHandler invalid input, status code (%q)", code)
 		}
 
 		out, err := ioutil.ReadAll(r)
 		if err != nil {
 			t.Fatalf("ReadAll: %v", err)
 		}
-		print(out)
 		if got := string(out); strings.Contains(got, test.want) != true {
-			t.Errorf("\nGenericHandler(%q): \ngot: %q\nwant to contain: %q", test.data, got, test.want)
+			t.Errorf("\nGenericHandler: \ngot: %q\nwant to contain: %q", got, test.want)
 		}
 	}
 }

--- a/eventarc/generic/main_test.go
+++ b/eventarc/generic/main_test.go
@@ -1,0 +1,67 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestGenericCloudEvent(t *testing.T) {
+	tests := []struct {
+		data string
+		want string
+	}{
+		{want: "Event received!"},
+		{want: `"Ce-Id": "1234"`},
+		{want: `{"message": "some string"}`},
+	}
+	log.SetFlags(log.Flags() &^ (log.Ldate | log.Ltime))
+	for _, test := range tests {
+		r, w, _ := os.Pipe()
+		log.SetOutput(w)
+		defer log.SetOutput(os.Stderr)
+
+		jsonStr := fmt.Sprintf(`{"message": "some string"}`)
+		payload := strings.NewReader(jsonStr)
+
+		req := httptest.NewRequest("POST", "/", payload)
+		req.Header.Set("Ce-Id", "1234")
+		req.Header.Set("Ce-Source", "//storage.googleapis.com/projects/YOUR-PROJECT")
+		rr := httptest.NewRecorder()
+		GenericHandler(rr, req)
+
+		w.Close()
+
+		if code := rr.Result().StatusCode; code == http.StatusBadRequest {
+			t.Errorf("GenericHandler(%q) invalid input, status code (%q)", test.data, code)
+		}
+
+		out, err := ioutil.ReadAll(r)
+		if err != nil {
+			t.Fatalf("ReadAll: %v", err)
+		}
+		print(out)
+		if got := string(out); strings.Contains(got, test.want) != true {
+			t.Errorf("\nGenericHandler(%q): \ngot: %q\nwant to contain: %q", test.data, got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
## feat: add eventarc generic snippet

- Simple Cloud Run service that logs and replies with the HTTP request (headers/body) received by the service.
  - Tests event received string, header, body
- Does not log `Authorization` header.
  - Includes test
- Very useful for debugging Eventarc systems in Go
- Adds a simple test to ensure the headers and body are appropriately logged.

### Testing

- Tested locally
- Deployed to Cloud Run
  - Example: https://helloworld123-q7vieseilq-uc.a.run.app/