### PR TITLE
docs(securitycenter): wrap samples with future prefix

### DIFF
--- a/securitycenter/assets/add_delete_security_marks.go
+++ b/securitycenter/assets/add_delete_security_marks.go
@@ -14,6 +14,7 @@
 
 package assets
 
+// [START securitycenter_add_delete_security_marks]
 // [START add_delete_security_marks]
 import (
 	"context"
@@ -63,3 +64,4 @@ func addDeleteSecurityMarks(w io.Writer, assetName string) error {
 }
 
 // [END add_delete_security_marks]
+// [END securitycenter_add_delete_security_marks]

--- a/securitycenter/assets/add_security_marks.go
+++ b/securitycenter/assets/add_security_marks.go
@@ -14,6 +14,7 @@
 
 package assets
 
+// [START securitycenter_add_security_marks]
 // [START add_security_marks]
 import (
 	"context"
@@ -64,3 +65,4 @@ func addSecurityMarks(w io.Writer, assetName string) error {
 }
 
 // [END add_security_marks]
+// [END securitycenter_add_security_marks]

--- a/securitycenter/assets/delete_security_marks.go
+++ b/securitycenter/assets/delete_security_marks.go
@@ -14,6 +14,7 @@
 
 package assets
 
+// [START securitycenter_delete_security_marks]
 // [START delete_security_marks]
 import (
 	"context"
@@ -61,3 +62,4 @@ func deleteSecurityMarks(w io.Writer, assetName string) error {
 }
 
 // [END delete_security_marks]
+// [END securitycenter_delete_security_marks]

--- a/securitycenter/assets/list_all_assets.go
+++ b/securitycenter/assets/list_all_assets.go
@@ -14,6 +14,7 @@
 
 package assets
 
+// [START securitycenter_list_all_assets]
 // [START list_all_assets]
 import (
 	"context"
@@ -62,3 +63,4 @@ func listAllAssets(w io.Writer, orgID string) error {
 }
 
 // [END list_all_assets]
+// [END securitycenter_list_all_assets]

--- a/securitycenter/assets/list_all_project_assets.go
+++ b/securitycenter/assets/list_all_project_assets.go
@@ -14,6 +14,7 @@
 
 package assets
 
+// [START securitycenter_list_project_assets]
 // [START list_project_assets]
 import (
 	"context"

--- a/securitycenter/assets/list_all_project_assets.go
+++ b/securitycenter/assets/list_all_project_assets.go
@@ -63,3 +63,4 @@ func listAllProjectAssets(w io.Writer, orgID string) error {
 }
 
 // [END list_project_assets]
+// [END securitycenter_list_project_assets]

--- a/securitycenter/assets/list_assets_with_security_marks.go
+++ b/securitycenter/assets/list_assets_with_security_marks.go
@@ -14,6 +14,7 @@
 
 package assets
 
+// [START securitycenter_list_assets_with_security_marks]
 // [START list_assets_with_security_marks]
 import (
 	"context"
@@ -61,3 +62,4 @@ func listAssetsWithMarks(w io.Writer, orgID string) error {
 }
 
 // [END list_assets_with_security_marks]
+// [END securitycenter_list_assets_with_security_marks]

--- a/securitycenter/assets/list_project_assets_and_state_changes.go
+++ b/securitycenter/assets/list_project_assets_and_state_changes.go
@@ -14,6 +14,7 @@
 
 package assets
 
+// [START securitycenter_list_project_assets_and_state_changes]
 // [START list_project_assets_and_state_changes]
 import (
 	"context"
@@ -68,3 +69,4 @@ func listAllProjectAssetsAndStateChanges(w io.Writer, orgID string) error {
 }
 
 // [END list_project_assets_and_state_changes]
+// [END securitycenter_list_project_assets_and_state_changes]

--- a/securitycenter/assets/list_project_assets_at_time.go
+++ b/securitycenter/assets/list_project_assets_at_time.go
@@ -14,6 +14,7 @@
 
 package assets
 
+// [START securitycenter_list_project_assets_at_time]
 // [START list_project_assets_at_time]
 import (
 	"context"
@@ -72,3 +73,4 @@ func listAllProjectAssetsAtTime(w io.Writer, orgID string, asOf time.Time) error
 }
 
 // [END list_project_assets_at_time]
+// [END securitycenter_list_project_assets_at_time]

--- a/securitycenter/findings/add_security_marks.go
+++ b/securitycenter/findings/add_security_marks.go
@@ -14,6 +14,7 @@
 
 package findings
 
+// [START securitycenter_add_security_marks]
 // [START add_security_marks]
 import (
 	"context"
@@ -65,3 +66,4 @@ func addSecurityMarks(w io.Writer, findingName string) error {
 }
 
 // [END add_security_marks]
+// [END securitycenter_add_security_marks]

--- a/securitycenter/findings/create_finding.go
+++ b/securitycenter/findings/create_finding.go
@@ -14,6 +14,7 @@
 
 package findings
 
+// [START securitycenter_create_finding]
 // [START create_finding]
 import (
 	"context"
@@ -68,3 +69,4 @@ func createFinding(w io.Writer, sourceName string) error {
 }
 
 // [END create_finding]
+// [END securitycenter_create_finding]

--- a/securitycenter/findings/create_finding_with_source_properties.go
+++ b/securitycenter/findings/create_finding_with_source_properties.go
@@ -14,6 +14,7 @@
 
 package findings
 
+// [START securitycenter_create_finding_with_source_properties]
 // [START create_finding_with_source_properties]
 import (
 	"context"
@@ -85,3 +86,4 @@ func createFindingWithProperties(w io.Writer, sourceName string) error {
 }
 
 // [END create_finding_with_source_properties]
+// [END securitycenter_create_finding_with_source_properties]

--- a/securitycenter/findings/create_source.go
+++ b/securitycenter/findings/create_source.go
@@ -14,6 +14,7 @@
 
 package findings
 
+// [START securitycenter_create_source]
 // [START create_source]
 import (
 	"context"
@@ -54,3 +55,4 @@ func createSource(w io.Writer, orgID string) error {
 }
 
 // [END create_source]
+// [END securitycenter_create_source]

--- a/securitycenter/findings/get_source.go
+++ b/securitycenter/findings/get_source.go
@@ -14,6 +14,7 @@
 
 package findings
 
+// [START securitycenter_get_source]
 // [START get_source]
 import (
 	"context"
@@ -50,3 +51,4 @@ func getSource(w io.Writer, sourceName string) error {
 }
 
 // [END get_source]
+// [END securitycenter_get_source]

--- a/securitycenter/findings/get_source_iam.go
+++ b/securitycenter/findings/get_source_iam.go
@@ -14,6 +14,7 @@
 
 package findings
 
+// [START securitycenter_get_iam_policy_source]
 // [START get_iam_policy_source]
 import (
 	"context"
@@ -50,3 +51,4 @@ func getSourceIamPolicy(w io.Writer, sourceName string) error {
 }
 
 // [END get_iam_policy_source]
+// [END securitycenter_get_iam_policy_source]

--- a/securitycenter/findings/list_all_findings.go
+++ b/securitycenter/findings/list_all_findings.go
@@ -14,6 +14,7 @@
 
 package findings
 
+// [START securitycenter_list_all_findings]
 // [START list_all_findings]
 import (
 	"context"
@@ -59,3 +60,4 @@ func listFindings(w io.Writer, orgID string) error {
 }
 
 // [END list_all_findings]
+// [END securitycenter_list_all_findings]

--- a/securitycenter/findings/list_filtered_findings.go
+++ b/securitycenter/findings/list_filtered_findings.go
@@ -14,6 +14,7 @@
 
 package findings
 
+// [START securitycenter_list_filtered_findings]
 // [START list_filtered_findings]
 import (
 	"context"
@@ -63,3 +64,4 @@ func listFilteredFindings(w io.Writer, sourceName string) error {
 }
 
 // [END list_filtered_findings]
+// [END securitycenter_list_filtered_findings]

--- a/securitycenter/findings/list_findings_at_time.go
+++ b/securitycenter/findings/list_findings_at_time.go
@@ -14,6 +14,7 @@
 
 package findings
 
+// [START securitycenter_list_findings_at_time]
 // [START list_findings_at_time]
 import (
 	"context"
@@ -68,3 +69,4 @@ func listFindingsAtTime(w io.Writer, sourceName string) error {
 }
 
 // [END list_findings_at_time]
+// [END securitycenter_list_findings_at_time]

--- a/securitycenter/findings/list_findings_with_security_mark.go
+++ b/securitycenter/findings/list_findings_with_security_mark.go
@@ -14,6 +14,7 @@
 
 package findings
 
+// [START securitycenter_list_findings_with_marks]
 // [START list_findings_with_marks]
 import (
 	"context"
@@ -60,3 +61,4 @@ func listFindingsWithMarks(w io.Writer, sourceName string) error {
 }
 
 // [END list_findings_with_marks]
+// [END securitycenter_list_findings_with_marks]

--- a/securitycenter/findings/list_sources.go
+++ b/securitycenter/findings/list_sources.go
@@ -14,6 +14,7 @@
 
 package findings
 
+// [START securitycenter_list_sources]
 // [START list_sources]
 import (
 	"context"
@@ -57,3 +58,4 @@ func listSources(w io.Writer, orgID string) error {
 }
 
 // [END list_sources]
+// [END securitycenter_list_sources]

--- a/securitycenter/findings/set_finding_state.go
+++ b/securitycenter/findings/set_finding_state.go
@@ -14,6 +14,7 @@
 
 package findings
 
+// [START securitycenter_set_finding_state]
 // [START set_finding_state]
 import (
 	"context"
@@ -63,3 +64,4 @@ func setFindingState(w io.Writer, findingName string) error {
 }
 
 // [END set_finding_state]
+// [END securitycenter_set_finding_state]

--- a/securitycenter/findings/set_source_iam.go
+++ b/securitycenter/findings/set_source_iam.go
@@ -14,6 +14,7 @@
 
 package findings
 
+// [START securitycenter_set_iam_policy_source]
 // [START set_iam_policy_source]
 import (
 	"context"
@@ -75,3 +76,4 @@ func setSourceIamPolicy(w io.Writer, sourceName string, user string) error {
 }
 
 // [END set_iam_policy_source]
+// [END securitycenter_set_iam_policy_source]

--- a/securitycenter/findings/test_iam.go
+++ b/securitycenter/findings/test_iam.go
@@ -14,6 +14,7 @@
 
 package findings
 
+// [START securitycenter_test_iam]
 // [START test_iam]
 import (
 	"context"
@@ -66,3 +67,4 @@ func testIam(w io.Writer, sourceName string) error {
 }
 
 // [END test_iam]
+// [END securitycenter_test_iam]

--- a/securitycenter/findings/update_finding_source_properties.go
+++ b/securitycenter/findings/update_finding_source_properties.go
@@ -14,6 +14,7 @@
 
 package findings
 
+// [START securitycenter_update_finding_source_properties]
 // [START update_finding_source_properties]
 import (
 	"context"
@@ -77,3 +78,4 @@ func updateFindingSourceProperties(w io.Writer, findingName string) error {
 }
 
 // [END update_finding_source_properties]
+// [END securitycenter_update_finding_source_properties]

--- a/securitycenter/findings/update_source.go
+++ b/securitycenter/findings/update_source.go
@@ -14,6 +14,7 @@
 
 package findings
 
+// [START securitycenter_update_source]
 // [START update_source]
 import (
 	"context"
@@ -61,3 +62,4 @@ func updateSource(w io.Writer, sourceName string) error {
 }
 
 // [END update_source]
+// [END securitycenter_update_source]

--- a/securitycenter/notifications/create_notification_config.go
+++ b/securitycenter/notifications/create_notification_config.go
@@ -14,6 +14,7 @@
 
 package notifications
 
+// [START securitycenter_create_notification_config]
 // [START scc_create_notification_config]
 import (
 	"context"
@@ -61,3 +62,4 @@ func createNotificationConfig(w io.Writer, orgID string, pubsubTopic string, not
 }
 
 // [END scc_create_notification_config]
+// [END securitycenter_create_notification_config]

--- a/securitycenter/notifications/delete_notification_config.go
+++ b/securitycenter/notifications/delete_notification_config.go
@@ -14,6 +14,7 @@
 
 package notifications
 
+// [START securitycenter_delete_notification_config]
 // [START scc_delete_notification_config]
 import (
 	"context"
@@ -50,3 +51,4 @@ func deleteNotificationConfig(w io.Writer, orgID string, notificationConfigID st
 }
 
 // [END scc_delete_notification_config]
+// [END securitycenter_delete_notification_config]

--- a/securitycenter/notifications/get_notification_config.go
+++ b/securitycenter/notifications/get_notification_config.go
@@ -14,6 +14,7 @@
 
 package notifications
 
+// [START securitycenter_get_notification_config]
 // [START scc_get_notification_config]
 import (
 	"context"
@@ -50,3 +51,4 @@ func getNotificationConfig(w io.Writer, orgID string, notificationConfigID strin
 }
 
 // [END scc_get_notification_config]
+// [END securitycenter_get_notification_config]

--- a/securitycenter/notifications/list_notification_configs.go
+++ b/securitycenter/notifications/list_notification_configs.go
@@ -14,6 +14,7 @@
 
 package notifications
 
+// [START securitycenter_list_notification_configs]
 // [START scc_list_notification_configs]
 import (
 	"context"
@@ -57,3 +58,4 @@ func listNotificationConfigs(w io.Writer, orgID string) error {
 }
 
 // [END scc_list_notification_configs]
+// [END securitycenter_list_notification_configs]

--- a/securitycenter/notifications/receive_notifications.go
+++ b/securitycenter/notifications/receive_notifications.go
@@ -14,6 +14,7 @@
 
 package notifications
 
+// [START securitycenter_receive_notifications]
 // [START scc_receive_notifications]
 import (
 	"bytes"
@@ -56,3 +57,4 @@ func receiveMessages(w io.Writer, projectID string, subscriptionName string) err
 }
 
 // [END scc_receive_notifications]
+// [END securitycenter_receive_notifications]

--- a/securitycenter/notifications/update_notification_config.go
+++ b/securitycenter/notifications/update_notification_config.go
@@ -14,6 +14,7 @@
 
 package notifications
 
+// [START securitycenter_update_notification_config]
 // [START scc_update_notification_config]
 import (
 	"context"
@@ -67,3 +68,4 @@ func updateNotificationConfig(w io.Writer, orgID string, notificationConfigID st
 }
 
 // [END scc_update_notification_config]
+// [END securitycenter_update_notification_config]

--- a/securitycenter/settings/enable_asset_discovery.go
+++ b/securitycenter/settings/enable_asset_discovery.go
@@ -15,6 +15,7 @@
 // Package settings contains snippets for working with CSCC organization settings.
 package settings
 
+// [START securitycenter_get_org_settings]
 // [START get_org_settings]
 import (
 	"context"
@@ -58,3 +59,4 @@ func enableAssetDiscovery(w io.Writer, orgID string) error {
 }
 
 // [END get_org_settings]
+// [END securitycenter_get_org_settings]

--- a/securitycenter/settings/get_org_settings.go
+++ b/securitycenter/settings/get_org_settings.go
@@ -14,6 +14,7 @@
 
 package settings
 
+// [START securitycenter_get_org_settings]
 // [START get_org_settings]
 import (
 	"context"
@@ -49,3 +50,4 @@ func getOrgSettings(w io.Writer, orgID string) error {
 }
 
 // [END get_org_settings]
+// [END securitycenter_get_org_settings]


### PR DESCRIPTION
Standardizing Security Command Center samples to use 'securitycenter' prefixing. 

- Wrapped existing samples to keep published doclinks unbroken
- Replace region tags that aren't published. 

Once this PR is through, published sample inclusions will be updated to use the new prefix, then I'll come through again and remove the unused block wraps.