### PR TITLE
refactor(asset): refactor a couple of samples

### DIFF
--- a/asset/quickstart/analyze-iam-policy-longrunning-gcs/analyze_policy_gcs.go
+++ b/asset/quickstart/analyze-iam-policy-longrunning-gcs/analyze_policy_gcs.go
@@ -1,0 +1,77 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// [START asset_quickstart_analyze_iam_policy_longrunning_gcs]
+import (
+	"context"
+	"fmt"
+
+	asset "cloud.google.com/go/asset/apiv1"
+	assetpb "google.golang.org/genproto/googleapis/cloud/asset/v1"
+)
+
+// analyzeIAMPolicyGCS analyzes accessible IAM policies that match a request.
+func analyzeIAMPolicyGCS(scope, fullResourceName, gcsURI string) error {
+	// scope := "projects/my-project-id"
+	// fullResourceName := "//cloudresourcemanager.googleapis.com/projects/project/my-project-id"
+	// gcsURI := "gs://bucket_name/object_name"
+
+	ctx := context.Background()
+	client, err := asset.NewClient(ctx)
+	if err != nil {
+		return fmt.Errorf("asset.NewClient: %v", err)
+	}
+	defer client.Close()
+
+	req := &assetpb.AnalyzeIamPolicyLongrunningRequest{
+		AnalysisQuery: &assetpb.IamPolicyAnalysisQuery{
+			Scope: scope,
+			ResourceSelector: &assetpb.IamPolicyAnalysisQuery_ResourceSelector{
+				FullResourceName: fullResourceName,
+			},
+			Options: &assetpb.IamPolicyAnalysisQuery_Options{
+				ExpandGroups:     true,
+				OutputGroupEdges: true,
+			},
+		},
+		OutputConfig: &assetpb.IamPolicyAnalysisOutputConfig{
+			Destination: &assetpb.IamPolicyAnalysisOutputConfig_GcsDestination_{
+				GcsDestination: &assetpb.IamPolicyAnalysisOutputConfig_GcsDestination{
+					Uri: gcsURI,
+				},
+			},
+		},
+	}
+
+	op, err := client.AnalyzeIamPolicyLongrunning(ctx, req)
+	if err != nil {
+		return fmt.Errorf("client.AnalyzeIamPolicyLongrunning: %v", err)
+	}
+	fmt.Print(op.Metadata())
+
+	// Wait for the longrunning operation complete.
+	resp, err := op.Wait(ctx)
+	if err != nil && !op.Done() {
+		return fmt.Errorf("failed to fetch operation status: %v", err)
+	}
+	if err != nil && op.Done() {
+		return fmt.Errorf("operation completed with error: %v", err)
+	}
+	fmt.Printf("operation completed successfully: %v\n", resp)
+	return nil
+}
+
+// [END asset_quickstart_analyze_iam_policy_longrunning_gcs]

--- a/asset/quickstart/analyze-iam-policy-longrunning-gcs/analyze_policy_gcs_test.go
+++ b/asset/quickstart/analyze-iam-policy-longrunning-gcs/analyze_policy_gcs_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,42 +17,21 @@ package main
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 )
 
-func TestMain(t *testing.T) {
+func TestAnalyzeIAMPolicyGCS(t *testing.T) {
 	tc := testutil.SystemTest(t)
-	env := map[string]string{"GOOGLE_CLOUD_PROJECT": tc.ProjectID}
 	scope := fmt.Sprintf("projects/%s", tc.ProjectID)
 	fullResourceName := fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%s", tc.ProjectID)
-
-	m := testutil.BuildMain(t)
-	defer m.Cleanup()
-
-	if !m.Built() {
-		t.Errorf("failed to build app")
-	}
-
 	// Delete the bucket (if it exists) then recreate it.
-	ctx := context.Background()
 	bucketName := fmt.Sprintf("%s-for-assets", tc.ProjectID)
-	testutil.CleanBucket(ctx, t, tc.ProjectID, bucketName)
+	testutil.CleanBucket(context.Background(), t, tc.ProjectID, bucketName)
 	uri := fmt.Sprintf("gs://%s/client_library_obj", bucketName)
 
-	stdOut, stdErr, err := m.Run(env, 2*time.Minute, fmt.Sprintf("--scope=%s", scope), fmt.Sprintf("--fullResourceName=%s", fullResourceName), fmt.Sprintf("--uri=%s", uri))
-
-	if err != nil {
+	if err := analyzeIAMPolicyGCS(scope, fullResourceName, uri); err != nil {
 		t.Errorf("execution failed: %v", err)
-	}
-	if len(stdErr) > 0 {
-		t.Errorf("did not expect stderr output, got %d bytes: %s", len(stdErr), string(stdErr))
-	}
-	got := string(stdOut)
-	if !strings.Contains(got, "operation completed successfully") {
-		t.Errorf("stdout returned %s, wanted to contain %s", got, uri)
 	}
 }

--- a/asset/quickstart/export-assets-bigquery/export_bq.go
+++ b/asset/quickstart/export-assets-bigquery/export_bq.go
@@ -1,0 +1,62 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// [START asset_quickstart_export_assets_bigquery]
+import (
+	"context"
+	"fmt"
+
+	asset "cloud.google.com/go/asset/apiv1"
+	assetpb "google.golang.org/genproto/googleapis/cloud/asset/v1"
+)
+
+// exportAssetsToBigQuery demonstrates how to export assets to a given bigquery
+// table.
+func exportAssetsToBigQuery(projectID, datasetID string) error {
+	// projectID := "my-project-id"
+	// datasetID := "mydataset"
+	ctx := context.Background()
+	client, err := asset.NewClient(ctx)
+	if err != nil {
+		return fmt.Errorf("asset.NewClient: %v", err)
+	}
+	defer client.Close()
+	dataset := fmt.Sprintf("projects/%s/datasets/%s", projectID, datasetID)
+	req := &assetpb.ExportAssetsRequest{
+		Parent: fmt.Sprintf("projects/%s", projectID),
+		OutputConfig: &assetpb.OutputConfig{
+			Destination: &assetpb.OutputConfig_BigqueryDestination{
+				BigqueryDestination: &assetpb.BigQueryDestination{
+					Dataset: dataset,
+					Table:   "test",
+					Force:   true,
+				},
+			},
+		},
+	}
+	op, err := client.ExportAssets(ctx, req)
+	if err != nil {
+		return fmt.Errorf("client.ExportAssets: %v", err)
+	}
+	resp, err := op.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("op.Wait: %v", err)
+	}
+	fmt.Print(resp)
+	return nil
+}
+
+// [END asset_quickstart_export_assets_bigquery]


### PR DESCRIPTION
These samples are called quickstarts but looking at other samples
in different langs they are presented as functions to call. The main
wraping around these tests make them hard to debug when their are
failures. Made them more of a traditional sample. Will delete old
code once docs point to new sample.

Fixes: #2418
Fixes: #2414
Updates: #2423