### PR TITLE
test(spanner): unskip list backup operations

### DIFF
--- a/spanner/spanner_snippets/spanner/integration_test.go
+++ b/spanner/spanner_snippets/spanner/integration_test.go
@@ -350,9 +350,8 @@ func TestBackupSample(t *testing.T) {
 	assertContains(t, out, fmt.Sprintf("/backups/%s", backupID))
 	assertContains(t, out, "Backups listed.")
 
-	// TODO: Unskip when prod issue is fixed. See #1745.
-	// out = runSample(t, listBackupOperations, dbName, "failed to list backup operations")
-	// assertContains(t, out, fmt.Sprintf("on database %s", dbName))
+	out = runSample(t, listBackupOperations, dbName, "failed to list backup operations")
+	assertContains(t, out, fmt.Sprintf("on database %s", dbName))
 
 	out = runBackupSample(t, updateBackup, dbName, backupID, "failed to update a backup")
 	assertContains(t, out, fmt.Sprintf("Updated backup %s", backupID))


### PR DESCRIPTION
The backend issue has been fixed and released so we can unskip the test. 

Fixes #1745 