### PR TITLE
fix(memorystore): update main.go since redis.NewPool is deprecated

### DIFF
--- a/memorystore/redis/main.go
+++ b/memorystore/redis/main.go
@@ -48,7 +48,7 @@ func main() {
 	const maxConnections = 10
 	redisPool = &redis.Pool{
 		MaxIdle: maxConnections,
-		Dial: func () (redis.Conn, error) { return redis.Dial("tcp", redisAddr) },
+		Dial:    func() (redis.Conn, error) { return redis.Dial("tcp", redisAddr) },
 	}
 
 	http.HandleFunc("/", incrementHandler)

--- a/memorystore/redis/main.go
+++ b/memorystore/redis/main.go
@@ -46,9 +46,10 @@ func main() {
 	redisAddr := fmt.Sprintf("%s:%s", redisHost, redisPort)
 
 	const maxConnections = 10
-	redisPool = redis.NewPool(func() (redis.Conn, error) {
-		return redis.Dial("tcp", redisAddr)
-	}, maxConnections)
+	redisPool = &redis.Pool{
+		MaxIdle: maxConnections,
+		Dial: func () (redis.Conn, error) { return redis.Dial("tcp", redisAddr) },
+	}
 
 	http.HandleFunc("/", incrementHandler)
 


### PR DESCRIPTION
From the Redis docs: "Deprecated: Initialize the Pool directly as shown in the example." So I updated the file to use `redis.Pool` as shown in the example.