### PR TITLE
fix(storagetransfer): use UTC for Schedule

### DIFF
--- a/storagetransfer/transfer_from_aws.go
+++ b/storagetransfer/transfer_from_aws.go
@@ -49,7 +49,7 @@ func transferFromAws(w io.Writer, projectID string, awsSourceBucket string, gcsS
 	jobDescription := "Transfers objects from an AWS bucket to a GCS bucket"
 
 	// The time to start the transfer
-	startTime := time.Now()
+	startTime := time.Now().UTC()
 
 	// The AWS access key credential, should be accessed via environment variable for security
 	awsAccessKeyID := os.Getenv("AWS_ACCESS_KEY_ID")

--- a/storagetransfer/transfer_to_nearline.go
+++ b/storagetransfer/transfer_to_nearline.go
@@ -50,7 +50,7 @@ func transferToNearline(w io.Writer, projectID string, gcsSourceBucket string, g
 	jobDescription := "Transfers objects that haven't been modified in 30 days to a Nearline bucket"
 
 	// The time to start the transfer
-	startTime := time.Now()
+	startTime := time.Now().UTC()
 
 	req := &storagetransferpb.CreateTransferJobRequest{
 		TransferJob: &storagetransferpb.TransferJob{


### PR DESCRIPTION
[Schedule](https://cloud.google.com/storage-transfer/docs/reference/rest/v1/transferJobs#schedule) Date and TimeOfDay fields require UTC, so the example code should guarantee UTC is used.