### PR TITLE
chore: disable Renovate for pubsublite

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,7 +19,10 @@
       "enabled": false
     },
     {
-      "packageNames": ["golang.org/x/tools"],
+      "packageNames": [
+        "golang.org/x/tools",
+        "cloud.google.com/go/pubsublite"
+      ],
       "enabled": false
     }
   ],


### PR DESCRIPTION
Renovate consistently picks the wrong version. See https://github.com/renovatebot/renovate/issues/4589.