### PR TITLE
docs(run): Tokens expire after 1 hour - use Tokensource instead.

### DIFF
--- a/run/grpc-ping/connection.go
+++ b/run/grpc-ping/connection.go
@@ -18,8 +18,15 @@ package main
 // [START run_grpc_conn]
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"google.golang.org/api/idtoken"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/oauth"
+	"google.golang.org/grpc/status"
+	"strings"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -45,6 +52,28 @@ func NewConn(host string, insecure bool) (*grpc.ClientConn, error) {
 		})
 		opts = append(opts, grpc.WithTransportCredentials(cred))
 	}
+
+	// Create a TokenSource
+	// Using a TokenSource instead of a Token will ensure that the underlying Token
+	// used will be refreshed when needed
+	// A TokenSource automatically inject tokens with each underlying client request
+	audience := "https://" + strings.Split(host, ":")[0]
+	tokenSource, err := idtoken.NewTokenSource(context.Background(), audience,
+		option.WithAudiences(audience))
+	if err != nil {
+		return nil, status.Errorf(
+			codes.Unauthenticated,
+			"NewTokenSource: %s", err,
+		)
+	}
+	type grpcTokenSource struct {
+		oauth.TokenSource
+	}
+	opts = append(opts, grpc.WithPerRPCCredentials(grpcTokenSource{
+		TokenSource: oauth.TokenSource{
+			TokenSource: tokenSource,
+		},
+	}))
 
 	return grpc.Dial(host, opts...)
 }


### PR DESCRIPTION
The current example manually adds a token to each client request. For some longer running services, this becomes an issue since the client is usually instantiated when launching the service, requests made after 1 hour of the initial client instantiation will fail since the token will have expired by then.

Rather use the TokenSource methodology where the underlying token is validated and only refreshed when needed.