### PR TITLE
feat: init workflows quickstart

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	cloud.google.com/go/video v0.1.0
 	cloud.google.com/go/videointelligence v0.1.0
 	cloud.google.com/go/vision v0.1.0
+	cloud.google.com/go/workflows v0.1.0
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.5
 	github.com/aws/aws-sdk-go v1.38.69
 	github.com/bmatcuk/doublestar/v2 v2.0.4

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,7 @@ cloud.google.com/go v0.92.3/go.mod h1:8utlLll2EF5XMAV15woO4lSbWQlk8rer9aLOfLh7+Y
 cloud.google.com/go v0.93.3/go.mod h1:8utlLll2EF5XMAV15woO4lSbWQlk8rer9aLOfLh7+YI=
 cloud.google.com/go v0.94.0 h1:QDB2MZHqjTt0hGKnoEWyG/iWykue/lvkLdogLgrg10U=
 cloud.google.com/go v0.94.0/go.mod h1:qAlAugsXlC+JWO+Bke5vCtc9ONxjQT3drlTTnAplMW4=
+cloud.google.com/go v0.94.1 h1:DwuSvDZ1pTYGbXo8yOJevCTr3BoBlE+OVkHAKiYQUXc=
 cloud.google.com/go/asset v0.1.0 h1:PJ7LYN5g6r8JwDdBABrE/mtNhSu3kKCRgGukKR4v8ok=
 cloud.google.com/go/asset v0.1.0/go.mod h1:GYxqEh/Sp2Am02W0znTHRLmpuFNiqoQb5D65WSWlpfU=
 cloud.google.com/go/automl v0.1.0 h1:Ogr3mzEIEIfMEULyNA3lEyL6rPgbvYxOFzHZEZqFU/A=
@@ -122,6 +123,8 @@ cloud.google.com/go/videointelligence v0.1.0 h1:nQH44yWh9Ht9Og/k+dL8zoe76Dbd/X6X
 cloud.google.com/go/videointelligence v0.1.0/go.mod h1:mAVxBaVTPlh6M5piY3Dxuggw4PZFnzKRpreHhUd6xmE=
 cloud.google.com/go/vision v0.1.0 h1:HbJoT0LbMAoMYAQmtRPEm7zmb4xKRI+jRTo6TScTytE=
 cloud.google.com/go/vision v0.1.0/go.mod h1:X17DgbLA3TlEh4d+rQPQO7yO5yAjZg4NBVO8WpEKgNU=
+cloud.google.com/go/workflows v0.1.0 h1:USggy0OWhdRhWV8J5JQaxG6glt8T5nxKewy7dWV22XE=
+cloud.google.com/go/workflows v0.1.0/go.mod h1:sypZ0mJTB9SGmxCPBO4CiZ2Pw7aIjQGJNaMGqVV8VaY=
 contrib.go.opencensus.io/exporter/stackdriver v0.13.5 h1:TNaexHK16gPUoc7uzELKOU7JULqccn1NDuqUxmxSqfo=
 contrib.go.opencensus.io/exporter/stackdriver v0.13.5/go.mod h1:aXENhDJ1Y4lIg4EUaVTwzvYETVNZk10Pu26tevFKLUc=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=

--- a/workflows/quickstart/main.go
+++ b/workflows/quickstart/main.go
@@ -1,0 +1,105 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Simple CLI to run the executeWorkflow function.
+// Used for one-off testing and development.
+
+// [START workflows_api_quickstart]
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	executions "cloud.google.com/go/workflows/executions/apiv1"
+	executionspb "google.golang.org/genproto/googleapis/cloud/workflows/executions/v1"
+)
+
+// executeWorkflow executes a workflow and returns the results from the workflow.
+func executeWorkflow(projectID, locationID, workflowID string) (string, error) {
+	ctx := context.Background()
+
+	// Creates a client.
+	client, err := executions.NewClient(ctx)
+	if err != nil {
+		return "", fmt.Errorf("executions.NewClient: %v", err)
+	}
+
+	if workflowID == "" {
+		workflowID = "myFirstWorkflow"
+	}
+	workflowPath := fmt.Sprintf("projects/%s/locations/%s/workflows/%s", projectID, locationID, workflowID)
+
+	exe, err := client.CreateExecution(ctx, &executionspb.CreateExecutionRequest{
+		Parent:    workflowPath,
+		Execution: &executionspb.Execution{},
+	})
+	if err != nil {
+		return "", fmt.Errorf("client.CreateExecution: %v", err)
+	}
+
+	name := exe.GetName()
+	fmt.Printf("Created execution: %v\n", name)
+
+	// Wait for execution to finish, then print results.
+	backoffDelay := 1 * time.Second // Start wait with delay of 1s.
+	fmt.Println("Poll for result...")
+	for {
+		exe, err := client.GetExecution(ctx, &executionspb.GetExecutionRequest{
+			Name: name,
+		})
+		if err != nil {
+			return "", fmt.Errorf("client.GetExecution: %v", err)
+		}
+
+		// If we haven't seen the result yet, wait a second.
+		if exe.State == executionspb.Execution_ACTIVE {
+			fmt.Printf("- Waiting %ds for results...\n", backoffDelay/time.Second)
+			time.Sleep(backoffDelay)
+			backoffDelay *= 2 // Double the delay to provide exponential backoff.
+		} else {
+			fmt.Printf("Execution finished with state: %v\n", exe.State)
+			return exe.Result, nil
+		}
+	}
+}
+
+func main() {
+	if len(os.Args) < 3 {
+		fmt.Println("Usage: Must include 2 arguments for projectID, locationID")
+		os.Exit(1)
+	}
+	projectID := os.Args[1]
+	locationID := os.Args[2]
+	workflowID := ""
+	if len(os.Args) > 3 {
+		workflowID = os.Args[3]
+	}
+
+	res, err := executeWorkflow(projectID, locationID, workflowID)
+	if err != nil {
+		log.Fatalf("Failure in workflow execution: %v", err)
+	}
+	var jsonStringArr []string
+	err = json.Unmarshal([]byte(res), &jsonStringArr)
+
+	fmt.Print(jsonStringArr)
+}
+
+// [END workflows_api_quickstart]

