### PR TITLE
chore: bump grpc message send limit to 128MB in sample

### DIFF
--- a/bigquery/bigquery_storage_quickstart/main.go
+++ b/bigquery/bigquery_storage_quickstart/main.go
@@ -42,10 +42,10 @@ import (
 )
 
 // rpcOpts is used to configure the underlying gRPC client to accept large
-// messages.  The BigQuery Storage API may send message blocks up to 10MB
+// messages.  The BigQuery Storage API may send message blocks up to 128MB
 // in size.
 var rpcOpts = gax.WithGRPCOptions(
-	grpc.MaxCallRecvMsgSize(1024 * 1024 * 11),
+	grpc.MaxCallRecvMsgSize(1024 * 1024 * 129),
 )
 
 // Command-line flags.


### PR DESCRIPTION

grpc-go sets 4MB as the default client receive size, so we still can't just remove this option entirely in the face of large row response messages.