### PR TITLE
chore(bigquery): switch bigquery query snippets to direct iterator

### DIFF
--- a/bigquery/snippets/querying/bigquery_query.go
+++ b/bigquery/snippets/querying/bigquery_query.go
@@ -43,7 +43,7 @@ func queryBasic(w io.Writer, projectID string) error {
 	// Run the query and process the returned row iterator.
 	it, err := q.Read(ctx)
 	if err != nil {
-		return fmt.Errorf("query.Read(: %v", err)
+		return fmt.Errorf("query.Read(): %v", err)
 	}
 	for {
 		var row []bigquery.Value

--- a/bigquery/snippets/querying/bigquery_query.go
+++ b/bigquery/snippets/querying/bigquery_query.go
@@ -40,19 +40,11 @@ func queryBasic(w io.Writer, projectID string) error {
 			"LIMIT 100")
 	// Location must match that of the dataset(s) referenced in the query.
 	q.Location = "US"
-	// Run the query and print results when the query job is completed.
-	job, err := q.Run(ctx)
+	// Run the query and process the returned row iterator.
+	it, err := q.Read(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("query.Read(: %v", err)
 	}
-	status, err := job.Wait(ctx)
-	if err != nil {
-		return err
-	}
-	if err := status.Err(); err != nil {
-		return err
-	}
-	it, err := job.Read(ctx)
 	for {
 		var row []bigquery.Value
 		err := it.Next(&row)

--- a/bigquery/snippets/querying/bigquery_query_clustered_table.go
+++ b/bigquery/snippets/querying/bigquery_query_clustered_table.go
@@ -55,7 +55,7 @@ func queryClusteredTable(w io.Writer, projectID, datasetID, tableID string) erro
 	// Run the query and process the returned row iterator.
 	it, err := q.Read(ctx)
 	if err != nil {
-		return fmt.Errorf("query.Read(: %v", err)
+		return fmt.Errorf("query.Read(): %v", err)
 	}
 	for {
 		var row []bigquery.Value

--- a/bigquery/snippets/querying/bigquery_query_clustered_table.go
+++ b/bigquery/snippets/querying/bigquery_query_clustered_table.go
@@ -52,19 +52,11 @@ func queryClusteredTable(w io.Writer, projectID, datasetID, tableID string) erro
 			Value: "wallet00001866cb7e0f09a890",
 		},
 	}
-	// Run the query and print results when the query job is completed.
-	job, err := q.Run(ctx)
+	// Run the query and process the returned row iterator.
+	it, err := q.Read(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("query.Read(: %v", err)
 	}
-	status, err := job.Wait(ctx)
-	if err != nil {
-		return err
-	}
-	if err := status.Err(); err != nil {
-		return err
-	}
-	it, err := job.Read(ctx)
 	for {
 		var row []bigquery.Value
 		err := it.Next(&row)

--- a/bigquery/snippets/querying/bigquery_query_destination_table.go
+++ b/bigquery/snippets/querying/bigquery_query_destination_table.go
@@ -40,19 +40,11 @@ func queryWithDestination(w io.Writer, projectID, destDatasetID, destTableID str
 	q := client.Query("SELECT 17 as my_col")
 	q.Location = "US" // Location must match the dataset(s) referenced in query.
 	q.QueryConfig.Dst = client.Dataset(destDatasetID).Table(destTableID)
-	// Run the query and print results when the query job is completed.
-	job, err := q.Run(ctx)
+	// Run the query and process the returned row iterator.
+	it, err := q.Read(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("query.Read(: %v", err)
 	}
-	status, err := job.Wait(ctx)
-	if err != nil {
-		return err
-	}
-	if err := status.Err(); err != nil {
-		return err
-	}
-	it, err := job.Read(ctx)
 	for {
 		var row []bigquery.Value
 		err := it.Next(&row)

--- a/bigquery/snippets/querying/bigquery_query_destination_table.go
+++ b/bigquery/snippets/querying/bigquery_query_destination_table.go
@@ -43,7 +43,7 @@ func queryWithDestination(w io.Writer, projectID, destDatasetID, destTableID str
 	// Run the query and process the returned row iterator.
 	it, err := q.Read(ctx)
 	if err != nil {
-		return fmt.Errorf("query.Read(: %v", err)
+		return fmt.Errorf("query.Read(): %v", err)
 	}
 	for {
 		var row []bigquery.Value

--- a/bigquery/snippets/querying/bigquery_query_destination_table_cmek.go
+++ b/bigquery/snippets/querying/bigquery_query_destination_table_cmek.go
@@ -47,7 +47,7 @@ func queryWithDestinationCMEK(w io.Writer, projectID, dstDatasetID, dstTableID s
 	// Run the query and process the returned row iterator.
 	it, err := q.Read(ctx)
 	if err != nil {
-		return fmt.Errorf("query.Read(: %v", err)
+		return fmt.Errorf("query.Read(): %v", err)
 	}
 	for {
 		var row []bigquery.Value

--- a/bigquery/snippets/querying/bigquery_query_destination_table_cmek.go
+++ b/bigquery/snippets/querying/bigquery_query_destination_table_cmek.go
@@ -44,19 +44,11 @@ func queryWithDestinationCMEK(w io.Writer, projectID, dstDatasetID, dstTableID s
 		// TODO: Replace this key with a key you have created in Cloud KMS.
 		KMSKeyName: "projects/cloud-samples-tests/locations/us-central1/keyRings/test/cryptoKeys/test",
 	}
-	// Run the query and print results when the query job is completed.
-	job, err := q.Run(ctx)
+	// Run the query and process the returned row iterator.
+	it, err := q.Read(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("query.Read(: %v", err)
 	}
-	status, err := job.Wait(ctx)
-	if err != nil {
-		return err
-	}
-	if err := status.Err(); err != nil {
-		return err
-	}
-	it, err := job.Read(ctx)
 	for {
 		var row []bigquery.Value
 		err := it.Next(&row)

--- a/bigquery/snippets/querying/bigquery_query_legacy.go
+++ b/bigquery/snippets/querying/bigquery_query_legacy.go
@@ -38,19 +38,11 @@ func queryLegacy(w io.Writer, projectID, sqlString string) error {
 	q := client.Query(sqlString)
 	q.UseLegacySQL = true
 
-	// Run the query and print results when the query job is completed.
-	job, err := q.Run(ctx)
+	// Run the query and process the returned row iterator.
+	it, err := q.Read(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("query.Read(: %v", err)
 	}
-	status, err := job.Wait(ctx)
-	if err != nil {
-		return err
-	}
-	if err := status.Err(); err != nil {
-		return err
-	}
-	it, err := job.Read(ctx)
 	for {
 		var row []bigquery.Value
 		err := it.Next(&row)

--- a/bigquery/snippets/querying/bigquery_query_legacy.go
+++ b/bigquery/snippets/querying/bigquery_query_legacy.go
@@ -41,7 +41,7 @@ func queryLegacy(w io.Writer, projectID, sqlString string) error {
 	// Run the query and process the returned row iterator.
 	it, err := q.Read(ctx)
 	if err != nil {
-		return fmt.Errorf("query.Read(: %v", err)
+		return fmt.Errorf("query.Read(): %v", err)
 	}
 	for {
 		var row []bigquery.Value

--- a/bigquery/snippets/querying/bigquery_query_legacy_large_results.go
+++ b/bigquery/snippets/querying/bigquery_query_legacy_large_results.go
@@ -45,7 +45,7 @@ func queryLegacyLargeResults(w io.Writer, projectID, datasetID, tableID string) 
 	// Run the query and process the returned row iterator.
 	it, err := q.Read(ctx)
 	if err != nil {
-		return fmt.Errorf("query.Read(: %v", err)
+		return fmt.Errorf("query.Read(): %v", err)
 	}
 	for {
 		var row []bigquery.Value

--- a/bigquery/snippets/querying/bigquery_query_legacy_large_results.go
+++ b/bigquery/snippets/querying/bigquery_query_legacy_large_results.go
@@ -42,19 +42,11 @@ func queryLegacyLargeResults(w io.Writer, projectID, datasetID, tableID string) 
 	q.UseLegacySQL = true
 	q.AllowLargeResults = true
 	q.QueryConfig.Dst = client.Dataset(datasetID).Table(tableID)
-	// Run the query and print results when the query job is completed.
-	job, err := q.Run(ctx)
+	// Run the query and process the returned row iterator.
+	it, err := q.Read(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("query.Read(: %v", err)
 	}
-	status, err := job.Wait(ctx)
-	if err != nil {
-		return err
-	}
-	if err := status.Err(); err != nil {
-		return err
-	}
-	it, err := job.Read(ctx)
 	for {
 		var row []bigquery.Value
 		err := it.Next(&row)

--- a/bigquery/snippets/querying/bigquery_query_no_cache.go
+++ b/bigquery/snippets/querying/bigquery_query_no_cache.go
@@ -43,7 +43,7 @@ func queryDisableCache(w io.Writer, projectID string) error {
 	// Run the query and process the returned row iterator.
 	it, err := q.Read(ctx)
 	if err != nil {
-		return fmt.Errorf("query.Read(: %v", err)
+		return fmt.Errorf("query.Read(): %v", err)
 	}
 	for {
 		var row []bigquery.Value

--- a/bigquery/snippets/querying/bigquery_query_no_cache.go
+++ b/bigquery/snippets/querying/bigquery_query_no_cache.go
@@ -40,19 +40,11 @@ func queryDisableCache(w io.Writer, projectID string) error {
 	// Location must match that of the dataset(s) referenced in the query.
 	q.Location = "US"
 
-	// Run the query and print results when the query job is completed.
-	job, err := q.Run(ctx)
+	// Run the query and process the returned row iterator.
+	it, err := q.Read(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("query.Read(: %v", err)
 	}
-	status, err := job.Wait(ctx)
-	if err != nil {
-		return err
-	}
-	if err := status.Err(); err != nil {
-		return err
-	}
-	it, err := job.Read(ctx)
 	for {
 		var row []bigquery.Value
 		err := it.Next(&row)

--- a/bigquery/snippets/querying/bigquery_query_params_arrays.go
+++ b/bigquery/snippets/querying/bigquery_query_params_arrays.go
@@ -58,19 +58,11 @@ func queryWithArrayParams(w io.Writer, projectID string) error {
 			Value: []string{"WA", "WI", "WV", "WY"},
 		},
 	}
-	// Run the query and print results when the query job is completed.
-	job, err := q.Run(ctx)
+	// Run the query and process the returned row iterator.
+	it, err := q.Read(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("query.Read(: %v", err)
 	}
-	status, err := job.Wait(ctx)
-	if err != nil {
-		return err
-	}
-	if err := status.Err(); err != nil {
-		return err
-	}
-	it, err := job.Read(ctx)
 	for {
 		var row []bigquery.Value
 		err := it.Next(&row)

--- a/bigquery/snippets/querying/bigquery_query_params_arrays.go
+++ b/bigquery/snippets/querying/bigquery_query_params_arrays.go
@@ -61,7 +61,7 @@ func queryWithArrayParams(w io.Writer, projectID string) error {
 	// Run the query and process the returned row iterator.
 	it, err := q.Read(ctx)
 	if err != nil {
-		return fmt.Errorf("query.Read(: %v", err)
+		return fmt.Errorf("query.Read(): %v", err)
 	}
 	for {
 		var row []bigquery.Value

--- a/bigquery/snippets/querying/bigquery_query_params_named.go
+++ b/bigquery/snippets/querying/bigquery_query_params_named.go
@@ -50,19 +50,11 @@ func queryWithNamedParams(w io.Writer, projectID string) error {
 			Value: 250,
 		},
 	}
-	// Run the query and print results when the query job is completed.
-	job, err := q.Run(ctx)
+	// Run the query and process the returned row iterator.
+	it, err := q.Read(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("query.Read(: %v", err)
 	}
-	status, err := job.Wait(ctx)
-	if err != nil {
-		return err
-	}
-	if err := status.Err(); err != nil {
-		return err
-	}
-	it, err := job.Read(ctx)
 	for {
 		var row []bigquery.Value
 		err := it.Next(&row)

--- a/bigquery/snippets/querying/bigquery_query_params_named.go
+++ b/bigquery/snippets/querying/bigquery_query_params_named.go
@@ -53,7 +53,7 @@ func queryWithNamedParams(w io.Writer, projectID string) error {
 	// Run the query and process the returned row iterator.
 	it, err := q.Read(ctx)
 	if err != nil {
-		return fmt.Errorf("query.Read(: %v", err)
+		return fmt.Errorf("query.Read(): %v", err)
 	}
 	for {
 		var row []bigquery.Value

--- a/bigquery/snippets/querying/bigquery_query_params_positional.go
+++ b/bigquery/snippets/querying/bigquery_query_params_positional.go
@@ -48,19 +48,11 @@ func queryWithPositionalParams(w io.Writer, projectID string) error {
 			Value: 250,
 		},
 	}
-	// Run the query and print results when the query job is completed.
-	job, err := q.Run(ctx)
+	// Run the query and process the returned row iterator.
+	it, err := q.Read(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("query.Read(: %v", err)
 	}
-	status, err := job.Wait(ctx)
-	if err != nil {
-		return err
-	}
-	if err := status.Err(); err != nil {
-		return err
-	}
-	it, err := job.Read(ctx)
 	for {
 		var row []bigquery.Value
 		err := it.Next(&row)

--- a/bigquery/snippets/querying/bigquery_query_params_positional.go
+++ b/bigquery/snippets/querying/bigquery_query_params_positional.go
@@ -51,7 +51,7 @@ func queryWithPositionalParams(w io.Writer, projectID string) error {
 	// Run the query and process the returned row iterator.
 	it, err := q.Read(ctx)
 	if err != nil {
-		return fmt.Errorf("query.Read(: %v", err)
+		return fmt.Errorf("query.Read(): %v", err)
 	}
 	for {
 		var row []bigquery.Value

--- a/bigquery/snippets/querying/bigquery_query_params_structs.go
+++ b/bigquery/snippets/querying/bigquery_query_params_structs.go
@@ -47,19 +47,11 @@ func queryWithStructParam(w io.Writer, projectID string) error {
 			Value: MyStruct{X: 1, Y: "foo"},
 		},
 	}
-	// Run the query and print results when the query job is completed.
-	job, err := q.Run(ctx)
+	// Run the query and process the returned row iterator.
+	it, err := q.Read(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("query.Read(: %v", err)
 	}
-	status, err := job.Wait(ctx)
-	if err != nil {
-		return err
-	}
-	if err := status.Err(); err != nil {
-		return err
-	}
-	it, err := job.Read(ctx)
 	for {
 		var row []bigquery.Value
 		err := it.Next(&row)

--- a/bigquery/snippets/querying/bigquery_query_params_structs.go
+++ b/bigquery/snippets/querying/bigquery_query_params_structs.go
@@ -50,7 +50,7 @@ func queryWithStructParam(w io.Writer, projectID string) error {
 	// Run the query and process the returned row iterator.
 	it, err := q.Read(ctx)
 	if err != nil {
-		return fmt.Errorf("query.Read(: %v", err)
+		return fmt.Errorf("query.Read(): %v", err)
 	}
 	for {
 		var row []bigquery.Value

--- a/bigquery/snippets/querying/bigquery_query_params_timestamps.go
+++ b/bigquery/snippets/querying/bigquery_query_params_timestamps.go
@@ -46,7 +46,7 @@ func queryWithTimestampParam(w io.Writer, projectID string) error {
 	// Run the query and process the returned row iterator.
 	it, err := q.Read(ctx)
 	if err != nil {
-		return fmt.Errorf("query.Read(: %v", err)
+		return fmt.Errorf("query.Read(): %v", err)
 	}
 	for {
 		var row []bigquery.Value

--- a/bigquery/snippets/querying/bigquery_query_params_timestamps.go
+++ b/bigquery/snippets/querying/bigquery_query_params_timestamps.go
@@ -43,19 +43,11 @@ func queryWithTimestampParam(w io.Writer, projectID string) error {
 			Value: time.Date(2016, 12, 7, 8, 0, 0, 0, time.UTC),
 		},
 	}
-	// Run the query and print results when the query job is completed.
-	job, err := q.Run(ctx)
+	// Run the query and process the returned row iterator.
+	it, err := q.Read(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("query.Read(: %v", err)
 	}
-	status, err := job.Wait(ctx)
-	if err != nil {
-		return err
-	}
-	if err := status.Err(); err != nil {
-		return err
-	}
-	it, err := job.Read(ctx)
 	for {
 		var row []bigquery.Value
 		err := it.Next(&row)

--- a/bigquery/snippets/querying/bigquery_query_partitioned_table.go
+++ b/bigquery/snippets/querying/bigquery_query_partitioned_table.go
@@ -38,19 +38,11 @@ func queryPartitionedTable(w io.Writer, projectID, datasetID, tableID string) er
 	defer client.Close()
 
 	q := client.Query(fmt.Sprintf("SELECT * FROM `%s.%s` WHERE `date` BETWEEN DATE('1800-01-01') AND DATE('1899-12-31')", datasetID, tableID))
-	// Run the query and print results when the query job is completed.
-	job, err := q.Run(ctx)
+	// Run the query and process the returned row iterator.
+	it, err := q.Read(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("query.Read(: %v", err)
 	}
-	status, err := job.Wait(ctx)
-	if err != nil {
-		return err
-	}
-	if err := status.Err(); err != nil {
-		return err
-	}
-	it, err := job.Read(ctx)
 	for {
 		var row []bigquery.Value
 		err := it.Next(&row)

--- a/bigquery/snippets/querying/bigquery_query_partitioned_table.go
+++ b/bigquery/snippets/querying/bigquery_query_partitioned_table.go
@@ -41,7 +41,7 @@ func queryPartitionedTable(w io.Writer, projectID, datasetID, tableID string) er
 	// Run the query and process the returned row iterator.
 	it, err := q.Read(ctx)
 	if err != nil {
-		return fmt.Errorf("query.Read(: %v", err)
+		return fmt.Errorf("query.Read(): %v", err)
 	}
 	for {
 		var row []bigquery.Value


### PR DESCRIPTION
This updates the existing query snippets to demonstrate directly accessing the iterator.  Previously, these samples used the pattern of managing/monitoring the job directly via Run -> Wait -> Read.

This does two things:  simplifies the query samples, and potentially enables faster results access.

Samples that don't access query results were left unmodified (e.g. dry run, DML queries, etc).