### PR TITLE
fix(cloudsql) database max connection lifetime

### DIFF
--- a/cloudsql/mysql/database-sql/cloudsql.go
+++ b/cloudsql/mysql/database-sql/cloudsql.go
@@ -31,6 +31,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/go-sql-driver/mysql"
 )
@@ -365,7 +366,7 @@ func configureConnectionPool(dbPool *sql.DB) {
 	// [START cloud_sql_mysql_databasesql_lifetime]
 
 	// Set Maximum time (in seconds) that a connection can remain open.
-	dbPool.SetConnMaxLifetime(1800)
+	dbPool.SetConnMaxLifetime(1800 * time.Second)
 
 	// [END cloud_sql_mysql_databasesql_lifetime]
 }

--- a/cloudsql/postgres/database-sql/cloudsql.go
+++ b/cloudsql/postgres/database-sql/cloudsql.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"time"
 
 	_ "github.com/jackc/pgx/v4/stdlib"
 )
@@ -326,7 +327,7 @@ func configureConnectionPool(dbPool *sql.DB) {
 	// [START cloud_sql_postgres_databasesql_lifetime]
 
 	// Set Maximum time (in seconds) that a connection can remain open.
-	dbPool.SetConnMaxLifetime(1800)
+	dbPool.SetConnMaxLifetime(1800 * time.Second)
 
 	// [END cloud_sql_postgres_databasesql_lifetime]
 }

--- a/cloudsql/sqlserver/database-sql/cloudsql.go
+++ b/cloudsql/sqlserver/database-sql/cloudsql.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"time"
 
 	_ "github.com/denisenkom/go-mssqldb"
 )
@@ -267,7 +268,7 @@ func configureConnectionPool(dbPool *sql.DB) {
 	// [START cloud_sql_sqlserver_databasesql_lifetime]
 
 	// Set Maximum time (in seconds) that a connection can remain open.
-	dbPool.SetConnMaxLifetime(1800)
+	dbPool.SetConnMaxLifetime(1800 * time.Second)
 
 	// [END cloud_sql_sqlserver_databasesql_lifetime]
 }


### PR DESCRIPTION
Google Cloud recommends limiting a database connection's lifetime to 1800 seconds, but samples use a 1800 value for `time.Duration` which evaluates to 1800 nanoseconds.

Express the arguments to `SetConnMaxLifetime` as `time.Second`.