### PR TITLE
fix(pubsub): default value of LimitExceededBehavior

### DIFF
--- a/pubsub/topics/publish_flow_control.go
+++ b/pubsub/topics/publish_flow_control.go
@@ -40,7 +40,7 @@ func publishWithFlowControlSettings(w io.Writer, projectID, topicID string) erro
 	t.PublishSettings.FlowControlSettings = pubsub.FlowControlSettings{
 		MaxOutstandingMessages: 100,                     // default 1000
 		MaxOutstandingBytes:    10 * 1024 * 1024,        // default 0 (unlimited)
-		LimitExceededBehavior:  pubsub.FlowControlBlock, // default Block, other options: SignalError and Ignore
+		LimitExceededBehavior:  pubsub.FlowControlBlock, // default Ignore, other options: Block and SignalError
 	}
 
 	var wg sync.WaitGroup


### PR DESCRIPTION
This PR updates comments in sample codes.

Default value of pub/sub publish flow control has changed but sample codes were not updated.

https://github.com/googleapis/google-cloud-go/pull/5983
