### PR TITLE
refactor(pubsub): make test resources unique and improve cleanup

### DIFF
--- a/pubsub/topics/publish_scale.go
+++ b/pubsub/topics/publish_scale.go
@@ -49,12 +49,14 @@ func publishThatScales(w io.Writer, projectID, topicID string, n int) error {
 			defer wg.Done()
 			// The Get method blocks until a server-generated ID or
 			// an error is returned for the published message.
-			_, err := res.Get(ctx)
+			id, err := res.Get(ctx)
 			if err != nil {
 				// Error handling code can be added here.
+				fmt.Fprintf(w, "Failed to publish: %v", err)
 				atomic.AddUint64(&totalErrors, 1)
 				return
 			}
+			fmt.Fprintf(w, "Published message %d; msg ID: %v\n", i, id)
 		}(i, result)
 	}
 

--- a/pubsub/topics/publish_scale.go
+++ b/pubsub/topics/publish_scale.go
@@ -49,14 +49,12 @@ func publishThatScales(w io.Writer, projectID, topicID string, n int) error {
 			defer wg.Done()
 			// The Get method blocks until a server-generated ID or
 			// an error is returned for the published message.
-			id, err := res.Get(ctx)
+			_, err := res.Get(ctx)
 			if err != nil {
 				// Error handling code can be added here.
-				fmt.Fprintf(w, "Failed to publish: %v", err)
 				atomic.AddUint64(&totalErrors, 1)
 				return
 			}
-			fmt.Fprintf(w, "Published message %d; msg ID: %v\n", i, id)
 		}(i, result)
 	}
 

