### PR TITLE
fix: relax https:// requirement in license check

### DIFF
--- a/license_test.go
+++ b/license_test.go
@@ -29,7 +29,7 @@ var sentinel = regexp.MustCompile(`// Copyright \d\d\d\d Google LLC
 // you may not use this file except in compliance with the License\.
 // You may obtain a copy of the License at
 //
-//     https://www\.apache\.org/licenses/LICENSE-2\.0
+//     https?://www\.apache\.org/licenses/LICENSE-2\.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
The Apache 2.0 license itself (https://www.apache.org/licenses/LICENSE-2.0)
shows http:// to apply the license.

Therefore our own tooling (https://github.com/google/addlicense) also uses
this http:// string in the boilerplate.

I'm sending a patch to relax this requirement