### PR TITLE
chore(functions/v2): migrate CORS sample to gen2

### DIFF
--- a/functions/http/cors.go
+++ b/functions/http/cors.go
@@ -20,6 +20,8 @@ package http
 import (
 	"fmt"
 	"net/http"
+
+	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 )
 
 // CORSEnabledFunction is an example of setting CORS headers.
@@ -38,6 +40,10 @@ func CORSEnabledFunction(w http.ResponseWriter, r *http.Request) {
 	// Set CORS headers for the main request.
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	fmt.Fprint(w, "Hello, World!")
+}
+
+func init() {
+	functions.HTTP("CORSEnabledFunction", CORSEnabledFunction)
 }
 
 // [END functions_http_cors]


### PR DESCRIPTION
Migrate https://cloud.google.com/functions/docs/samples/functions-http-cors#functions_http_cors-go example to gen2 signature using functions framework.

Tested, executes successfully with the command:
```
curl -m 70 -X POST https://garethgeorge-http-function-go-sehddnhvmq-uc.a.run.app \
-H "Authorization: bearer $(gcloud auth print-identity-token)" \
-H "Content-Type: application/json" \
-d '{
  "name": "Hello World"
}'
```
