### PR TITLE
feat(eventarc): use eventarc library for pubsub sample

### DIFF
--- a/eventarc/pubsub/go.mod
+++ b/eventarc/pubsub/go.mod
@@ -1,5 +1,0 @@
-module github.com/GoogleCloudPlatform/golang-samples/eventarc/pubsub
-
-go 1.13
-
-require github.com/googleapis/google-cloudevents-go v0.0.0-20210412200750-de059319bac5

--- a/eventarc/pubsub/go.mod
+++ b/eventarc/pubsub/go.mod
@@ -1,3 +1,5 @@
 module github.com/GoogleCloudPlatform/golang-samples/eventarc/pubsub
 
 go 1.13
+
+require github.com/googleapis/google-cloudevents-go v0.0.0-20210412200750-de059319bac5 // indirect

--- a/eventarc/pubsub/go.mod
+++ b/eventarc/pubsub/go.mod
@@ -2,4 +2,4 @@ module github.com/GoogleCloudPlatform/golang-samples/eventarc/pubsub
 
 go 1.13
 
-require github.com/googleapis/google-cloudevents-go v0.0.0-20210412200750-de059319bac5 // indirect
+require github.com/googleapis/google-cloudevents-go v0.0.0-20210412200750-de059319bac5

--- a/eventarc/pubsub/go.sum
+++ b/eventarc/pubsub/go.sum
@@ -1,0 +1,2 @@
+github.com/googleapis/google-cloudevents-go v0.0.0-20210412200750-de059319bac5 h1:mBzeuJCPfVtTvv9Ui304rrEhPb35V0soO+jHpkc2+K8=
+github.com/googleapis/google-cloudevents-go v0.0.0-20210412200750-de059319bac5/go.mod h1:JVgKDEolKoN/zaDyI8JpHlN1Ja7m033o2ikYjBljBss=

--- a/eventarc/pubsub/go.sum
+++ b/eventarc/pubsub/go.sum
@@ -1,2 +1,4 @@
 github.com/googleapis/google-cloudevents-go v0.0.0-20210412200750-de059319bac5 h1:mBzeuJCPfVtTvv9Ui304rrEhPb35V0soO+jHpkc2+K8=
 github.com/googleapis/google-cloudevents-go v0.0.0-20210412200750-de059319bac5/go.mod h1:JVgKDEolKoN/zaDyI8JpHlN1Ja7m033o2ikYjBljBss=
+github.com/googleapis/google-cloudevents-go v0.1.0 h1:uSS0DtVH+vXMHg6kErjUPXuxxjZeoni4v7C2ip/Mg4o=
+github.com/googleapis/google-cloudevents-go v0.1.0/go.mod h1:JVgKDEolKoN/zaDyI8JpHlN1Ja7m033o2ikYjBljBss=

--- a/eventarc/pubsub/main.go
+++ b/eventarc/pubsub/main.go
@@ -18,7 +18,6 @@
 package main
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -36,11 +35,7 @@ func HelloEventsPubSub(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Bad HTTP Request: %v", http.StatusBadRequest)
 		return
 	}
-	b, err := base64.URLEncoding.DecodeString(*e.Message.Data)
-	name := string(b)
-	if err != nil {
-		panic(err)
-	}
+	name := string(e.Message.Data)
 
 	if name == "" {
 		name = "World"

--- a/eventarc/pubsub/main.go
+++ b/eventarc/pubsub/main.go
@@ -18,33 +18,30 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
-)
 
-// PubSubMessage is the payload of a Pub/Sub event.
-// See the documentation for more details:
-// https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage
-type PubSubMessage struct {
-	Message struct {
-		Data []byte `json:"data,omitempty"`
-		ID   string `json:"id"`
-	} `json:"message"`
-	Subscription string `json:"subscription"`
-}
+	pubsub "github.com/googleapis/google-cloudevents-go/cloud/pubsub/v1"
+)
 
 // HelloEventsPubSub receives and processes a Pub/Sub push message.
 func HelloEventsPubSub(w http.ResponseWriter, r *http.Request) {
-	var e PubSubMessage
+	var e pubsub.MessagePublishedData
 	if err := json.NewDecoder(r.Body).Decode(&e); err != nil {
 		http.Error(w, "Bad HTTP Request", http.StatusBadRequest)
 		log.Printf("Bad HTTP Request: %v", http.StatusBadRequest)
 		return
 	}
-	name := string(e.Message.Data)
+	b, err := base64.URLEncoding.DecodeString(*e.Message.Data)
+	name := string(b)
+	if err != nil {
+		panic(err)
+	}
+
 	if name == "" {
 		name = "World"
 	}

--- a/eventarc/pubsub/main_test.go
+++ b/eventarc/pubsub/main_test.go
@@ -43,12 +43,9 @@ func TestHelloPubSubCloudEvent(t *testing.T) {
 		log.SetOutput(w)
 		defer log.SetOutput(os.Stderr)
 
-		payload := strings.NewReader("{}")
-		if test.data != "" {
-			encoded := base64.StdEncoding.EncodeToString([]byte(test.data))
-			jsonStr := fmt.Sprintf(`{"message":{"data":"%s","id":"%s"}}`, encoded, test.id)
-			payload = strings.NewReader(jsonStr)
-		}
+		encoded := base64.StdEncoding.EncodeToString([]byte(test.data))
+		jsonStr := fmt.Sprintf(`{"message":{"data":"%s","id":"%s"}}`, encoded, test.id)
+		payload := strings.NewReader(jsonStr)
 
 		req := httptest.NewRequest("POST", "/", payload)
 		req.Header.Set("Ce-Id", test.id)

--- a/eventarc/testing/go.sum
+++ b/eventarc/testing/go.sum
@@ -159,6 +159,7 @@ github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/googleapis/google-cloudevents-go v0.1.0/go.mod h1:JVgKDEolKoN/zaDyI8JpHlN1Ja7m033o2ikYjBljBss=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/h2non/filetype v1.1.1/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/google/go-cmp v0.5.5
 	github.com/google/uuid v1.2.0
 	github.com/googleapis/gax-go/v2 v2.0.5
+	github.com/googleapis/google-cloudevents-go v0.1.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2
 	github.com/h2non/filetype v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -187,6 +187,8 @@ github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/googleapis/google-cloudevents-go v0.1.0 h1:uSS0DtVH+vXMHg6kErjUPXuxxjZeoni4v7C2ip/Mg4o=
+github.com/googleapis/google-cloudevents-go v0.1.0/go.mod h1:JVgKDEolKoN/zaDyI8JpHlN1Ja7m033o2ikYjBljBss=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=

--- a/run/testing/go.sum
+++ b/run/testing/go.sum
@@ -162,6 +162,7 @@ github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/googleapis/google-cloudevents-go v0.1.0/go.mod h1:JVgKDEolKoN/zaDyI8JpHlN1Ja7m033o2ikYjBljBss=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/h2non/filetype v1.1.1/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=


### PR DESCRIPTION
Uses the eventarc Golang library for our Eventarc Pub/Sub type.

Automatic base64 decoding for the pub/sub data is a FR, not included here.

fixes https://github.com/GoogleCloudPlatform/golang-samples/issues/1645