### PR TITLE
feat: use default -mod=readonly from Go 1.16

### DIFF
--- a/cloudsql/mysql/database-sql/Dockerfile
+++ b/cloudsql/mysql/database-sql/Dockerfile
@@ -30,7 +30,7 @@ RUN go mod download
 COPY . ./
 
 # Build the binary.
-RUN go build -mod=readonly -v -o server
+RUN go build -v -o server
 
 # Use the official Debian slim image for a lean production container.
 # https://hub.docker.com/_/debian

--- a/cloudsql/postgres/database-sql/Dockerfile
+++ b/cloudsql/postgres/database-sql/Dockerfile
@@ -30,7 +30,7 @@ RUN go mod download
 COPY . ./
 
 # Build the binary.
-RUN go build -mod=readonly -v -o server
+RUN go build -v -o server
 
 # Use the official Debian slim image for a lean production container.
 # https://hub.docker.com/_/debian

--- a/cloudsql/sqlserver/database-sql/Dockerfile
+++ b/cloudsql/sqlserver/database-sql/Dockerfile
@@ -30,7 +30,7 @@ RUN go mod download
 COPY . ./
 
 # Build the binary.
-RUN go build -mod=readonly -v -o server
+RUN go build -v -o server
 
 # Use the official Debian slim image for a lean production container.
 # https://hub.docker.com/_/debian

--- a/eventarc/audit_storage/Dockerfile
+++ b/eventarc/audit_storage/Dockerfile
@@ -32,7 +32,7 @@ RUN go mod download
 COPY . ./
 
 # Build the binary.
-RUN go build -mod=readonly -v -o server
+RUN go build -v -o server
 
 # Use the official Debian slim image for a lean production container.
 # https://hub.docker.com/_/debian

--- a/eventarc/generic/Dockerfile
+++ b/eventarc/generic/Dockerfile
@@ -32,7 +32,7 @@ RUN go mod download
 COPY . ./
 
 # Build the binary.
-RUN go build -mod=readonly -v -o server
+RUN go build -v -o server
 
 # Use the official Debian slim image for a lean production container.
 # https://hub.docker.com/_/debian

--- a/eventarc/pubsub/Dockerfile
+++ b/eventarc/pubsub/Dockerfile
@@ -32,7 +32,7 @@ RUN go mod download
 COPY . ./
 
 # Build the binary.
-RUN go build -mod=readonly -v -o server
+RUN go build -v -o server
 
 # Use the official Debian slim image for a lean production container.
 # https://hub.docker.com/_/debian

--- a/memorystore/redis/cloud_run_deployment/Dockerfile
+++ b/memorystore/redis/cloud_run_deployment/Dockerfile
@@ -32,7 +32,7 @@ RUN go mod download
 COPY . ./
 
 # Build the binary.
-RUN go build -mod=readonly -v -o server
+RUN go build -v -o server
 
 # Use the official Debian slim image for a lean production container.
 # https://hub.docker.com/_/debian

--- a/run/grpc-ping/Dockerfile
+++ b/run/grpc-ping/Dockerfile
@@ -33,7 +33,7 @@ RUN go mod download
 COPY . ./
 
 # Build the binary.
-RUN go build -mod=readonly -v -o server
+RUN go build -v -o server
 
 # Use the official Debian slim image for a lean production container.
 # https://hub.docker.com/_/debian

--- a/run/hello-broken/Dockerfile
+++ b/run/hello-broken/Dockerfile
@@ -33,7 +33,7 @@ RUN go mod download
 COPY . ./
 
 # Build the binary.
-RUN go build -mod=readonly -v -o server
+RUN go build -v -o server
 
 # Use the official Debian slim image for a lean production container.
 # https://hub.docker.com/_/debian

--- a/run/helloworld/Dockerfile
+++ b/run/helloworld/Dockerfile
@@ -33,7 +33,7 @@ RUN go mod download
 COPY . ./
 
 # Build the binary.
-RUN go build -mod=readonly -v -o server
+RUN go build -v -o server
 
 # Use the official Debian slim image for a lean production container.
 # https://hub.docker.com/_/debian

--- a/run/image-processing/Dockerfile
+++ b/run/image-processing/Dockerfile
@@ -30,7 +30,7 @@ RUN go mod download
 COPY . ./
 
 # Build the binary.
-RUN CGO_ENABLED=0 go build -mod=readonly -v -o server
+RUN CGO_ENABLED=0 go build -v -o server
 
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds

--- a/run/logging-manual/Dockerfile
+++ b/run/logging-manual/Dockerfile
@@ -30,7 +30,7 @@ RUN go mod download
 COPY . ./
 
 # Build the binary.
-RUN go build -mod=readonly -v -o server
+RUN go build -v -o server
 
 # Use the official Debian slim image for a lean production container.
 # https://hub.docker.com/_/debian

--- a/run/markdown-preview/editor/Dockerfile
+++ b/run/markdown-preview/editor/Dockerfile
@@ -30,7 +30,7 @@ RUN go mod download
 COPY . ./
 
 # Build the binary.
-RUN go build -mod=readonly -v -o server
+RUN go build -v -o server
 
 # Use the official Debian slim image for a lean production container.
 # https://hub.docker.com/_/debian

--- a/run/markdown-preview/renderer/Dockerfile
+++ b/run/markdown-preview/renderer/Dockerfile
@@ -30,7 +30,7 @@ RUN go mod download
 COPY . ./
 
 # Build the binary.
-RUN go build -mod=readonly -v -o server
+RUN go build -v -o server
 
 # Use the official Debian slim image for a lean production container.
 # https://hub.docker.com/_/debian

--- a/run/pubsub/Dockerfile
+++ b/run/pubsub/Dockerfile
@@ -33,7 +33,7 @@ RUN go mod download
 COPY . ./
 
 # Build the binary.
-RUN go build -mod=readonly -v -o server
+RUN go build -v -o server
 
 # Use the official Debian slim image for a lean production container.
 # https://hub.docker.com/_/debian

--- a/run/sigterm-handler/Dockerfile
+++ b/run/sigterm-handler/Dockerfile
@@ -30,7 +30,7 @@ RUN go mod download
 COPY . ./
 
 # Build the binary.
-RUN go build -mod=readonly -v -o server
+RUN go build -v -o server
 
 # Use the official Debian slim image for a lean production container.
 # https://hub.docker.com/_/debian

--- a/run/system_package/Dockerfile
+++ b/run/system_package/Dockerfile
@@ -29,7 +29,7 @@ RUN go mod download
 COPY . ./
 
 # Build the binary.
-RUN go build -mod=readonly -v -o server
+RUN go build -v -o server
 # Use a Docker multi-stage build to create a lean production image.
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 # https://hub.docker.com/_/ubuntu


### PR DESCRIPTION
Uses default `-mod=readonly` behavior of Go 1.16.
Internal b/181980790