### PR TITLE
feat(storage): add etag to HMAC key samples

### DIFF
--- a/storage/service_account/hmac/activate.go
+++ b/storage/service_account/hmac/activate.go
@@ -46,7 +46,7 @@ func activateHMACKey(w io.Writer, accessID string, projectID string) (*storage.H
 	// criteria. This avoids race conditions and data corruption.
 	key, err := handle.Get(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("storage.NewClient: %v", err)
+		return nil, fmt.Errorf("HMACKeyHandle.Get: %v", err)
 	}
 	keyAttrsToUpdate.Etag = key.Etag
 

--- a/storage/service_account/hmac/deactivate.go
+++ b/storage/service_account/hmac/deactivate.go
@@ -46,7 +46,7 @@ func deactivateHMACKey(w io.Writer, accessID string, projectID string) (*storage
 	// criteria. This avoids race conditions and data corruption.
 	key, err := handle.Get(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("storage.NewClient: %v", err)
+		return nil, fmt.Errorf("HMACKeyHandle.Get: %v", err)
 	}
 	keyAttrsToUpdate.Etag = key.Etag
 

--- a/storage/service_account/hmac/delete.go
+++ b/storage/service_account/hmac/delete.go
@@ -40,7 +40,7 @@ func deleteHMACKey(w io.Writer, accessID string, projectID string) error {
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 	if err = handle.Delete(ctx); err != nil {
-		return fmt.Errorf("Delete: %v", err)
+		return fmt.Errorf("HMACKeyHandle.Delete: %v", err)
 	}
 
 	fmt.Fprintln(w, "The key is deleted, though it may still appear in ListHMACKeys results.")


### PR DESCRIPTION
Adds etag conditions to the ops that require them to be idempotent.