### PR TITLE
doc(bigquery): remove spurious comment

### DIFF
--- a/bigquery/snippets/table/bigquery_list_tables.go
+++ b/bigquery/snippets/table/bigquery_list_tables.go
@@ -28,7 +28,6 @@ import (
 func listTables(w io.Writer, projectID, datasetID string) error {
 	// projectID := "my-project-id"
 	// datasetID := "mydataset"
-	// tableID := "mytable"
 	ctx := context.Background()
 	client, err := bigquery.NewClient(ctx, projectID)
 	if err != nil {


### PR DESCRIPTION
Artifact of copy and pasting.  The tableID comment isn't needed for
table listing.