### PR TITLE
test(run): don't skip gRPC server streaming tests

### DIFF
--- a/run/testing/grpc_server_streaming.e2e_test.go
+++ b/run/testing/grpc_server_streaming.e2e_test.go
@@ -34,7 +34,6 @@ import (
 // TestGRPCServerStreamingService is an end-to-end test that confirms the image builds, deploys and runs on
 // Cloud Run and can stream messages from server.
 func TestGRPCServerStreamingService(t *testing.T) {
-	t.Skip("Feature not yet available (https://github.com/GoogleCloudPlatform/golang-samples/issues/1628)")
 	tc := testutil.EndToEndTest(t)
 
 	service := cloudrunci.NewService("grpc-server-streaming", tc.ProjectID)

--- a/run/testing/h2c.e2e_test.go
+++ b/run/testing/h2c.e2e_test.go
@@ -25,7 +25,7 @@ import (
 	"golang.org/x/net/http2"
 )
 
-// TestGRPCServerStreamingService is an end-to-end test that confirms the image builds, deploys and runs on
+// TestHTTP2Server is an end-to-end test that confirms the image builds, deploys and runs on
 // Cloud Run and can stream messages from server.
 func TestHTTP2Server(t *testing.T) {
 	tc := testutil.EndToEndTest(t)


### PR DESCRIPTION
Fixes #1628