### PR TITLE
test(spanner): unskip backup test

### DIFF
--- a/spanner/spanner_snippets/spanner/integration_test.go
+++ b/spanner/spanner_snippets/spanner/integration_test.go
@@ -315,7 +315,6 @@ func TestSample(t *testing.T) {
 }
 
 func TestBackupSample(t *testing.T) {
-	t.Skip("https://github.com/GoogleCloudPlatform/golang-samples/issues/1900")
 	if os.Getenv("GOLANG_SAMPLES_E2E_TEST") == "" {
 		t.Skip("GOLANG_SAMPLES_E2E_TEST not set")
 	}


### PR DESCRIPTION
Unskip backup test now that each test uses its own instance (#2122). This should reduce the probability that a (backup) test times out.

Fixes #1900