### PR TITLE
feat: Add snippets for Spanner DML with returning clause

### DIFF
--- a/spanner/spanner_snippets/spanner/pg_spanner_dml_delete_returning.go
+++ b/spanner/spanner_snippets/spanner/pg_spanner_dml_delete_returning.go
@@ -1,0 +1,72 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanner
+
+// [START spanner_postgresql_dml_delete_returning]
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+func pgDeleteUsingDMLReturning(w io.Writer, db string) error {
+	ctx := context.Background()
+	client, err := spanner.NewClient(ctx, db)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	// Delete records from SINGERS table satisfying a
+	// particular condition and returns the SingerId
+	// and FullName column of the deleted records using
+	// 'RETURNING SingerId, FullName'.
+	// It is also possible to return all columns of all the
+	// deleted records by using 'RETURNING *'.
+	_, err = client.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		stmt := spanner.Statement{
+			SQL: `DELETE FROM Singers WHERE FirstName = 'Alice'
+			        RETURNING SingerId, FullName`,
+		}
+		iter := txn.Query(ctx, stmt)
+		defer iter.Stop()
+		for {
+			row, err := iter.Next()
+			if err == iterator.Done {
+				break
+			}
+			if err != nil {
+				return err
+			}
+			var (
+				singerID int64
+				fullName string
+			)
+			if err := row.Columns(&singerID, &fullName); err != nil {
+				return err
+			}
+			fmt.Fprintf(w, "%d %s\n", singerID, fullName)
+		}
+		fmt.Fprintf(w, "%d record(s) deleted.\n", iter.RowCount)
+		return nil
+	})
+	return err
+}
+
+// [END spanner_postgresql_dml_delete_returning]

--- a/spanner/spanner_snippets/spanner/pg_spanner_dml_insert_returning.go
+++ b/spanner/spanner_snippets/spanner/pg_spanner_dml_insert_returning.go
@@ -1,0 +1,72 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanner
+
+// [START spanner_postgresql_dml_insert_returning]
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+func pgInsertUsingDMLReturning(w io.Writer, db string) error {
+	ctx := context.Background()
+	client, err := spanner.NewClient(ctx, db)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	// Insert records into the SINGERS table and returns the
+	// generated column FullName of the inserted records using
+	// 'RETURNING FullName'.
+	// It is also possible to return all columns of all the
+	// inserted records by using 'RETURNING *'.
+	_, err = client.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		stmt := spanner.Statement{
+			SQL: `INSERT INTO Singers (SingerId, FirstName, LastName)
+			        VALUES (21, 'Melissa', 'Garcia'),
+			               (22, 'Russell', 'Morales'),
+			               (23, 'Jacqueline', 'Long'),
+			               (24, 'Dylan', 'Shaw')
+			        RETURNING FullName`,
+		}
+		iter := txn.Query(ctx, stmt)
+		defer iter.Stop()
+		for {
+			row, err := iter.Next()
+			if err == iterator.Done {
+				break
+			}
+			if err != nil {
+				return err
+			}
+			var fullName string
+			if err := row.Columns(&fullName); err != nil {
+				return err
+			}
+			fmt.Fprintf(w, "%s\n", fullName)
+		}
+		fmt.Fprintf(w, "%d record(s) inserted.\n", iter.RowCount)
+		return nil
+	})
+	return err
+}
+
+// [END spanner_postgresql_dml_insert_returning]

--- a/spanner/spanner_snippets/spanner/pg_spanner_dml_update_returning.go
+++ b/spanner/spanner_snippets/spanner/pg_spanner_dml_update_returning.go
@@ -1,0 +1,71 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanner
+
+// [START spanner_postgresql_dml_update_returning]
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+func pgUpdateUsingDMLReturning(w io.Writer, db string) error {
+	ctx := context.Background()
+	client, err := spanner.NewClient(ctx, db)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	// Update MarketingBudget column for records satisfying
+	// a particular condition and returns the modified
+	// MarketingBudget column of the updated records using
+	// 'RETURNING MarketingBudget'.
+	// It is also possible to return all columns of all the
+	// updated records by using 'RETURNING *'.
+	_, err = client.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		stmt := spanner.Statement{
+			SQL: `UPDATE Albums
+				SET MarketingBudget = MarketingBudget * 2
+				WHERE SingerId = 1 and AlbumId = 1
+				RETURNING MarketingBudget`,
+		}
+		iter := txn.Query(ctx, stmt)
+		defer iter.Stop()
+		for {
+			row, err := iter.Next()
+			if err == iterator.Done {
+				break
+			}
+			if err != nil {
+				return err
+			}
+			var marketingBudget int64
+			if err := row.Columns(&marketingBudget); err != nil {
+				return err
+			}
+			fmt.Fprintf(w, "%d\n", marketingBudget)
+		}
+		fmt.Fprintf(w, "%d record(s) updated.\n", iter.RowCount)
+		return nil
+	})
+	return err
+}
+
+// [END spanner_postgresql_dml_update_returning]

