### PR TITLE
chore: update dockerfile regions

### DIFF
--- a/eventarc/audit_storage/Dockerfile
+++ b/eventarc/audit_storage/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START eventarc_gcs_dockerfile]
+# [START eventarc_audit_storage_dockerfile]
 
 # Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
@@ -48,4 +48,4 @@ COPY --from=builder /app/server /server
 # Run the web service on container startup.
 CMD ["/server"]
 
-# [END eventarc_gcs_dockerfile]
+# [END eventarc_audit_storage_dockerfile]

--- a/eventarc/audit_storage/main.go
+++ b/eventarc/audit_storage/main.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START eventarc_gcs_handler]
+// [START eventarc_audit_storage_handler]
 
 // Sample audit_storage is a Cloud Run service which handles Cloud Audit Log events with Cloud Storage data.
 package main
@@ -31,8 +31,8 @@ func HelloEventsStorage(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintln(w, s)
 }
 
-// [END eventarc_gcs_handler]
-// [START eventarc_gcs_server]
+// [END eventarc_audit_storage_handler]
+// [START eventarc_audit_storage_server]
 
 func main() {
 	http.HandleFunc("/", HelloEventsStorage)
@@ -48,4 +48,4 @@ func main() {
 	}
 }
 
-// [END eventarc_gcs_server]
+// [END eventarc_audit_storage_server]


### PR DESCRIPTION
Updates region tags to use `audit_storage`, not `gcs`.

These aren't in the docs, please merge this when approved.