### PR TITLE
test: switch dataproc test to E2E, improve dlp/storage error handling

### DIFF
--- a/dataproc/instantiate_inline_workflow_template_test.go
+++ b/dataproc/instantiate_inline_workflow_template_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestInstantiateInlineWorkflowTemplate(t *testing.T) {
-	tc := testutil.SystemTest(t)
+	tc := testutil.EndToEndTest(t)
 
 	region := "us-central1"
 

--- a/dlp/snippets/trigger/trigger_test.go
+++ b/dlp/snippets/trigger/trigger_test.go
@@ -44,7 +44,7 @@ func TestTriggersSamples(t *testing.T) {
 	}
 
 	if err := createTrigger(buf, tc.ProjectID, "my-trigger", "My Trigger", "Test trigger", "my-bucket", nil); err != nil {
-		t.Errorf("createTrigger: %v", err)
+		t.Fatalf("createTrigger: %v", err)
 	}
 	if got, want := buf.String(), "Successfully created trigger"; !strings.Contains(got, want) {
 		t.Errorf("createTrigger got\n----\n%v\n----\nWant to contain:\n----\n%v\n----", got, want)

--- a/storage/objects/objects_test.go
+++ b/storage/objects/objects_test.go
@@ -282,6 +282,9 @@ func TestV4SignedURL(t *testing.T) {
 	bucketName := tc.ProjectID + "-signed-url-bucket-name"
 	objectName := "foo.txt"
 	serviceAccount := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
+	if serviceAccount == "" {
+		t.Skip("GOOGLE_APPLICATION_CREDENTIALS must be set")
+	}
 
 	testutil.CleanBucket(ctx, t, tc.ProjectID, bucketName)
 	putBuf := new(bytes.Buffer)


### PR DESCRIPTION
Fixes #1408. I went through the failures in #1408 and improved where I could. It's possible we could add additional checks to make sure the API is enabled or the current service account has permission. But, that seems like more effort than it's worth.