### PR TITLE
fix(pubsub): remove references to deprecated Synchronous field

### DIFF
--- a/pubsub/subscriptions/pull_concurrency.go
+++ b/pubsub/subscriptions/pull_concurrency.go
@@ -37,13 +37,15 @@ func pullMsgsConcurrencyControl(w io.Writer, projectID, subID string) error {
 
 	sub := client.Subscription(subID)
 	// Must set ReceiveSettings.Synchronous to false (or leave as default) to enable
-	// concurrency settings. Otherwise, NumGoroutines will be set to 1.
+	// concurrency pulling of messages. Otherwise, NumGoroutines will be set to 1.
 	sub.ReceiveSettings.Synchronous = false
 	// NumGoroutines determines the number of goroutines sub.Receive will spawn to pull
 	// messages.
 	sub.ReceiveSettings.NumGoroutines = 16
 	// MaxOutstandingMessages limits the number of concurrent handlers of messages.
 	// In this case, up to 8 unacked messages can be handled concurrently.
+	// Note, even in synchronous mode, messages pulled in a batch can still be handled
+	// concurrently.
 	sub.ReceiveSettings.MaxOutstandingMessages = 8
 
 	// Receive messages for 10 seconds, which simplifies testing.

--- a/pubsub/subscriptions/pull_settings.go
+++ b/pubsub/subscriptions/pull_settings.go
@@ -23,7 +23,7 @@ import (
 	"cloud.google.com/go/pubsub"
 )
 
-func pullMsgsSettings(w io.Writer, projectID, subID string) error {
+func pullMsgsFlowControlSettings(w io.Writer, projectID, subID string) error {
 	// projectID := "my-project-id"
 	// subID := "my-sub"
 	ctx := context.Background()
@@ -34,28 +34,21 @@ func pullMsgsSettings(w io.Writer, projectID, subID string) error {
 	defer client.Close()
 
 	sub := client.Subscription(subID)
-	sub.ReceiveSettings.Synchronous = true
 	// MaxOutstandingMessages is the maximum number of unprocessed messages the
-	// client will pull from the server before pausing.
+	// subscriber client will pull from the server before pausing. This also configures
+	// the maximum number of concurrent handlers for received messages.
 	//
-	// This is only guaranteed when ReceiveSettings.Synchronous is set to true.
-	// When Synchronous is set to false, the StreamingPull RPC is used which
-	// can pull a single large batch of messages at once that is greater than
-	// MaxOustandingMessages before pausing. For more info, see
-	// https://cloud.google.com/pubsub/docs/pull#streamingpull_dealing_with_large_backlogs_of_small_messages.
-	sub.ReceiveSettings.MaxOutstandingMessages = 10
+	// For more information, see https://cloud.google.com/pubsub/docs/pull#streamingpull_dealing_with_large_backlogs_of_small_messages.
+	sub.ReceiveSettings.MaxOutstandingMessages = 100
 	// MaxOutstandingBytes is the maximum size of unprocessed messages,
-	// that the client will pull from the server before pausing. Similar
-	// to MaxOutstandingMessages, this may be exceeded with a large batch
-	// of messages since we cannot control the size of a batch of messages
-	// from the server (even with the synchronous Pull RPC).
-	sub.ReceiveSettings.MaxOutstandingBytes = 1e10
+	// that the subscriber client will pull from the server before pausing.
+	sub.ReceiveSettings.MaxOutstandingBytes = 1e8
 	err = sub.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
 		fmt.Fprintf(w, "Got message: %q\n", string(msg.Data))
 		msg.Ack()
 	})
 	if err != nil {
-		return fmt.Errorf("Receive: %v", err)
+		return fmt.Errorf("sub.Receive: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
We deprecated `subscription.ReceiveSettings.Synchronous` a while back with the introduction of server side flow control. This PR updates the samples to no longer reference this and clarifies some behavior.