### PR TITLE
test(spanner): fix backup tests

### DIFF
--- a/spanner/spanner_snippets/spanner/integration_test.go
+++ b/spanner/spanner_snippets/spanner/integration_test.go
@@ -443,7 +443,7 @@ func TestCustomerManagedEncryptionKeys(t *testing.T) {
 
 	var b bytes.Buffer
 
-	locationId := "us-central1"
+	locationId := "us-west1"
 	keyRingId := "spanner-test-keyring"
 	keyId := "spanner-test-key"
 

--- a/spanner/spanner_snippets/spanner/spanner_list_backup_operations.go
+++ b/spanner/spanner_snippets/spanner/spanner_list_backup_operations.go
@@ -41,7 +41,7 @@ func listBackupOperations(ctx context.Context, w io.Writer, db string) error {
 	}
 	instanceName := matches[1]
 	// List the CreateBackup operations.
-	filter := fmt.Sprintf("(metadata.database:%s) AND (metadata.@type:type.googleapis.com/google.spanner.admin.database.v1.CreateBackupMetadata)", db)
+	filter := fmt.Sprintf("(metadata.@type:type.googleapis.com/google.spanner.admin.database.v1.CreateBackupMetadata) AND (metadata.database:%s)", db)
 	iter := adminClient.ListBackupOperations(ctx, &adminpb.ListBackupOperationsRequest{
 		Parent: instanceName,
 		Filter: filter,


### PR DESCRIPTION
TestCustomerManagedEncryptionKeys need encryption key in same region as test instance, and ListBackupOperation needs metadata.@type as first filter option similar issue in C++ https://github.com/googleapis/google-cloud-cpp/issues/7741.

Fixes: https://github.com/GoogleCloudPlatform/golang-samples/issues/2333 https://github.com/GoogleCloudPlatform/golang-samples/issues/2334