### PR TITLE
fix(run): deflake sigterm-handler by sigterm'ing explicitly

### DIFF
--- a/run/sigterm-handler/main.go
+++ b/run/sigterm-handler/main.go
@@ -78,8 +78,8 @@ func main() {
 func handler(w http.ResponseWriter, r *http.Request) {
 	// The 'terminate' parameter is used by tests in sigterm_handler.e2e_test.go
 	if r.URL.Query().Get("terminate") != "" {
-		signalChan <- syscall.SIGTERM
 		fmt.Fprint(w, "Goodbye World!\n")
+		signalChan <- syscall.SIGTERM
 		return
 	}
 	fmt.Fprint(w, "Hello World!\n")

--- a/run/sigterm-handler/main.go
+++ b/run/sigterm-handler/main.go
@@ -77,7 +77,7 @@ func main() {
 // [END cloudrun_sigterm_handler]
 
 func handler(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Query().Has("terminate") {
+	if r.URL.Query().Get("terminate") != "" {
 		SignalChan <- syscall.SIGTERM
 		fmt.Fprint(w, "Goodbye World!\n")
 	} else {

--- a/run/testing/sigterm_handler.e2e_test.go
+++ b/run/testing/sigterm_handler.e2e_test.go
@@ -35,19 +35,20 @@ func TestSigtermHandlerService(t *testing.T) {
 	defer GetLogEntries(service, t)
 	defer service.Clean()
 
-	requestPath := "/"
+	// Explicitly send SIGTERM
+	requestPath := "/?terminate=1"
 	req, err := service.NewRequest("GET", requestPath)
 	if err != nil {
 		t.Fatalf("service.NewRequest: %v", err)
 	}
 
-	client := http.Client{Timeout: 10 * time.Second}
+	client := http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
 		t.Fatalf("client.Do: %v", err)
 	}
-	defer resp.Body.Close()
 	fmt.Printf("client.Do: %s %s\n", req.Method, req.URL)
+	resp.Body.Close()
 
 	if got := resp.StatusCode; got != http.StatusOK {
 		t.Errorf("response status: got %d, want %d", got, http.StatusOK)
@@ -64,7 +65,7 @@ func GetLogEntries(service *cloudrunci.Service, t *testing.T) {
 	attempts := 6
 	found, err := service.LogEntries(filter, find, attempts)
 	if err != nil || !found {
-		t.Errorf("%q log entry not found.", find)
+		t.Errorf("%q log entry not found. (%s)", find, err)
 	}
 	return
 }

--- a/run/testing/sigterm_handler.e2e_test.go
+++ b/run/testing/sigterm_handler.e2e_test.go
@@ -47,8 +47,8 @@ func TestSigtermHandlerService(t *testing.T) {
 	if err != nil {
 		t.Fatalf("client.Do: %v", err)
 	}
+	defer resp.Body.Close()
 	fmt.Printf("client.Do: %s %s\n", req.Method, req.URL)
-	resp.Body.Close()
 
 	if got := resp.StatusCode; got != http.StatusOK {
 		t.Errorf("response status: got %d, want %d", got, http.StatusOK)
@@ -65,7 +65,7 @@ func GetLogEntries(service *cloudrunci.Service, t *testing.T) {
 	attempts := 6
 	found, err := service.LogEntries(filter, find, attempts)
 	if err != nil || !found {
-		t.Errorf("%q log entry not found. (%s)", find, err)
+		t.Errorf("%q log entry not found. (%v)", find, err)
 	}
 	return
 }


### PR DESCRIPTION
Using a query param, request explicit termination, rather than waiting for
instance timeouts.

Fixes #2444

This PR also increases a client Timeout that was causing some flakiness (like
[this
one](https://source.cloud.google.com/results/invocations/a3483248-ddbc-44db-b4b8-e8a6f453a55b/targets/github%2Fgolang-samples%2Frun%2Ftesting/tests))
