### PR TITLE
feat(run/grpc-ping): reuse TokenSource as suggested in #2139

### DIFF
--- a/run/grpc-ping/go.mod
+++ b/run/grpc-ping/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/golang/protobuf v1.5.2
+	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f
 	google.golang.org/api v0.58.0
 	google.golang.org/grpc v1.44.0
 )


### PR DESCRIPTION
Adam, as per our discussion earlier today, here's a solution that reuses the TokenSource between multiple calls. Its only really good for a single `audience`, but i think it helps improve the sample, in line with the request in #2139 