### PR TITLE
test(vision): unskip tests

### DIFF
--- a/vision/product_search/get_similar_products_uri_test.go
+++ b/vision/product_search/get_similar_products_uri_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 func TestGetSimilarProductsURI(t *testing.T) {
-	t.Skip("https://github.com/GoogleCloudPlatform/golang-samples/issues/2206")
 	tc := testutil.SystemTest(t)
 
 	const location = "us-west1"

--- a/vision/product_search/get_similar_products_uri_with_filter_test.go
+++ b/vision/product_search/get_similar_products_uri_with_filter_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 func TestGetSimilarProductsURIWithFilter(t *testing.T) {
-	t.Skip("https://github.com/GoogleCloudPlatform/golang-samples/issues/2206")
 	tc := testutil.SystemTest(t)
 
 	const location = "us-west1"


### PR DESCRIPTION
After running these tests locally they do not seem to fail anymore.
Maybe assets were restored, I am not quite sure.

Fixes: #2206