### PR TITLE
test(storage): Skip dual region test

### DIFF
--- a/storage/buckets/buckets_test.go
+++ b/storage/buckets/buckets_test.go
@@ -87,6 +87,7 @@ func TestCreateBucketClassLocation(t *testing.T) {
 }
 
 func TestCreateBucketDualRegion(t *testing.T) {
+	t.Skip("Fails due to backend change, skip until #2620 is merged.")
 	tc := testutil.SystemTest(t)
 	bucketName := testutil.UniqueBucketName(testPrefix)
 	ctx := context.Background()


### PR DESCRIPTION
This test is failing due to the rollout of a backend change.
It should be fixed and re-enabled in #2620.

Updates #2644