### PR TITLE
fix(asset): fix tests

### DIFF
--- a/asset/quickstart/analyze-iam-policy-longrunning-bigquery/main_test.go
+++ b/asset/quickstart/analyze-iam-policy-longrunning-bigquery/main_test.go
@@ -60,7 +60,7 @@ func TestMain(t *testing.T) {
 			r.Errorf("did not expect stderr output, got %d bytes: %s", len(stdErr), string(stdErr))
 		}
 		got := string(stdOut)
-		if !strings.Contains(got, dataset) {
+		if !strings.Contains(got, "operation completed successfully") {
 			r.Errorf("stdout returned %s, wanted to contain %s", got, dataset)
 		}
 	})

--- a/asset/quickstart/analyze-iam-policy-longrunning-gcs/main_test.go
+++ b/asset/quickstart/analyze-iam-policy-longrunning-gcs/main_test.go
@@ -52,7 +52,7 @@ func TestMain(t *testing.T) {
 		t.Errorf("did not expect stderr output, got %d bytes: %s", len(stdErr), string(stdErr))
 	}
 	got := string(stdOut)
-	if !strings.Contains(got, uri) {
+	if !strings.Contains(got, "operation completed successfully") {
 		t.Errorf("stdout returned %s, wanted to contain %s", got, uri)
 	}
 }


### PR DESCRIPTION
There was recently an intentional breaking change in the way
asset LROs respond. Updaing the test to just check for a successful
completion.

Fixes: #2176
Fixes: #2182