### PR TITLE
fix(kms): asymmetric public key ec error message

### DIFF
--- a/kms/verify_asymmetric_ec.go
+++ b/kms/verify_asymmetric_ec.go
@@ -60,7 +60,7 @@ func verifyAsymmetricSignatureEC(w io.Writer, name string, message, signature []
 	}
 	ecKey, ok := publicKey.(*ecdsa.PublicKey)
 	if !ok {
-		return fmt.Errorf("public key is not rsa")
+		return fmt.Errorf("public key is not elliptic curve")
 	}
 
 	// Verify Elliptic Curve signature.


### PR DESCRIPTION
Fixes error message in asymmetric public key check for ECDSA signature
verification example.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>