### PR TITLE
fix(spanner): use earliest version time for backups

### DIFF
--- a/spanner/spanner_snippets/spanner/spanner_create_backup.go
+++ b/spanner/spanner_snippets/spanner/spanner_create_backup.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	t "log"
 	"regexp"
 	"time"
 
@@ -43,7 +42,7 @@ func createBackup(w io.Writer, db, backupID string) error {
 	defer adminClient.Close()
 	dbMetadata, err := adminClient.GetDatabase(ctx, &adminpb.GetDatabaseRequest{Name: db})
 	if err != nil {
-		t.Fatalf("createBackup.GetDatabase: %v", err)
+		return fmt.Errorf("createBackup.GetDatabase: %v", err)
 	}
 
 	expireTime := time.Now().AddDate(0, 0, 14)


### PR DESCRIPTION
Using the local date/time as the version time of a backup can cause issues if there's a difference between the local time and the backend time. The backend will not accept any version time that is in the future, or that is before the earliest version time of a database. Using the earliest version time is therefore the safest option.

Fixes #1900