### PR TITLE
opentelemetry: export traces in batch rather than synchronously

### DIFF
--- a/opentelemetry/trace/main.go
+++ b/opentelemetry/trace/main.go
@@ -46,7 +46,7 @@ func main() {
 	// probabilistic sampling.
 	// Example:
 	//   tp := sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.TraceIDRatioBased(0.0001)), ...)
-	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	tp := sdktrace.NewTracerProvider(sdktrace.WithBatcher(exporter))
 	otel.SetTracerProvider(tp)
 
 	// [START opentelemetry_trace_custom_span]


### PR DESCRIPTION
Synchronous export carries a very heavy performance penalty (added
latency for each request), whereas batching with default options only
adds a 5s delay before a given trace is exported.

With this change, we guide users towards the right starting point. If
they have more specialized needs that call for synchronous export, they
can learn more from the upstream OTel docs.