### PR TITLE
fix(workflows): test with both go 1.16 and 1.11

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -54,6 +54,9 @@ jobs:
   test:
     name: Root tests ${{ matrix.go }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.16', '1.11' ]
     steps:
       - name: Setup Go
         uses: actions/setup-go@v2

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -52,13 +52,13 @@ jobs:
     - name: shellcheck
       run: find . -name "*.sh" -exec shellcheck {} \;
   test:
-    name: Root tests
+    name: Root tests ${{ matrix.go }}
     runs-on: ubuntu-latest
     steps:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.16'
+          go-version: ${{ matrix.go }}
       - name: Check code
         uses: actions/checkout@v2
       - run: go test -v

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.16', '1.11' ]
+        go: [ '1.16' ]
     steps:
     - name: Setup Go
       uses: actions/setup-go@v2

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -8,13 +8,16 @@ on:
       - master
 jobs:
   build:
-    name: Build and Lint
+    name: Build and Lint ${{ matrix.go }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [ '1.16', '1.11' ]
     steps:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '^1.16'
+        go-version: ${{ matrix.go }}
     - name: Install goimports
       run: go get golang.org/x/tools/cmd/goimports
     - name: Check code


### PR DESCRIPTION
Switches github actions to matrix builds so we can test multiple go versions.

Follows on from https://github.com/GoogleCloudPlatform/golang-samples/pull/2104 to ensure we're testing more broadly across go versions, as we also invoke these tests as part of google-cloud-go.