### PR TITLE
test(spanner): increase timeout and cleanup test

### DIFF
--- a/spanner/spanner_leaderboard/leaderboard_test.go
+++ b/spanner/spanner_leaderboard/leaderboard_test.go
@@ -95,8 +95,6 @@ func TestSample(t *testing.T) {
 	// since earlier commands setup the database for the subsequent commands.
 	mustRunCommand(t, "createdatabase", dbName, 0)
 	assertContains(t, runCommand(t, "insertplayers", dbName, 0), "Inserted players")
-	assertContains(t, runCommand(t, "insertplayers", dbName, 0), "Inserted players")
-	assertContains(t, runCommand(t, "insertscores", dbName, 0), "Inserted scores")
 	assertContains(t, runCommand(t, "insertscores", dbName, 0), "Inserted scores")
 	assertContains(t, runCommand(t, "query", dbName, 0), "PlayerId: ")
 	assertContains(t, runCommand(t, "querywithtimespan", dbName, 168), "PlayerId: ")

--- a/spanner/spanner_leaderboard/leaderboard_test.go
+++ b/spanner/spanner_leaderboard/leaderboard_test.go
@@ -19,16 +19,23 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+	"github.com/google/uuid"
 	adminpb "google.golang.org/genproto/googleapis/spanner/admin/database/v1"
 )
 
+func randomID() string {
+	now := time.Now().UTC()
+	return fmt.Sprintf("%s-%s", strconv.FormatInt(now.Unix(), 10), uuid.New().String()[:8])
+}
+
 func TestSample(t *testing.T) {
-	tc := testutil.EndToEndTest(t)
+	testutil.EndToEndTest(t)
 
 	instance := os.Getenv("GOLANG_SAMPLES_SPANNER")
 	if instance == "" {
@@ -37,16 +44,22 @@ func TestSample(t *testing.T) {
 	if !strings.HasPrefix(instance, "projects/") {
 		t.Fatal("Spanner instance ref must be in the form of 'projects/PROJECT_ID/instances/INSTANCE_ID'")
 	}
-	// "test-l-" is different from the database name in snippet_test.go because
-	// this prevents from running against the same database.
-	dbName := fmt.Sprintf("%s/databases/test-l-%s", instance, tc.ProjectID)
+	dbName := fmt.Sprintf("%s/databases/lb-%s", instance, randomID())
 
 	ctx := context.Background()
 	adminClient, dataClient := createClients(ctx, dbName)
-	defer adminClient.Close()
-	defer dataClient.Close()
+	defer func() {
+		dataClient.Close()
+		testutil.Retry(t, 10, time.Second, func(r *testutil.R) {
+			err := adminClient.DropDatabase(ctx, &adminpb.DropDatabaseRequest{Database: dbName})
+			if err != nil {
+				r.Errorf("DropDatabase(%q): %v", dbName, err)
+			}
+		})
+		adminClient.Close()
+	}()
 
-	// Check for database existance prior to test start and delete, as resources may not have
+	// Check for database existence prior to test start and delete, as resources may not have
 	// been cleaned up from previous invocations.
 	if db, err := adminClient.GetDatabase(ctx, &adminpb.GetDatabaseRequest{Name: dbName}); err == nil {
 		t.Logf("database %s exists in state %s. delete result: %v", db.GetName(), db.GetState().String(),
@@ -61,8 +74,8 @@ func TestSample(t *testing.T) {
 	runCommand := func(t *testing.T, cmd string, dbName string, timespan int) string {
 		t.Helper()
 		var b bytes.Buffer
-		// Set timeout to 60s so it should avoid DeadlineExceeded error.
-		cctx, cancel := context.WithTimeout(ctx, 60000*time.Millisecond)
+		// Set timeout to 600 seconds so it should avoid DeadlineExceeded error.
+		cctx, cancel := context.WithTimeout(ctx, 600*time.Second)
 		defer cancel()
 		if err := run(cctx, adminClient, dataClient, &b, cmd, dbName, timespan); err != nil {
 			t.Errorf("run(%q, %q): %v", cmd, dbName, err)
@@ -77,15 +90,6 @@ func TestSample(t *testing.T) {
 		}
 		return b.String()
 	}
-
-	defer func() {
-		testutil.Retry(t, 10, time.Second, func(r *testutil.R) {
-			err := adminClient.DropDatabase(ctx, &adminpb.DropDatabaseRequest{Database: dbName})
-			if err != nil {
-				r.Errorf("DropDatabase(%q): %v", dbName, err)
-			}
-		})
-	}()
 
 	// These commands have to be run in a specific order
 	// since earlier commands setup the database for the subsequent commands.


### PR DESCRIPTION
Inserting 800 rows as a single Batch DML statement can take a long time, and the transaction can be aborted one or more times. The deadline used for such an operation therefore needs to be (very) long. It is now increased to 10 minutes.

Furthermore, the test case has been cleaned up a little bit:
* The multiple deferred functions for cleaning up have been combined into one.
* The database name is no longer fixed, allowing multiple instances of this test case to be executed at the same time.
* The generated player id's are now guaranteed to be unique. The previous version generated random id values that could overlap (although the probability was extremely low).

Fixes #1726