### PR TITLE
fix(pubsub): update concurrency sample

### DIFF
--- a/pubsub/subscriptions/pull_concurrency.go
+++ b/pubsub/subscriptions/pull_concurrency.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"runtime"
 	"sync/atomic"
 	"time"
 
@@ -40,12 +39,15 @@ func pullMsgsConcurrenyControl(w io.Writer, projectID, subID string) error {
 	// Must set ReceiveSettings.Synchronous to false (or leave as default) to enable
 	// concurrency settings. Otherwise, NumGoroutines will be set to 1.
 	sub.ReceiveSettings.Synchronous = false
-	// NumGoroutines is the number of goroutines sub.Receive will spawn to pull
-	// messages concurrently.
-	sub.ReceiveSettings.NumGoroutines = runtime.NumCPU()
+	// NumGoroutines determines the number of goroutines sub.Receive will spawn to pull
+	// messages.
+	sub.ReceiveSettings.NumGoroutines = 16
+	// MaxOutstandingMessages limits the number of concurrent handlers of messages.
+	// In this case, up to 8 messages can be handled concurrently.
+	sub.ReceiveSettings.MaxOutstandingMessages = 8
 
-	// Receive messages for 10 seconds.
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	// Receive messages for 30 seconds.
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	var counter int32

--- a/pubsub/subscriptions/pull_concurrency.go
+++ b/pubsub/subscriptions/pull_concurrency.go
@@ -43,7 +43,7 @@ func pullMsgsConcurrenyControl(w io.Writer, projectID, subID string) error {
 	// messages.
 	sub.ReceiveSettings.NumGoroutines = 16
 	// MaxOutstandingMessages limits the number of concurrent handlers of messages.
-	// In this case, up to 8 messages can be handled concurrently.
+	// In this case, up to 8 unacked messages can be handled concurrently.
 	sub.ReceiveSettings.MaxOutstandingMessages = 8
 
 	// Receive messages for 30 seconds.

--- a/pubsub/subscriptions/subscription_test.go
+++ b/pubsub/subscriptions/subscription_test.go
@@ -320,35 +320,37 @@ func TestPullMsgsConcurrencyControl(t *testing.T) {
 	topicIDConc := topicID + "-conc"
 	subIDConc := subID + "-conc"
 
-	topic, err := getOrCreateTopic(ctx, client, topicIDConc)
-	if err != nil {
-		t.Fatalf("getOrCreateTopic: %v", err)
-	}
-	defer topic.Delete(ctx)
-	defer topic.Stop()
+	testutil.Retry(t, 3, time.Second, func(r *testutil.R) {
+		topic, err := getOrCreateTopic(ctx, client, topicIDConc)
+		if err != nil {
+			r.Errorf("getOrCreateTopic: %v", err)
+		}
+		defer topic.Delete(ctx)
+		defer topic.Stop()
 
-	cfg := &pubsub.SubscriptionConfig{
-		Topic: topic,
-	}
-	sub, err := getOrCreateSub(ctx, client, subIDConc, cfg)
-	if err != nil {
-		t.Fatalf("getOrCreateSub: %v", err)
-	}
-	defer sub.Delete(ctx)
+		cfg := &pubsub.SubscriptionConfig{
+			Topic: topic,
+		}
+		sub, err := getOrCreateSub(ctx, client, subIDConc, cfg)
+		if err != nil {
+			r.Errorf("getOrCreateSub: %v", err)
+		}
+		defer sub.Delete(ctx)
 
-	// Publish 5 message to test with.
-	const numMsgs = 5
-	publishMsgs(ctx, topic, numMsgs)
+		// Publish 5 message to test with.
+		const numMsgs = 5
+		publishMsgs(ctx, topic, numMsgs)
 
-	buf := new(bytes.Buffer)
-	if err := pullMsgsConcurrenyControl(buf, tc.ProjectID, subIDConc); err != nil {
-		t.Fatalf("failed to pull messages: %v", err)
-	}
-	got := buf.String()
-	want := fmt.Sprintf("Received %d messages\n", numMsgs)
-	if got != want {
-		t.Fatalf("pullMsgsConcurrencyControl got %s\nwant %s", got, want)
-	}
+		buf := new(bytes.Buffer)
+		if err := pullMsgsConcurrenyControl(buf, tc.ProjectID, subIDConc); err != nil {
+			r.Errorf("failed to pull messages: %v", err)
+		}
+		got := buf.String()
+		want := fmt.Sprintf("Received %d messages\n", numMsgs)
+		if got != want {
+			r.Errorf("pullMsgsConcurrencyControl got %s\nwant %s", got, want)
+		}
+	})
 }
 
 func TestPullMsgsCustomAttributes(t *testing.T) {


### PR DESCRIPTION
The concurrency sample before didn't show how to configure the number of message handlers (`MaxOutstandingMessages`). This PR adds that and adds retries to reduce flakiness, as well as increasing the total pull time to 30 seconds to match the Java sample.

Fixes #2194