### PR TITLE
test(logging): remove TestSimpleLog flakiness and reduce test run time

### DIFF
--- a/logging/simplelog/simplelog.go
+++ b/logging/simplelog/simplelog.go
@@ -137,9 +137,13 @@ func getEntries(adminClient *logadmin.Client, projID string) ([]*logging.Entry, 
 	// [START logging_list_log_entries]
 	var entries []*logging.Entry
 	const name = "log-example"
+	lastHour := time.Now().Add(-1 * time.Hour).Format(time.RFC3339)
+
 	iter := adminClient.Entries(ctx,
 		// Only get entries from the log-example log.
 		logadmin.Filter(fmt.Sprintf(`logName = "projects/%s/logs/%s"`, projID, name)),
+		// Only queries from the last 1 hour.
+		logadmin.Filter(fmt.Sprintf(`timestamp > "%s"`, lastHour)),
 		// Get most recent entries first.
 		logadmin.NewestFirst(),
 	)

--- a/logging/simplelog/simplelog.go
+++ b/logging/simplelog/simplelog.go
@@ -140,10 +140,8 @@ func getEntries(adminClient *logadmin.Client, projID string) ([]*logging.Entry, 
 	lastHour := time.Now().Add(-1 * time.Hour).Format(time.RFC3339)
 
 	iter := adminClient.Entries(ctx,
-		// Only get entries from the log-example log.
-		logadmin.Filter(fmt.Sprintf(`logName = "projects/%s/logs/%s"`, projID, name)),
-		// Only queries from the last 1 hour.
-		logadmin.Filter(fmt.Sprintf(`timestamp > "%s"`, lastHour)),
+		// Only get entries from the "log-example" log within the last hour.
+		logadmin.Filter(fmt.Sprintf(`logName = "projects/%s/logs/%s" AND timestamp > "%s"`, projID, name, lastHour)),
 		// Get most recent entries first.
 		logadmin.NewestFirst(),
 	)

--- a/logging/simplelog/simplelog_test.go
+++ b/logging/simplelog/simplelog_test.go
@@ -67,6 +67,11 @@ func TestSimplelog(t *testing.T) {
 			return
 		}
 
+		if len(entries) < 2 {
+			r.Errorf("len(entries) = %d; want at least 2 entries", len(entries))
+			return
+		}
+
 		wantContain := map[string]*logging.Entry{
 			"Anything":                            entries[0],
 			"The payload can be any type!":        entries[0],

--- a/logging/simplelog/simplelog_test.go
+++ b/logging/simplelog/simplelog_test.go
@@ -67,11 +67,6 @@ func TestSimplelog(t *testing.T) {
 			return
 		}
 
-		if got, want := len(entries), 2; got != want {
-			r.Errorf("len(entries) = %d; want %d", got, want)
-			return
-		}
-
 		wantContain := map[string]*logging.Entry{
 			"Anything":                            entries[0],
 			"The payload can be any type!":        entries[0],


### PR DESCRIPTION
fixes: #1559, #1800 

1. Flakiness context: DeleteLog itself creates an audit log entry which cannot be deleted by deleteLog(). This caused previous flakiness issues as the test was expecting only 2 logs even if the test was run/terminated many times (and had multiple audit logs). 

2. [Run time context](https://github.com/googleapis/google-cloud-go/issues/3088)