### PR TITLE
testing(run): increase retry delay for builds to reduce flakiness

### DIFF
--- a/internal/cloudrunci/cloudrunci.go
+++ b/internal/cloudrunci/cloudrunci.go
@@ -33,6 +33,15 @@ import (
 	"time"
 )
 
+// labels are used in operation-related logs.
+const (
+	labelOperationDeploy        = "deploy service"
+	labelOperationBuild         = "build container image"
+	labelOperationDeleteService = "delete service"
+	labelOperationDeleteImage   = "delete container image"
+	labelOperationGetURL        = "get url"
+)
+
 // Service describes a Cloud Run service
 type Service struct {
 	// Name is an ID, used for logging and to generate a unique version to this run.
@@ -143,7 +152,7 @@ func (s *Service) ParsedURL() (*url.URL, error) {
 		return nil, errors.New("URL called before Deploy")
 	}
 	if s.url == nil {
-		out, err := gcloud(s.operationLabel("get url"), s.urlCmd())
+		out, err := gcloud(s.operationLabel(labelOperationGetURL), s.urlCmd())
 		if err != nil {
 			return nil, fmt.Errorf("gcloud: %s: %q", s.Name, err)
 		}
@@ -199,7 +208,7 @@ func (s *Service) Deploy() error {
 		}
 	}
 
-	if _, err := gcloud(s.operationLabel("deploy service"), s.deployCmd()); err != nil {
+	if _, err := gcloud(s.operationLabel(labelOperationDeploy), s.deployCmd()); err != nil {
 		return fmt.Errorf("gcloud: %s: %q", s.version(), err)
 	}
 
@@ -223,7 +232,7 @@ func (s *Service) Build() error {
 		s.Image = fmt.Sprintf("gcr.io/%s/%s:%s", s.ProjectID, s.Name, runID)
 	}
 
-	if out, err := gcloud(s.operationLabel("build container image"), s.buildCmd()); err != nil {
+	if out, err := gcloud(s.operationLabel(labelOperationBuild), s.buildCmd()); err != nil {
 		fmt.Printf(string(out))
 		return fmt.Errorf("gcloud: %s: %q", s.Image, err)
 	}
@@ -241,7 +250,7 @@ func (s *Service) Clean() error {
 		return err
 	}
 
-	if _, err := gcloud(s.operationLabel("delete service"), s.deleteServiceCmd()); err != nil {
+	if _, err := gcloud(s.operationLabel(labelOperationDeleteService), s.deleteServiceCmd()); err != nil {
 		return fmt.Errorf("gcloud: %v: %q", s.version(), err)
 	}
 	s.deployed = false

--- a/internal/cloudrunci/gcloud.go
+++ b/internal/cloudrunci/gcloud.go
@@ -43,7 +43,7 @@ func gcloud(label string, cmd *exec.Cmd) ([]byte, error) {
 	var err error
 
 	delaySeconds := 2 * time.Second
-	if strings.Contains("build container image", label) {
+	if strings.Contains(label, "build container image") {
 		delaySeconds = 60 * time.Second
 	}
 

--- a/internal/cloudrunci/gcloud.go
+++ b/internal/cloudrunci/gcloud.go
@@ -42,8 +42,13 @@ func gcloud(label string, cmd *exec.Cmd) ([]byte, error) {
 	var out []byte
 	var err error
 
+	delaySeconds := 2 * time.Second
+	if strings.Contains("build container image", label) {
+		delaySeconds = 60 * time.Second
+	}
+
 	maxAttempts := 5
-	success := testutil.RetryWithoutTest(maxAttempts, 2*time.Second, func(r *testutil.R) {
+	success := testutil.RetryWithoutTest(maxAttempts, delaySeconds, func(r *testutil.R) {
 		out, err = gcloudExec(fmt.Sprintf("Attempt #%d: ", r.Attempt), label, cmd)
 		if err != nil {
 			log.Printf("gcloudExec: %v", err)

--- a/internal/cloudrunci/gcloud.go
+++ b/internal/cloudrunci/gcloud.go
@@ -43,7 +43,7 @@ func gcloud(label string, cmd *exec.Cmd) ([]byte, error) {
 	var err error
 
 	delaySeconds := 2 * time.Second
-	if strings.Contains(label, "build container image") {
+	if strings.Contains(label, labelOperationBuild) {
 		delaySeconds = 60 * time.Second
 	}
 


### PR DESCRIPTION
Fixes #1934 
Fixes #1925
Fixes #1944

This iteration of improvement was discussed in #1934.
https://github.com/GoogleCloudPlatform/golang-samples/issues/1934#issuecomment-776279586 had my thoughts on a more complicated solution that would allow shorter retry delays.