### PR TITLE
chore: try to get renovate working

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,7 +13,7 @@
   "ignorePaths": [
     "testing/docker/Dockerfile*"
   ],
-  "groupName": "all",
+  "groupName": "everything",
   "packageRules": [
     {
       "updateTypes": ["major"],


### PR DESCRIPTION
Similar to googleapis/google-cloud-go#6050

> Switching the group name should make changes come from a new branch on the renovate fork I believe. This may fix the issue that we are no longer getting PRs from our current branch.