### PR TITLE
fix: add missing return statements

### DIFF
--- a/appengine/go11x/pubsub/authenicated_push/main.go
+++ b/appengine/go11x/pubsub/authenicated_push/main.go
@@ -109,6 +109,7 @@ func (a *app) receiveMessagesHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	if payload.Issuer != "accounts.google.com" && payload.Issuer != "https://accounts.google.com" {
 		http.Error(w, "Wrong Issuer", http.StatusBadRequest)
+		return
 	}
 
 	var pr pushRequest

--- a/appengine_flexible/pubsub/pubsub.go
+++ b/appengine_flexible/pubsub/pubsub.go
@@ -102,6 +102,7 @@ func pushHandler(w http.ResponseWriter, r *http.Request) {
 	// Verify the token.
 	if r.URL.Query().Get("token") != token {
 		http.Error(w, "Bad token", http.StatusBadRequest)
+		return
 	}
 	msg := &pushRequest{}
 	if err := json.NewDecoder(r.Body).Decode(msg); err != nil {


### PR DESCRIPTION
This adds two missing 'return' statements after calls to http.Error to avoid execution falling through into the 'success' code path.

In both cases, the calls to http.Error are reporting failed security checks, so if this example code was copied into a production system it would probably cause a security vulnerability.