### PR TITLE
fix(run/markdown-preview): narrow text input width in web UI

### DIFF
--- a/run/markdown-preview/editor/templates/index.html
+++ b/run/markdown-preview/editor/templates/index.html
@@ -20,8 +20,8 @@ limitations under the License.
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Markdown Editor</title>
   <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgo=">
-  <link href="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.css" rel="stylesheet">
-  <script src="https://unpkg.com/material-components-web@latest/dist/material-components-web.min.js"></script>
+  <link href="https://unpkg.com/material-components-web@11.0.0/dist/material-components-web.min.css" rel="stylesheet">
+  <script src="https://unpkg.com/material-components-web@11.0.0/dist/material-components-web.min.js"></script>
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 </head>
 <body class="mdc-typography">
@@ -50,7 +50,7 @@ limitations under the License.
         <h2>Markdown Text</h2>
         <section class="mdc-card mdc-card--outlined">
           <div class="text-field-container">
-            <div class="mdc-text-field mdc-text-field--fullwidth md-text-field--no-label mdc-text-field--textarea mdc-ripple-upgraded">
+            <div class="mdc-text-field md-text-field--no-label mdc-text-field--textarea mdc-ripple-upgraded" style="width:100%">
               <textarea id="editor" class="mdc-text-field__input" style="height: 36rem;">{{ .Default }}</textarea>
             </div>
           </div>


### PR DESCRIPTION
Fixes #1924, my expectation is this problem faces all versions of this sample app.

It looks from the material-components-web repository that major releases with breaking changes have moved from "measured in years" to "measured in months": https://github.com/material-components/material-components-web/releases

This means all samples that use CDN inclusion of material-components-web should switch from `latest` to the most recent major release (e.g., `11.0.0`).

It appears that in June 2020, the fullwidth option used in the Markdown Preview Editor styling became unsupported in favor of recommending an explicit `width: 100%` attribute: https://github.com/material-components/material-components-web/commit/69a35e80ceadb5ef9ffae87345eefbd80b383f51

I have made these two changes in this PR, and once merged will carry them across to the other languages.
