### PR TITLE
fix(endpoints): update gke deployment apiVersion to apps/v1

### DIFF
--- a/endpoints/getting-started-grpc/deployment.yaml
+++ b/endpoints/getting-started-grpc/deployment.yaml
@@ -26,12 +26,15 @@ spec:
     app: grpc-hello
   type: LoadBalancer
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: grpc-hello
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: grpc-hello
   template:
     metadata:
       labels:


### PR DESCRIPTION
Deprecated APIs was removed from 1.16