### PR TITLE
test(iam): Add Retry to TestServiceAccounts

### DIFF
--- a/iam/snippets/service_accounts_test.go
+++ b/iam/snippets/service_accounts_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 	"github.com/gofrs/uuid"
@@ -41,14 +42,17 @@ func TestServiceAccounts(t *testing.T) {
 	}
 
 	// renameServiceAccount test.
-	account, err = renameServiceAccount(buf, account.Email, "Updated Test")
-	if err != nil {
-		t.Fatalf("renameServiceAccount: %v", err)
-	}
-	wantDispName := "Updated Test"
-	if wantDispName != account.DisplayName {
-		t.Fatalf("renameServiceAccount: account.DisplayName is %q, wanted %q", account.Name, wantDispName)
-	}
+
+	testutil.Retry(t, 5, 5*time.Second, func(r *testutil.R) {
+		account, err = renameServiceAccount(buf, account.Email, "Updated Test")
+		if err != nil {
+			r.Errorf("renameServiceAccount: %v", err)
+		}
+		wantDispName := "Updated Test"
+		if wantDispName != account.DisplayName {
+			r.Errorf("renameServiceAccount: account.DisplayName is %q, wanted %q", account.Name, wantDispName)
+		}
+	})
 
 	// disableServiceAccount test.
 	err = disableServiceAccount(buf, account.Email)

--- a/iam/snippets/service_accounts_test.go
+++ b/iam/snippets/service_accounts_test.go
@@ -47,6 +47,7 @@ func TestServiceAccounts(t *testing.T) {
 		account, err = renameServiceAccount(buf, account.Email, "Updated Test")
 		if err != nil {
 			r.Errorf("renameServiceAccount: %v", err)
+			return
 		}
 		wantDispName := "Updated Test"
 		if wantDispName != account.DisplayName {


### PR DESCRIPTION
Attempt to fix occasional test flakes apparently caused by eventual consistency of recently created Service Account with retry of `renameServiceAccount`.

closes: #2486