### PR TITLE
testing: check mod version when no Go files in root

### DIFF
--- a/testing/kokoro/system_tests.sh
+++ b/testing/kokoro/system_tests.sh
@@ -203,7 +203,7 @@ goVersionShouldSkip() {
     return 1
   fi
 
-  go list -f "{{context.ReleaseTags}}" | grep -q -v "go$modVersion\b"
+  go list -f "{{context.ReleaseTags}}" ./... | grep -q -v "go$modVersion\b"
 }
 
 if [[ $RUN_ALL_TESTS = "1" ]]; then


### PR DESCRIPTION
If there are no `.go` files in the module root, `goVersionShouldSkip` fails.
Similarly, if it's a brand new module, the module can't be found and
`goVersionShouldSkip` wouldn't check the current directory.

These are both fixed by doing `go list [...] ./...` to list the current
directory.

Note that `grep` exits 0 if there is any match. So, `grep -v go$modVersion`
exits 0 if there is at least one line that does not contain the module
version. In other words, if the list of Go versions supported by the
current version of the `go` command does not contain `go$modVersion`,
skip testing this module.

For example:

    $ go1.11.13 list -f "{{context.ReleaseTags}}" ./...
    [go1.1 go1.2 go1.3 go1.4 go1.5 go1.6 go1.7 go1.8 go1.9 go1.10 go1.11]

That line does not include go1.12 (or 13, 14, ...), so `grep` exits 0, and
testing is skipped.

This will unblock #2046. cc @yuriatgoogle.