### PR TITLE
test(asset): increase BQ retries

### DIFF
--- a/asset/quickstart/analyze-iam-policy-longrunning-bigquery/main_test.go
+++ b/asset/quickstart/analyze-iam-policy-longrunning-bigquery/main_test.go
@@ -49,18 +49,21 @@ func TestMain(t *testing.T) {
 	tablePrefix := "client_library_table"
 	createDataset(ctx, t, client, datasetID)
 
-	stdOut, stdErr, err := m.Run(env, 2*time.Minute, fmt.Sprintf("--scope=%s", scope), fmt.Sprintf("--fullResourceName=%s", fullResourceName), fmt.Sprintf("--dataset=%s", dataset), fmt.Sprintf("--tablePrefix=%s", tablePrefix))
+	testutil.Retry(t, 5, 10*time.Second, func(r *testutil.R) {
+		stdOut, stdErr, err := m.Run(env, 2*time.Minute, fmt.Sprintf("--scope=%s", scope), fmt.Sprintf("--fullResourceName=%s", fullResourceName), fmt.Sprintf("--dataset=%s", dataset), fmt.Sprintf("--tablePrefix=%s", tablePrefix))
 
-	if err != nil {
-		t.Errorf("execution failed: %v", err)
-	}
-	if len(stdErr) > 0 {
-		t.Errorf("did not expect stderr output, got %d bytes: %s", len(stdErr), string(stdErr))
-	}
-	got := string(stdOut)
-	if !strings.Contains(got, dataset) {
-		t.Errorf("stdout returned %s, wanted to contain %s", got, dataset)
-	}
+		if err != nil {
+			r.Errorf("execution failed: %v", err)
+			return
+		}
+		if len(stdErr) > 0 {
+			r.Errorf("did not expect stderr output, got %d bytes: %s", len(stdErr), string(stdErr))
+		}
+		got := string(stdOut)
+		if !strings.Contains(got, dataset) {
+			r.Errorf("stdout returned %s, wanted to contain %s", got, dataset)
+		}
+	})
 }
 
 func createDataset(ctx context.Context, t *testing.T, client *bigquery.Client, datasetID string) {
@@ -86,15 +89,12 @@ func createDataset(ctx context.Context, t *testing.T, client *bigquery.Client, d
 
 	time.Sleep(10 * time.Second) // Extra time to let the delete settle.
 
-	meta := &bigquery.DatasetMetadata{
-		Location: "US", // See https://cloud.google.com/bigquery/docs/locations
-	}
-	if err := client.Dataset(datasetID).Create(ctx, meta); err != nil {
-		if err, ok := err.(*googleapi.Error); ok {
-			if err.Code == 409 { // Already exists. Not sure why.
-				return
-			}
+	testutil.Retry(t, 10, 10*time.Second, func(r *testutil.R) {
+		meta := &bigquery.DatasetMetadata{
+			Location: "US", // See https://cloud.google.com/bigquery/docs/locations.
 		}
-		t.Fatalf("Dataset.Create(%q): %v", datasetID, err)
-	}
+		if err := client.Dataset(datasetID).Create(ctx, meta); err != nil {
+			r.Errorf("Dataset.Create(%q): %v", datasetID, err)
+		}
+	})
 }


### PR DESCRIPTION
This passed `go test -v -count 10`.

Fixes #2025.