### PR TITLE
fix: Change desired translated text

### DIFF
--- a/functions/ocr/app/ocr_test.go
+++ b/functions/ocr/app/ocr_test.go
@@ -175,7 +175,7 @@ func TestDetectText(t *testing.T) {
 		t.Errorf("TestDetectText: %v", err)
 	}
 	got := buf.String()
-	if want := "Filets de Bœuf"; !strings.Contains(got, want) {
+	if want := "Filets de Boeuf"; !strings.Contains(got, want) {
 		t.Errorf("got %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
It appears that the API now translates beef to "Boeuf" instead of "Bœuf"