--- a/workflows/quickstart/main_test.go
+++ b/workflows/quickstart/main_test.go
@@ -1,0 +1,93 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+
+	workflows "cloud.google.com/go/workflows/apiv1beta"
+	workflowspb "google.golang.org/genproto/googleapis/cloud/workflows/v1beta"
+)
+
+func TestExecuteWorkflow(t *testing.T) {
+	tc := testutil.SystemTest(t)
+	locationID := "us-central1"
+	workflowName := "myFirstWorkflow"
+
+	fmt.Printf("deployWorkflow(%v, %v, %v)\n", tc.ProjectID, locationID, workflowName)
+	err := deployWorkflow(tc.ProjectID, locationID, workflowName)
+	if err != nil {
+		t.Errorf("deployWorkflow(%v, %v, %v): %v", tc.ProjectID, locationID, workflowName, err)
+	}
+
+	fmt.Printf("executeWorkflow(%v, %v, %v)\n", tc.ProjectID, locationID, workflowName)
+	_, err = executeWorkflow(tc.ProjectID, locationID, workflowName)
+	if err != nil {
+		t.Errorf("executeWorkflow(%v, %v, %v): %v", tc.ProjectID, locationID, workflowName, err)
+	}
+}
+
+// deployWorkflow deploys a workflow.
+func deployWorkflow(projectID, locationID, workflowID string) error {
+	// skip deploying if workflow exists already
+	workflowExists, _ := workflowExists(projectID, locationID, workflowID)
+	if workflowExists == true {
+		return nil
+	}
+
+	// create a new workflows
+	ctx := context.Background()
+	client, err := workflows.NewClient(ctx)
+	if err != nil {
+		return fmt.Errorf("workflows.NewClient: %v", err)
+	}
+	workflowPath := fmt.Sprintf("projects/%s/locations/%s/workflows/%s", projectID, locationID, workflowID)
+	_, err = client.CreateWorkflow(ctx, &workflowspb.CreateWorkflowRequest{
+		Parent:     workflowPath,
+		WorkflowId: workflowID,
+		Workflow: &workflowspb.Workflow{
+			Name: workflowID,
+			// Copied from:
+			// https://github.com/GoogleCloudPlatform/workflows-samples/blob/main/src/myFirstWorkflow.workflows.yaml
+			SourceCode: &workflowspb.Workflow_SourceContents{
+				SourceContents: "# Copyright 2020 Google LLC\n#\n# Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#      http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\n# [START workflows_myfirstworkflow]\n- getCurrentTime:\n    call: http.get\n    args:\n      url: https://us-central1-workflowsample.cloudfunctions.net/datetime\n    result: currentTime\n- readWikipedia:\n    call: http.get\n    args:\n      url: https://en.wikipedia.org/w/api.php\n      query:\n        action: opensearch\n        search: ${currentTime.body.dayOfTheWeek}\n    result: wikiResult\n- returnResult:\n    return: ${wikiResult.body[1]}\n# [END workflows_myfirstworkflow]\n",
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("workflows.CreateWorkflow: %v", err)
+	}
+	return nil
+}
+
+func workflowExists(projectID, locationID, workflowID string) (bool, error) {
+	ctx := context.Background()
+	client, err := workflows.NewClient(ctx)
+	if err != nil {
+		return false, fmt.Errorf("workflows.NewClient: %v", err)
+	}
+	workflowPath := fmt.Sprintf("projects/%s/locations/%s/workflows/%s", projectID, locationID, workflowID)
+	wf, err := client.GetWorkflow(ctx, &workflowspb.GetWorkflowRequest{
+		Name: workflowPath,
+	})
+	if err != nil {
+		return false, fmt.Errorf("client.GetWorkflow: %v", err)
+	}
+	return wf.State == workflowspb.Workflow_ACTIVE, nil
+}


### PR DESCRIPTION
This is one more attempt to add the workflows quickstart for golang. Things work on my end, the quickstart and tests.

If the tests somehow still do not pass in CI, I propose we could either have someone verify the quickstart works and merge without the test, as some quickstarts / main functions we write down have tests.

---

Inits Cloud Workflows API quickstart sample.

- Executes the Cloud Workflows quickstart (`myfirstworkflow`) using the Workflows client library
- Awaits the results with exponential backoff
- Includes test
https://cloud.google.com/workflows/docs/quickstart-client-libraries

Setup:

```
 gcloud projects add-iam-policy-binding $PROJECT \
    --member "serviceAccount:sa-name@$PROJECT.iam.gserviceaccount.com" \
    --role "roles/workflows.invoker"
```

Run:

```
gcloud auth application-default login
go run main.go "serverless-com-demo" "us-central1"
- Waiting 1s for results...
Execution finished with state: SUCCEEDED
[Thursday Thursday Night Football Thursday (band) Thursday Island Thursday Night Baseball Thursday at the Square Thursday Next Thursday (album) Thursday Afternoon Thursday's Child (David Bowie song)]%                                  
```

Test:

```
go test ./...
ok  	github.com/GoogleCloudPlatform/golang-samples/workflows/quickstart	0.358s
```