### PR TITLE
docs: add Google Cloud Samples browser link to readme template

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Some samples have accompanying guides on
 [cloud.google.com](https://cloud.google.com). See respective README files for
 details.
 
+## Google Cloud Samples
+
+To browse ready to use code samples check [Google Cloud Samples](https://cloud.google.com/docs/samples?l=go).
+
 ## Depending on samples
 
 **Copy any code you need from this repository into your own project.**


### PR DESCRIPTION
Adding a generic Google Code Sample link to the readme template.

This is for the benefit of the users, in navigating available Google Cloud code samples.