### PR TITLE
test(storage): fix HMAC key creation

### DIFF
--- a/storage/service_account/hmac/hmac_test.go
+++ b/storage/service_account/hmac/hmac_test.go
@@ -16,6 +16,7 @@ package hmac
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -122,7 +123,7 @@ func TestGetKey(t *testing.T) {
 	key, err := createTestKey(tc.ProjectID, t)
 	defer deleteTestKey(key)
 	if err != nil {
-		t.Errorf("Error in key creation: %s", err)
+		t.Fatalf("Error in key creation: %s", err)
 	}
 
 	testutil.Retry(t, 10, 10*time.Second, func(r *testutil.R) {
@@ -177,7 +178,8 @@ func createTestKey(projectID string, t *testing.T) (*storage.HMACKey, error) {
 		// Nil key check should not happen but is added to handle flaky
 		// "nil pointer dereference" error.
 		if key == nil {
-			r.Errorf("Returned nil key.")
+			r.Errorf("CreateHMACKey returned nil key.")
+			err = errors.New("CreateHMACKey returned nil key")
 			return
 		}
 	})


### PR DESCRIPTION
This test failed again with a nil pointer dereference. I believe
it's because test execution was not pausing after key creation
failed. This forces a fatal error at that point.

Fixes #2037