### PR TITLE
chore: skip some vision tests

### DIFF
--- a/vision/product_search/get_similar_products_uri_test.go
+++ b/vision/product_search/get_similar_products_uri_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestGetSimilarProductsURI(t *testing.T) {
+	t.Skip("https://github.com/GoogleCloudPlatform/golang-samples/issues/2206")
 	tc := testutil.SystemTest(t)
 
 	const location = "us-west1"

--- a/vision/product_search/get_similar_products_uri_with_filter_test.go
+++ b/vision/product_search/get_similar_products_uri_with_filter_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestGetSimilarProductsURIWithFilter(t *testing.T) {
+	t.Skip("https://github.com/GoogleCloudPlatform/golang-samples/issues/2206")
 	tc := testutil.SystemTest(t)
 
 	const location = "us-west1"

--- a/vision/product_search/get_similar_products_with_filter_test.go
+++ b/vision/product_search/get_similar_products_with_filter_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestGetSimilarProductsWithFilter(t *testing.T) {
+	t.Skip("https://github.com/GoogleCloudPlatform/golang-samples/issues/2206")
 	tc := testutil.SystemTest(t)
 
 	const location = "us-west1"


### PR DESCRIPTION
It appears some buckets/assests have disappeared. Skipping these
tests to unblock other work.

Updates: #2206