### PR TITLE
feat: add sample to disable billingAccount

### DIFF
--- a/billing/disableBillingAccount/go.mod
+++ b/billing/disableBillingAccount/go.mod
@@ -1,0 +1,23 @@
+module github.com/GoogleCloudPlatform/golang-samples/billing
+
+go 1.18
+
+require google.golang.org/api v0.85.0
+
+require (
+	cloud.google.com/go/compute v1.7.0 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/uuid v1.1.2 // indirect
+	github.com/googleapis/enterprise-certificate-proxy v0.1.0 // indirect
+	github.com/googleapis/gax-go/v2 v2.4.0 // indirect
+	go.opencensus.io v0.23.0 // indirect
+	golang.org/x/net v0.0.0-20220617184016-355a448f1bc9 // indirect
+	golang.org/x/oauth2 v0.0.0-20220608161450-d0670ef3b1eb // indirect
+	golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c // indirect
+	golang.org/x/text v0.3.7 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20220617124728-180714bec0ad // indirect
+	google.golang.org/grpc v1.47.0 // indirect
+	google.golang.org/protobuf v1.28.0 // indirect
+)

--- a/billing/disableBillingAccount/main.go
+++ b/billing/disableBillingAccount/main.go
@@ -1,0 +1,44 @@
+// https://cloud.google.com/billing/docs/how-to/notify#cap_disable_billing_to_stop_usage
+// Note that associating a project with a *closed* billing account will have much the same effect
+// as disabling billing on the project: any paid resources used by the project will be shut down.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"google.golang.org/api/cloudbilling/v1"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+	"log"
+	"os"
+)
+
+func main() {
+	ctx := context.Background()
+
+	project := os.Getenv("GCP_PROJECT_ID")
+	//project := "PROJECT_ID"
+	p := cloudbilling.ProjectBillingInfo{
+		BillingAccountName: "", // disable BillingAccount Project if empty
+		BillingEnabled:     false,
+		Name:               project,
+		ProjectId:          project,
+		ServerResponse:     googleapi.ServerResponse{},
+		ForceSendFields:    nil,
+		NullFields:         nil,
+	}
+
+	token := os.Getenv("GCP_ACCESS_TOKEN") //export GCP_ACCESS_TOKEN=$(gcloud auth print-access-token)
+	//token := "AIza..."
+	cloudBillingService, err := cloudbilling.NewService(ctx, option.WithAPIKey(os.Getenv(token)))
+	if err != nil {
+		log.Fatal(err)
+	}
+	ProjectPath := fmt.Sprintf("projects/%s", project)
+	b, err := cloudBillingService.Projects.UpdateBillingInfo(ProjectPath, &p).Do()
+	if err != nil {
+		log.Panic(err)
+	}
+	log.Println(b)
+}


### PR DESCRIPTION
On doc https://cloud.google.com/billing/docs/how-to/notify#cap_disable_billing_to_stop_usage
don't have any Go code, this can be used to disable sandbox when pub/sub triggered by the budget alert.