### PR TITLE
chore(bigquery): further work to deflake test

### DIFF
--- a/bigquery/bigquery_storage_quickstart/main_test.go
+++ b/bigquery/bigquery_storage_quickstart/main_test.go
@@ -32,6 +32,7 @@ func TestApp(t *testing.T) {
 		t.Errorf("failed to build app")
 	}
 
+	// TODO(shollyman): reduce this timeout back to 30s once underlying issues addressed
 	stdOut, stdErr, err := m.Run(nil, 5*time.Minute, fmt.Sprintf("--project_id=%s", tc.ProjectID))
 	if err != nil {
 		t.Errorf("execution failed: %v", err)

--- a/bigquery/bigquery_storage_quickstart/main_test.go
+++ b/bigquery/bigquery_storage_quickstart/main_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 	"time"
@@ -31,12 +32,14 @@ func TestApp(t *testing.T) {
 		t.Errorf("failed to build app")
 	}
 
-	stdOut, stdErr, err := m.Run(nil, 30*time.Second, fmt.Sprintf("--project_id=%s", tc.ProjectID))
+	stdOut, stdErr, err := m.Run(nil, 5*time.Minute, fmt.Sprintf("--project_id=%s", tc.ProjectID))
 	if err != nil {
 		t.Errorf("execution failed: %v", err)
-		// TODO(shollyman): remove after https://github.com/GoogleCloudPlatform/golang-samples/issues/1866 deflaked.
-		// We're running over the 30s timeout, but unclear why; normal execution is sub-5s.
-		t.Logf("stderr: %s", string(stdErr))
+		// We expect the first line of stdout to be the session ID, which can be useful for debugging.
+		idx := bytes.Index(stdOut, []byte("\n"))
+		if idx >= 0 {
+			t.Logf("first line: %s", stdOut[:idx])
+		}
 	}
 
 	// We don't look for specific strings, just expect at least 1kb of output.


### PR DESCRIPTION
We're doing two things here: bumping the test timeout to five minutes
and altering the logging to capture the first line of stdout if
available. We expect that to contain the session ID, useful for
diagnostic purposes.

Related: https://github.com/GoogleCloudPlatform/golang-samples/issues/1866
