### PR TITLE
Use storage.SignedURL in generate_v4_get_object_signed_url example

### DIFF
--- a/storage/objects/generate_v4_get_object_signed_url.go
+++ b/storage/objects/generate_v4_get_object_signed_url.go
@@ -51,7 +51,7 @@ func generateV4GetObjectSignedURL(w io.Writer, bucket, object string) (string, e
 		Expires: time.Now().Add(15 * time.Minute),
 	}
 
-	u, err := client.Bucket(bucket).SignedURL(object, opts)
+	u, err := storage.SignedURL(bucket, object, opts)
 	if err != nil {
 		return "", fmt.Errorf("Bucket(%q).SignedURL: %v", bucket, err)
 	}


### PR DESCRIPTION
This PR updates example for object signed urls