### PR TITLE
refactor: use testutil.SystemTest for getting project ids

### DIFF
--- a/functions/imagemagick/imagemagick_test.go
+++ b/functions/imagemagick/imagemagick_test.go
@@ -20,10 +20,13 @@ import (
 	"log"
 	"os"
 	"testing"
+
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 )
 
 func TestBlurOffensiveImages(t *testing.T) {
-	projectID := os.Getenv("GOLANG_SAMPLES_PROJECT_ID")
+	tc := testutil.SystemTest(t)
+	projectID := tc.ProjectID
 	if projectID == "" {
 		t.Skip("GOLANG_SAMPLES_PROJECT_ID not set")
 	}

--- a/functions/ocr/app/ocr_test.go
+++ b/functions/ocr/app/ocr_test.go
@@ -29,6 +29,7 @@ import (
 	"cloud.google.com/go/storage"
 	"cloud.google.com/go/translate"
 	vision "cloud.google.com/go/vision/apiv1"
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 	"golang.org/x/text/language"
 )
 
@@ -43,7 +44,8 @@ var (
 
 func setupTests(t *testing.T) {
 	ctx := context.Background()
-	projectID = os.Getenv("GOLANG_SAMPLES_PROJECT_ID")
+	tc := testutil.SystemTest(t)
+	projectID := tc.ProjectID
 	if projectID == "" {
 		t.Skip("GOLANG_SAMPLES_PROJECT_ID is unset")
 	}

--- a/functions/tips/contexttip/context_tip_test.go
+++ b/functions/tips/contexttip/context_tip_test.go
@@ -24,10 +24,13 @@ import (
 	"testing"
 
 	"cloud.google.com/go/pubsub"
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 )
 
 func TestPublishMessage(t *testing.T) {
 	// TODO: Use testutil to get the project.
+	tc := testutil.SystemTest(t)
+	projectID := tc.ProjectID
 	projectID = os.Getenv("GOLANG_SAMPLES_PROJECT_ID")
 	if projectID == "" {
 		t.Skip("Missing GOLANG_SAMPLES_PROJECT_ID.")

--- a/getting-started/bookshelf/db_test.go
+++ b/getting-started/bookshelf/db_test.go
@@ -71,6 +71,9 @@ func TestMemoryDB(t *testing.T) {
 func TestFirestoreDB(t *testing.T) {
 	tc := testutil.SystemTest(t)
 	generalProjectID := tc.ProjectID
+	if generalProjectID == "" {
+		t.Skip("GOLANG_SAMPLES_PROJECT_ID not set")
+	}
 	projectID := os.Getenv("GOLANG_SAMPLES_FIRESTORE_PROJECT")
 	if projectID == "" {
 		t.Skip("GOLANG_SAMPLES_FIRESTORE_PROJECT not set")

--- a/getting-started/bookshelf/db_test.go
+++ b/getting-started/bookshelf/db_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/firestore"
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 )
 
 func testDB(t *testing.T, db BookDatabase) {
@@ -68,10 +69,8 @@ func TestMemoryDB(t *testing.T) {
 }
 
 func TestFirestoreDB(t *testing.T) {
-	generalProjectID := os.Getenv("GOLANG_SAMPLES_PROJECT_ID")
-	if generalProjectID == "" {
-		t.Skip("GOLANG_SAMPLES_PROJECT_ID not set")
-	}
+	tc := testutil.SystemTest(t)
+	generalProjectID := tc.ProjectID
 	projectID := os.Getenv("GOLANG_SAMPLES_FIRESTORE_PROJECT")
 	if projectID == "" {
 		t.Skip("GOLANG_SAMPLES_FIRESTORE_PROJECT not set")

--- a/run/image-processing/imagemagick/imagemagick_test.go
+++ b/run/image-processing/imagemagick/imagemagick_test.go
@@ -20,10 +20,13 @@ import (
 	"log"
 	"os"
 	"testing"
+
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 )
 
 func TestBlurOffensiveImages(t *testing.T) {
-	projectID := os.Getenv("GOLANG_SAMPLES_PROJECT_ID")
+	tc := testutil.SystemTest(t)
+	projectID := tc.ProjectID
 	if projectID == "" {
 		t.Skip("GOLANG_SAMPLES_PROJECT_ID not set")
 	}


### PR DESCRIPTION
There were some lingering references of getting the test project via `os.Getenv`. This switches the remaining non-main tests to use `testutil.SystemTest(t).ProjectID` instead.