### PR TITLE
fix(opentelemetry): use the right flush method

### DIFF
--- a/opentelemetry/trace/main.go
+++ b/opentelemetry/trace/main.go
@@ -37,7 +37,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("texporter.NewExporter: %v", err)
 	}
-	defer exporter.Shutdown(ctx) // flushes any pending spans
 
 	// Create trace provider with the exporter.
 	//
@@ -47,6 +46,7 @@ func main() {
 	// Example:
 	//   tp := sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.TraceIDRatioBased(0.0001)), ...)
 	tp := sdktrace.NewTracerProvider(sdktrace.WithBatcher(exporter))
+	defer tp.ForceFlush(ctx) // flushes any pending spans
 	otel.SetTracerProvider(tp)
 
 	// [START opentelemetry_trace_custom_span]


### PR DESCRIPTION
According to internal chats, Shutdown() is not meant to be called by the user,
ForceFlush() is the right thing to do here.

Context: http://doc/1R82XXlE8dVt1C-kLYRH2gFLVCzSgKiRna0yroZTsjhs/edit?resourcekey=0-iYHnmYFHYuh8ltcMbPFxhw&disco=AAAAMyjSPL0

cc: @aabmass @punya