### PR TITLE
chore(.github): disable x/tools updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,10 @@
     {
       "updateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "packageNames": ["golang.org/x/tools"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
The latest changes are incompatible with Go 1.11.