### PR TITLE
docs: update running system tests instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -401,9 +401,11 @@ resource names that incorporate aspects of your test, such as `tc.ProjectID +
 
 ## Running system tests
 
+1. To run the system test yourself, you need a Google Cloud Project and a service account. During the creation of the service account, you should download the JSON credential file.
+1. Ensure the IAM roles needed by the tests are added to the service account.
+1. Ensure you are logged in using `gcloud auth login`.
 1. Set the `GOLANG_SAMPLES_PROJECT_ID` environment variable to a suitable test project.
-1. Ensure you are logged in using `gcloud auth login` or set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to the path of your credentials file.
-   Tests are authenticated using [Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials).
+1. Set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to the credential file path. Tests are authenticated using [Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials).
 1. Install the test dependencies:
 
     `go get -t -d github.com/GoogleCloudPlatform/golang-samples/...`


### PR DESCRIPTION
The instructions tripped me up a bit because user accounts can run tests in client library repo, but in samples, it has to be a service account 