### PR TITLE
docs(firestore): incorporate a var to sample, improve docstrings

### DIFF
--- a/datastore/snippets/snippet_test.go
+++ b/datastore/snippets/snippet_test.go
@@ -507,8 +507,10 @@ func SnippetIterator_Cursor() {
 	ctx := context.Background()
 	client, _ := datastore.NewClient(ctx, "my-proj")
 	defer client.Close()
-	cursorStr := ""
 	// [START datastore_cursor_paging]
+	// cursorString is a cursort to start querying at.
+	cursorStr := ""
+
 	const pageSize = 5
 	query := datastore.NewQuery("Tasks").Limit(pageSize)
 	if cursorStr != "" {
@@ -533,6 +535,7 @@ func SnippetIterator_Cursor() {
 	}
 
 	// Get the cursor for the next page of results.
+	// nextCursor.String can be used as the next page's token.
 	nextCursor, err := it.Cursor()
 	// [END datastore_cursor_paging]
 	_ = err        // Check the error.

--- a/datastore/snippets/snippet_test.go
+++ b/datastore/snippets/snippet_test.go
@@ -508,7 +508,7 @@ func SnippetIterator_Cursor() {
 	client, _ := datastore.NewClient(ctx, "my-proj")
 	defer client.Close()
 	// [START datastore_cursor_paging]
-	// cursorString is a cursor to start querying at.
+	// cursorStr is a cursor to start querying at.
 	cursorStr := ""
 
 	const pageSize = 5

--- a/datastore/snippets/snippet_test.go
+++ b/datastore/snippets/snippet_test.go
@@ -508,7 +508,7 @@ func SnippetIterator_Cursor() {
 	client, _ := datastore.NewClient(ctx, "my-proj")
 	defer client.Close()
 	// [START datastore_cursor_paging]
-	// cursorString is a cursort to start querying at.
+	// cursorString is a cursor to start querying at.
 	cursorStr := ""
 
 	const pageSize = 5


### PR DESCRIPTION
We received feedback that it was hard to understand what cursorStr was. This pulls the variable into the sample along with a doc string. Also adds a docstring to nextCursor