### PR TITLE
Add granular markers to V3 Translate API for code sample extraction

### DIFF
--- a/translate/v3/translate_text.go
+++ b/translate/v3/translate_text.go
@@ -17,6 +17,7 @@ package v3
 
 // [START translate_v3_translate_text]
 // [START translate_v3_translate_text_0]
+// Imports the Google Cloud Translation library
 import (
 	"context"
 	"fmt"
@@ -28,21 +29,24 @@ import (
 
 // [END translate_v3_translate_text_0]
 
-// [START translate_v3_translate_text_1]
-// translateText translates input text and returns translated text.
 func translateText(w io.Writer, projectID string, sourceLang string, targetLang string, text string) error {
 	// projectID := "my-project-id"
 	// sourceLang := "en-US"
 	// targetLang := "fr"
 	// text := "Text you wish to translate"
 
+	// [START translate_v3_translate_text_1]
+	// Instantiates a client
 	ctx := context.Background()
 	client, err := translate.NewTranslationClient(ctx)
 	if err != nil {
 		return fmt.Errorf("NewTranslationClient: %v", err)
 	}
 	defer client.Close()
+	// [END translate_v3_translate_text_1]
 
+	// [START translate_v3_translate_text_2]
+	// Construct request
 	req := &translatepb.TranslateTextRequest{
 		Parent:             fmt.Sprintf("projects/%s/locations/global", projectID),
 		SourceLanguageCode: sourceLang,
@@ -55,15 +59,16 @@ func translateText(w io.Writer, projectID string, sourceLang string, targetLang 
 	if err != nil {
 		return fmt.Errorf("TranslateText: %v", err)
 	}
+	// [END translate_v3_translate_text_2]
 
+	// [START translate_v3_translate_text_2]
 	// Display the translation for each input text provided
 	for _, translation := range resp.GetTranslations() {
 		fmt.Fprintf(w, "Translated text: %v\n", translation.GetTranslatedText())
 	}
+	// [END translate_v3_translate_text_2]
 
 	return nil
 }
-
-// [END translate_v3_translate_text_1]
 
 // [END translate_v3_translate_text]


### PR DESCRIPTION
This aligns the code samples with some other language samples such as [NodeJS](https://github.com/googleapis/nodejs-translate/blob/main/samples/v3/translate_translate_text.js) so that code samples can be extracted in documentation.