### PR TITLE
test(dataproc): improve flakiness for quickstart

### DIFF
--- a/dataproc/quickstart/quickstart_test.go
+++ b/dataproc/quickstart/quickstart_test.go
@@ -26,7 +26,6 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 	"github.com/google/uuid"
-	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	dataprocpb "google.golang.org/genproto/googleapis/cloud/dataproc/v1"
 )
@@ -76,7 +75,8 @@ func setup(t *testing.T, projectID string) {
 		t.Errorf("Error closing file: %v", err)
 	}
 
-	deleteClusters(ctx, projectID) // Ignore any errors.
+	// Opportunistically delete colliding cluster name.  Ignore errors.
+	deleteCluster(ctx, projectID, region, clusterName)
 }
 
 func teardown(t *testing.T, projectID string) {
@@ -95,40 +95,25 @@ func teardown(t *testing.T, projectID string) {
 		t.Errorf("Error deleting bucket: %v", err)
 	}
 
-	if err := deleteClusters(ctx, projectID); err != nil {
-		t.Errorf("deleteClusters: %v", err)
-	}
+	// Post-hoc cleanup, ignore errors.
+	deleteCluster(ctx, projectID, region, clusterName)
 }
 
-func deleteClusters(ctx context.Context, projectID string) error {
+func deleteCluster(ctx context.Context, projectID, region, clusterName string) error {
 	endpoint := fmt.Sprintf("%s-dataproc.googleapis.com:443", region)
 	client, err := dataproc.NewClusterControllerClient(ctx, option.WithEndpoint(endpoint))
 	if err != nil {
 		return fmt.Errorf("dataproc.NewClusterControllerClient: %v", err)
 	}
 
-	lReq := &dataprocpb.ListClustersRequest{ProjectId: projectID, Region: region}
-	it := client.ListClusters(ctx, lReq)
+	dReq := &dataprocpb.DeleteClusterRequest{ProjectId: projectID, Region: region, ClusterName: clusterName}
+	op, err := client.DeleteCluster(ctx, dReq)
+	if err != nil {
+		return fmt.Errorf("DeleteCluster: %v", err)
+	}
 
-	for {
-		resp, err := it.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			return fmt.Errorf("ListClusters.Next: %v", err)
-		}
-		if resp.ClusterName == clusterName {
-			dReq := &dataprocpb.DeleteClusterRequest{ProjectId: projectID, Region: region, ClusterName: clusterName}
-			op, err := client.DeleteCluster(ctx, dReq)
-			if err != nil {
-				return fmt.Errorf("DeleteCluster: %v", err)
-			}
-
-			if err := op.Wait(ctx); err != nil {
-				return fmt.Errorf("DeleteCluster.Wait: %v", err)
-			}
-		}
+	if err := op.Wait(ctx); err != nil {
+		return fmt.Errorf("DeleteCluster.Wait: %v", err)
 	}
 	return nil
 }
@@ -144,10 +129,7 @@ func TestQuickstart(t *testing.T) {
 	}
 
 	testutil.Retry(t, 3, 30*time.Second, func(r *testutil.R) {
-		if err := deleteClusters(context.Background(), tc.ProjectID); err != nil {
-			r.Errorf("failed to deleteClusters: %v", err)
-			return
-		}
+
 		stdOut, stdErr, err := m.Run(nil, 10*time.Minute,
 			"--project_id", tc.ProjectID,
 			"--region", region,
@@ -158,6 +140,8 @@ func TestQuickstart(t *testing.T) {
 			r.Errorf("stdout: %v", string(stdOut))
 			r.Errorf("stderr: %v", string(stdErr))
 			r.Errorf("execution failed: %v", err)
+			// We may have created the cluster in the failed invocation; try deleting.
+			deleteCluster(context.Background(), tc.ProjectID, region, clusterName)
 			return
 		}
 


### PR DESCRIPTION
The quickstart is fairly focused on resource deletion (rightly so), but
these opportunistic deletes can cause flakiness.

This change makes cluster deletion in the test non-failing, as well as removing
some unnecessary resource enumeration in the utility cluster deletion
function.  The quickstart itself performs setup and teardown, which
retains the necessary signalling.

Fixes: https://github.com/GoogleCloudPlatform/golang-samples/issues/2199