--- a/pubsub/topics/topics_test.go
+++ b/pubsub/topics/topics_test.go
@@ -132,8 +132,10 @@ func TestList(t *testing.T) {
 func TestPublish(t *testing.T) {
 	// Nothing much to do here, unless we are consuming.
 	// TODO(jbd): Merge topics and subscriptions programs maybe?
+	ctx := context.Background()
 	tc := testutil.SystemTest(t)
-	setup(t)
+	client := setup(t)
+	client.CreateTopic(ctx, topicID)
 	buf := new(bytes.Buffer)
 	if err := publish(buf, tc.ProjectID, topicID, "hello world"); err != nil {
 		t.Errorf("failed to publish message: %v", err)

--- a/pubsub/topics/topics_test.go
+++ b/pubsub/topics/topics_test.go
@@ -33,7 +33,7 @@ import (
 	"google.golang.org/api/iterator"
 )
 
-var topicResource string
+var topicID string
 
 const (
 	topicPrefix = "topic"
@@ -55,7 +55,7 @@ func setup(t *testing.T) *pubsub.Client {
 	}
 
 	once.Do(func() {
-		topicResource = fmt.Sprintf("%s-%d", topicPrefix, time.Now().UnixNano())
+		topicID = fmt.Sprintf("%s-%d", topicPrefix, time.Now().UnixNano())
 
 		// Cleanup resources from previous tests.
 		it := client.Topics(ctx)
@@ -94,15 +94,15 @@ func TestCreate(t *testing.T) {
 	client := setup(t)
 	tc := testutil.SystemTest(t)
 	buf := new(bytes.Buffer)
-	if err := create(buf, tc.ProjectID, topicResource); err != nil {
+	if err := create(buf, tc.ProjectID, topicID); err != nil {
 		t.Fatalf("failed to create a topic: %v", err)
 	}
-	ok, err := client.Topic(topicResource).Exists(context.Background())
+	ok, err := client.Topic(topicID).Exists(context.Background())
 	if err != nil {
 		t.Fatalf("failed to check if topic exists: %v", err)
 	}
 	if !ok {
-		t.Fatalf("got none; want topic = %q", topicResource)
+		t.Fatalf("got none; want topic = %q", topicID)
 	}
 }
 
@@ -116,7 +116,7 @@ func TestList(t *testing.T) {
 		}
 
 		for _, t := range topics {
-			if t.ID() == topicResource {
+			if t.ID() == topicID {
 				return // PASS
 			}
 		}
@@ -125,7 +125,7 @@ func TestList(t *testing.T) {
 		for i, t := range topics {
 			topicIDs[i] = t.ID()
 		}
-		r.Errorf("got %+v; want a list with topic = %q", topicIDs, topicResource)
+		r.Errorf("got %+v; want a list with topic = %q", topicIDs, topicID)
 	})
 }
 
@@ -135,7 +135,7 @@ func TestPublish(t *testing.T) {
 	tc := testutil.SystemTest(t)
 	setup(t)
 	buf := new(bytes.Buffer)
-	if err := publish(buf, tc.ProjectID, topicResource, "hello world"); err != nil {
+	if err := publish(buf, tc.ProjectID, topicID, "hello world"); err != nil {
 		t.Errorf("failed to publish message: %v", err)
 	}
 }
@@ -144,7 +144,7 @@ func TestPublishThatScales(t *testing.T) {
 	tc := testutil.SystemTest(t)
 	setup(t)
 	buf := new(bytes.Buffer)
-	if err := publishThatScales(buf, tc.ProjectID, topicResource, 10); err != nil {
+	if err := publishThatScales(buf, tc.ProjectID, topicID, 10); err != nil {
 		t.Errorf("failed to publish message: %v", err)
 	}
 }
@@ -152,7 +152,7 @@ func TestPublishThatScales(t *testing.T) {
 func TestPublishWithSettings(t *testing.T) {
 	tc := testutil.SystemTest(t)
 	setup(t)
-	if err := publishWithSettings(ioutil.Discard, tc.ProjectID, topicResource); err != nil {
+	if err := publishWithSettings(ioutil.Discard, tc.ProjectID, topicID); err != nil {
 		t.Errorf("failed to publish message: %v", err)
 	}
 }
@@ -161,7 +161,7 @@ func TestPublishCustomAttributes(t *testing.T) {
 	tc := testutil.SystemTest(t)
 	setup(t)
 	buf := new(bytes.Buffer)
-	if err := publishCustomAttributes(buf, tc.ProjectID, topicResource); err != nil {
+	if err := publishCustomAttributes(buf, tc.ProjectID, topicID); err != nil {
 		t.Errorf("failed to publish message: %v", err)
 	}
 }
@@ -172,7 +172,7 @@ func TestIAM(t *testing.T) {
 
 	testutil.Retry(t, 10, time.Second, func(r *testutil.R) {
 		buf := new(bytes.Buffer)
-		perms, err := testPermissions(buf, tc.ProjectID, topicResource)
+		perms, err := testPermissions(buf, tc.ProjectID, topicID)
 		if err != nil {
 			r.Errorf("testPermissions: %v", err)
 		}
@@ -182,14 +182,14 @@ func TestIAM(t *testing.T) {
 	})
 
 	testutil.Retry(t, 10, time.Second, func(r *testutil.R) {
-		if err := addUsers(tc.ProjectID, topicResource); err != nil {
+		if err := addUsers(tc.ProjectID, topicID); err != nil {
 			r.Errorf("addUsers: %v", err)
 		}
 	})
 
 	testutil.Retry(t, 10, time.Second, func(r *testutil.R) {
 		buf := new(bytes.Buffer)
-		policy, err := policy(buf, tc.ProjectID, topicResource)
+		policy, err := policy(buf, tc.ProjectID, topicID)
 		if err != nil {
 			r.Errorf("policy: %v", err)
 		}
@@ -206,7 +206,7 @@ func TestPublishWithOrderingKey(t *testing.T) {
 	tc := testutil.SystemTest(t)
 	setup(t)
 	buf := new(bytes.Buffer)
-	publishWithOrderingKey(buf, tc.ProjectID, topicResource)
+	publishWithOrderingKey(buf, tc.ProjectID, topicID)
 
 	got := buf.String()
 	want := "Published 4 messages with ordering keys successfully\n"
@@ -219,7 +219,7 @@ func TestResumePublishWithOrderingKey(t *testing.T) {
 	tc := testutil.SystemTest(t)
 	setup(t)
 	buf := new(bytes.Buffer)
-	resumePublishWithOrderingKey(buf, tc.ProjectID, topicResource)
+	resumePublishWithOrderingKey(buf, tc.ProjectID, topicID)
 
 	got := buf.String()
 	want := "Published a message with ordering key successfully\n"
@@ -232,27 +232,27 @@ func TestDelete(t *testing.T) {
 	tc := testutil.SystemTest(t)
 	client := setup(t)
 
-	topic := client.Topic(topicResource)
+	topic := client.Topic(topicID)
 	ok, err := topic.Exists(ctx)
 	if err != nil {
 		t.Fatalf("failed to check if topic exists: %v", err)
 	}
 	if !ok {
-		_, err := client.CreateTopic(ctx, topicResource)
+		_, err := client.CreateTopic(ctx, topicID)
 		if err != nil {
 			t.Fatalf("CreateTopic: %v", err)
 		}
 	}
 
 	buf := new(bytes.Buffer)
-	if err := delete(buf, tc.ProjectID, topicResource); err != nil {
-		t.Fatalf("failed to delete topic (%q): %v", topicResource, err)
+	if err := delete(buf, tc.ProjectID, topicID); err != nil {
+		t.Fatalf("failed to delete topic (%q): %v", topicID, err)
 	}
-	ok, err = client.Topic(topicResource).Exists(context.Background())
+	ok, err = client.Topic(topicID).Exists(context.Background())
 	if err != nil {
 		t.Fatalf("failed to check if topic exists: %v", err)
 	}
 	if ok {
-		t.Fatalf("got topic = %q; want none", topicResource)
+		t.Fatalf("got topic = %q; want none", topicID)
 	}
 }

--- a/pubsub/topics/topics_test.go
+++ b/pubsub/topics/topics_test.go
@@ -143,8 +143,10 @@ func TestPublish(t *testing.T) {
 }
 
 func TestPublishThatScales(t *testing.T) {
+	ctx := context.Background()
 	tc := testutil.SystemTest(t)
-	setup(t)
+	client := setup(t)
+	client.CreateTopic(ctx, topicID)
 	buf := new(bytes.Buffer)
 	if err := publishThatScales(buf, tc.ProjectID, topicID, 10); err != nil {
 		t.Errorf("failed to publish message: %v", err)
@@ -152,16 +154,20 @@ func TestPublishThatScales(t *testing.T) {
 }
 
 func TestPublishWithSettings(t *testing.T) {
+	ctx := context.Background()
 	tc := testutil.SystemTest(t)
-	setup(t)
+	client := setup(t)
+	client.CreateTopic(ctx, topicID)
 	if err := publishWithSettings(ioutil.Discard, tc.ProjectID, topicID); err != nil {
 		t.Errorf("failed to publish message: %v", err)
 	}
 }
 
 func TestPublishCustomAttributes(t *testing.T) {
+	ctx := context.Background()
 	tc := testutil.SystemTest(t)
-	setup(t)
+	client := setup(t)
+	client.CreateTopic(ctx, topicID)
 	buf := new(bytes.Buffer)
 	if err := publishCustomAttributes(buf, tc.ProjectID, topicID); err != nil {
 		t.Errorf("failed to publish message: %v", err)
@@ -169,8 +175,10 @@ func TestPublishCustomAttributes(t *testing.T) {
 }
 
 func TestIAM(t *testing.T) {
+	ctx := context.Background()
 	tc := testutil.SystemTest(t)
-	setup(t)
+	client := setup(t)
+	client.CreateTopic(ctx, topicID)
 
 	testutil.Retry(t, 10, time.Second, func(r *testutil.R) {
 		buf := new(bytes.Buffer)
@@ -205,8 +213,10 @@ func TestIAM(t *testing.T) {
 }
 
 func TestPublishWithOrderingKey(t *testing.T) {
+	ctx := context.Background()
 	tc := testutil.SystemTest(t)
-	setup(t)
+	client := setup(t)
+	client.CreateTopic(ctx, topicID)
 	buf := new(bytes.Buffer)
 	publishWithOrderingKey(buf, tc.ProjectID, topicID)
 
@@ -218,8 +228,10 @@ func TestPublishWithOrderingKey(t *testing.T) {
 }
 
 func TestResumePublishWithOrderingKey(t *testing.T) {
+	ctx := context.Background()
 	tc := testutil.SystemTest(t)
-	setup(t)
+	client := setup(t)
+	client.CreateTopic(ctx, topicID)
 	buf := new(bytes.Buffer)
 	resumePublishWithOrderingKey(buf, tc.ProjectID, topicID)
 


### PR DESCRIPTION
This takes the same resource creation/cleanup code from the Go pub/sub's e2e test and adds them here. Previously, tests were run with fixed topic/subscriptions with some cleanup, but if tests were run concurrently, this could lead to test failures, (e.g. #2082). Now, resources are unique for every invocation and includes a unix nano string that we can check for freshness. If resources are over 24 hours old, we'll delete them as part of the setup func.

Fixes #2082 