### PR TITLE
fix: add NUMERIC column to sample

### DIFF
--- a/spanner/spanner_snippets/spanner/integration_test.go
+++ b/spanner/spanner_snippets/spanner/integration_test.go
@@ -321,6 +321,7 @@ func TestSample(t *testing.T) {
 	assertContains(t, out, "19 Venue 19")
 	assertContains(t, out, "42 Venue 42")
 
+	runSample(t, dropColumn, dbName, "failed to drop column")
 	runSample(t, addNumericColumn, dbName, "failed to add numeric column")
 	runSample(t, updateDataWithNumericColumn, dbName, "failed to update data with numeric")
 	out = runSample(t, queryWithNumericParameter, dbName, "failed to query with numeric parameter")

--- a/spanner/spanner_snippets/spanner/spanner_create_table_with_datatypes.go
+++ b/spanner/spanner_snippets/spanner/spanner_create_table_with_datatypes.go
@@ -47,6 +47,7 @@ func createTableWithDatatypes(w io.Writer, db string) error {
 				LastContactDate DATE,
 				OutdoorVenue BOOL,
 				PopularityScore FLOAT64,
+				Revenue NUMERIC,
 				LastUpdateTime TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true)
 			) PRIMARY KEY (VenueId)`,
 		},

--- a/spanner/spanner_snippets/spanner/spanner_drop_column.go
+++ b/spanner/spanner_snippets/spanner/spanner_drop_column.go
@@ -1,0 +1,48 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanner
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	database "cloud.google.com/go/spanner/admin/database/apiv1"
+	adminpb "google.golang.org/genproto/googleapis/spanner/admin/database/v1"
+)
+
+func dropColumn(w io.Writer, db string) error {
+	ctx := context.Background()
+	adminClient, err := database.NewDatabaseAdminClient(ctx)
+	if err != nil {
+		return err
+	}
+	defer adminClient.Close()
+
+	op, err := adminClient.UpdateDatabaseDdl(ctx, &adminpb.UpdateDatabaseDdlRequest{
+		Database: db,
+		Statements: []string{
+			"ALTER TABLE Venues DROP COLUMN Revenue",
+		},
+	})
+	if err != nil {
+		return err
+	}
+	if err := op.Wait(ctx); err != nil {
+		return err
+	}
+	fmt.Fprintf(w, "Dropped Revenue column\n")
+	return nil
+}


### PR DESCRIPTION
Adds the missing `NUMERIC` column to the sample table.

Fixes #1942 