### PR TITLE
fix(endpoints): update sample deployment apiVersion to apps/v1

### DIFF
--- a/endpoints/getting-started/deployment.yaml
+++ b/endpoints/getting-started/deployment.yaml
@@ -26,12 +26,15 @@ spec:
     app: esp-echo
   type: LoadBalancer
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: esp-echo
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: esp-echo
   template:
     metadata:
       labels:


### PR DESCRIPTION
Deprecated APIs was removed from 1.16.

Similar changes made in #1893 need to be applied to this sample.