### PR TITLE
chore(bigquery): add verbose logging to flaky test

### DIFF
--- a/bigquery/bigquery_storage_quickstart/main_test.go
+++ b/bigquery/bigquery_storage_quickstart/main_test.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"testing"
 	"time"
 
@@ -37,7 +36,7 @@ func TestApp(t *testing.T) {
 		t.Errorf("execution failed: %v", err)
 		// TODO(shollyman): remove after https://github.com/GoogleCloudPlatform/golang-samples/issues/1866 deflaked.
 		// We're running over the 30s timeout, but unclear why; normal execution is sub-5s.
-		log.Printf("stderr: %s", string(stdErr))
+		t.Logf("stderr: %s", string(stdErr))
 	}
 
 	// We don't look for specific strings, just expect at least 1kb of output.

--- a/bigquery/bigquery_storage_quickstart/main_test.go
+++ b/bigquery/bigquery_storage_quickstart/main_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"testing"
 	"time"
 
@@ -34,6 +35,9 @@ func TestApp(t *testing.T) {
 	stdOut, stdErr, err := m.Run(nil, 30*time.Second, fmt.Sprintf("--project_id=%s", tc.ProjectID))
 	if err != nil {
 		t.Errorf("execution failed: %v", err)
+		// TODO(shollyman): remove after https://github.com/GoogleCloudPlatform/golang-samples/issues/1866 deflaked.
+		// We're running over the 30s timeout, but unclear why; normal execution is sub-5s.
+		log.Printf("stderr: %s", string(stdErr))
 	}
 
 	// We don't look for specific strings, just expect at least 1kb of output.


### PR DESCRIPTION
The storage quickstart is flaky, but there's not enough diagnostic
information to implicate why.  This PR adds the stderr output to the log
when the test errors.

Related issue:
https://github.com/GoogleCloudPlatform/golang-samples/issues/1866