### PR TITLE
fix(opencensus): trace exemplar example to show how to use attachments

### DIFF
--- a/opencensus/go.mod
+++ b/opencensus/go.mod
@@ -13,6 +13,7 @@ require (
 	go.opencensus.io v0.23.0
 	golang.org/x/exp v0.0.0-20211008200323-95152d363a1c
 	google.golang.org/genproto v0.0.0-20220118154757-00ab72f36ad5
+	google.golang.org/protobuf v1.27.1
 )
 
 replace github.com/GoogleCloudPlatform/golang-samples => ../

--- a/opencensus/trace_exemplar_test.go
+++ b/opencensus/trace_exemplar_test.go
@@ -27,12 +27,16 @@ import (
 
 func writeTimeSeriesData(projectID string) error {
 	ctx := context.Background()
-	dataPoint := createDataPointWithExemplar()
+	dataPoint, err := createDataPointWithExemplar(projectID)
+	if err != nil {
+		return err
+	}
 	// Creates a client.
 	client, err := monitoring.NewMetricClient(ctx)
 	if err != nil {
 		return err
 	}
+	defer client.Close()
 	// Writes time series data.
 	err = client.CreateTimeSeries(ctx, &monitoringpb.CreateTimeSeriesRequest{
 		Name: monitoring.MetricProjectPath(projectID),


### PR DESCRIPTION
The documentation for this is around trace exemplars, which requires a SpanContext attachment.

This is a common source of confusion when using Exemplars (the need to attach one of the documented types as an `Any`).