--- a/spanner/spanner_snippets/spanner/spanner_create_database.go
+++ b/spanner/spanner_snippets/spanner/spanner_create_database.go
@@ -45,7 +45,10 @@ func createDatabase(ctx context.Context, w io.Writer, db string) error {
 				SingerId   INT64 NOT NULL,
 				FirstName  STRING(1024),
 				LastName   STRING(1024),
-				SingerInfo BYTES(MAX)
+				SingerInfo BYTES(MAX),
+				FullName   STRING(2048) AS (
+					ARRAY_TO_STRING([FirstName, LastName], " ")
+				) STORED
 			) PRIMARY KEY (SingerId)`,
 			`CREATE TABLE Albums (
 				SingerId     INT64 NOT NULL,

--- a/spanner/spanner_snippets/spanner/spanner_dml_delete_returning.go
+++ b/spanner/spanner_snippets/spanner/spanner_dml_delete_returning.go
@@ -1,0 +1,72 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanner
+
+// [START spanner_dml_delete_returning]
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+func deleteUsingDMLReturning(w io.Writer, db string) error {
+	ctx := context.Background()
+	client, err := spanner.NewClient(ctx, db)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	// Delete records from SINGERS table satisfying a
+	// particular condition and returns the SingerId
+	// and FullName column of the deleted records using
+	// 'THEN RETURN SingerId, FullName'.
+	// It is also possible to return all columns of all the
+	// deleted records by using 'THEN RETURN *'.
+	_, err = client.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		stmt := spanner.Statement{
+			SQL: `DELETE FROM Singers WHERE FirstName = 'Alice'
+			        THEN RETURN SingerId, FullName`,
+		}
+		iter := txn.Query(ctx, stmt)
+		defer iter.Stop()
+		for {
+			row, err := iter.Next()
+			if err == iterator.Done {
+				break
+			}
+			if err != nil {
+				return err
+			}
+			var (
+				singerID int64
+				fullName string
+			)
+			if err := row.Columns(&singerID, &fullName); err != nil {
+				return err
+			}
+			fmt.Fprintf(w, "%d %s\n", singerID, fullName)
+		}
+		fmt.Fprintf(w, "%d record(s) deleted.\n", iter.RowCount)
+		return nil
+	})
+	return err
+}
+
+// [END spanner_dml_delete_returning]

--- a/spanner/spanner_snippets/spanner/spanner_dml_insert_returning.go
+++ b/spanner/spanner_snippets/spanner/spanner_dml_insert_returning.go
@@ -1,0 +1,72 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanner
+
+// [START spanner_dml_insert_returning]
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+func insertUsingDMLReturning(w io.Writer, db string) error {
+	ctx := context.Background()
+	client, err := spanner.NewClient(ctx, db)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	// Insert records into the SINGERS table and returns the
+	// generated column FullName of the inserted records using
+	// 'THEN RETURN FullName'.
+	// It is also possible to return all columns of all the
+	// inserted records by using 'THEN RETURN *'.
+	_, err = client.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		stmt := spanner.Statement{
+			SQL: `INSERT INTO Singers (SingerId, FirstName, LastName)
+			        VALUES (21, 'Melissa', 'Garcia'),
+			               (22, 'Russell', 'Morales'),
+			               (23, 'Jacqueline', 'Long'),
+			               (24, 'Dylan', 'Shaw')
+			        THEN RETURN FullName`,
+		}
+		iter := txn.Query(ctx, stmt)
+		defer iter.Stop()
+		for {
+			row, err := iter.Next()
+			if err == iterator.Done {
+				break
+			}
+			if err != nil {
+				return err
+			}
+			var fullName string
+			if err := row.Columns(&fullName); err != nil {
+				return err
+			}
+			fmt.Fprintf(w, "%s\n", fullName)
+		}
+		fmt.Fprintf(w, "%d record(s) inserted.\n", iter.RowCount)
+		return nil
+	})
+	return err
+}
+
+// [END spanner_dml_insert_returning]

--- a/spanner/spanner_snippets/spanner/spanner_dml_update_returning.go
+++ b/spanner/spanner_snippets/spanner/spanner_dml_update_returning.go
@@ -1,0 +1,71 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanner
+
+// [START spanner_dml_update_returning]
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+func updateUsingDMLReturning(w io.Writer, db string) error {
+	ctx := context.Background()
+	client, err := spanner.NewClient(ctx, db)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	// Update MarketingBudget column for records satisfying
+	// a particular condition and returns the modified
+	// MarketingBudget column of the updated records using
+	// 'THEN RETURN MarketingBudget'.
+	// It is also possible to return all columns of all the
+	// updated records by using 'THEN RETURN *'.
+	_, err = client.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		stmt := spanner.Statement{
+			SQL: `UPDATE Albums
+				SET MarketingBudget = MarketingBudget * 2
+				WHERE SingerId = 1 and AlbumId = 1
+				THEN RETURN MarketingBudget`,
+		}
+		iter := txn.Query(ctx, stmt)
+		defer iter.Stop()
+		for {
+			row, err := iter.Next()
+			if err == iterator.Done {
+				break
+			}
+			if err != nil {
+				return err
+			}
+			var marketingBudget int64
+			if err := row.Columns(&marketingBudget); err != nil {
+				return err
+			}
+			fmt.Fprintf(w, "%d\n", marketingBudget)
+		}
+		fmt.Fprintf(w, "%d record(s) updated.\n", iter.RowCount)
+		return nil
+	})
+	return err
+}
+
+// [END spanner_dml_update_returning]


### PR DESCRIPTION
Samples are provided for INSERT, DELETE, and UPDATE in both GoogleSQL and PostgreSQL dialects. To provide a more compelling example for the INSERT case, a generated column has been added in the "create_database" example so that the generated value can be returned in the INSERT examples. This changed the number of mutations generated for inserts to the Artists table, and the commitStats test case was updated as a result.