### PR TITLE
fix(run/sigterm): use query string for terminate

### DIFF
--- a/run/testing/sigterm_handler.e2e_test.go
+++ b/run/testing/sigterm_handler.e2e_test.go
@@ -36,8 +36,10 @@ func TestSigtermHandlerService(t *testing.T) {
 	defer service.Clean()
 
 	// Explicitly send SIGTERM
-	requestPath := "/?terminate=1"
-	req, err := service.NewRequest("GET", requestPath)
+	req, err := service.NewRequest("GET", "")
+	q := req.URL.Query()
+	q.Add("terminate", "1")
+	req.URL.RawQuery = q.Encode()
 	if err != nil {
 		t.Fatalf("service.NewRequest: %v", err)
 	}


### PR DESCRIPTION
the prior approach was being url escaped, so test is still flaky.

Fixes #2580
