### PR TITLE
storage: increase bucket create timeout

### DIFF
--- a/storage/buckets/create_bucket.go
+++ b/storage/buckets/create_bucket.go
@@ -35,7 +35,7 @@ func createBucket(w io.Writer, projectID, bucketName string) error {
 	}
 	defer client.Close()
 
-	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()
 
 	bucket := client.Bucket(bucketName)

--- a/storage/buckets/create_bucket_class_location.go
+++ b/storage/buckets/create_bucket_class_location.go
@@ -36,7 +36,7 @@ func createBucketClassLocation(w io.Writer, projectID, bucketName string) error 
 	}
 	defer client.Close()
 
-	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()
 
 	storageClassAndLocation := &storage.BucketAttrs{

--- a/storage/buckets/create_bucket_dual_region.go
+++ b/storage/buckets/create_bucket_dual_region.go
@@ -40,7 +40,7 @@ func createBucketDualRegion(w io.Writer, projectID, bucketName, region1, region2
 	}
 	defer client.Close()
 
-	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()
 
 	storageLocation := &storage.BucketAttrs{

--- a/storage/buckets/create_bucket_turbo_replication.go
+++ b/storage/buckets/create_bucket_turbo_replication.go
@@ -40,7 +40,7 @@ func createBucketTurboReplication(w io.Writer, projectID, bucketName, location s
 	}
 	defer client.Close()
 
-	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()
 
 	storageLocationAndRPO := &storage.BucketAttrs{


### PR DESCRIPTION
bucket.Create is being retried appropriately by the client, but
we still hit a test flake due to 503s. This extends the timeout
to 30s.

Fixes #2606