### PR TITLE
fix(testing): Work around kokoro image changes

### DIFF
--- a/testing/kokoro/trampoline.sh
+++ b/testing/kokoro/trampoline.sh
@@ -20,13 +20,13 @@ date
 
 cd github/golang-samples || exit 1
 
-SIGNIFICANT_CHANGES="$(git --no-pager diff --name-only main..HEAD | grep -Ev '(\.md$|^\.github)' || true)"
+# SIGNIFICANT_CHANGES="$(git --no-pager diff --name-only main..HEAD | grep -Ev '(\.md$|^\.github)' || true)"
 
-# If this is a PR with only insignificant changes, don't run any tests.
-if [[ -n ${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-} ]] && [[ -z "$SIGNIFICANT_CHANGES" ]]; then
-  echo "No big changes. Not running any tests."
-  exit 0
-fi
+# # If this is a PR with only insignificant changes, don't run any tests.
+# if [[ -n ${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-} ]] && [[ -z "$SIGNIFICANT_CHANGES" ]]; then
+#   echo "No big changes. Not running any tests."
+#   exit 0
+# fi
 
 cd - || exit 1
 


### PR DESCRIPTION
Recent changes to Kokoro have caused this initial `git` command to error, resulting in no tests being run.

While we're skipping the check here, it is still done in `testing/kokoro/system_test.sh`, so I do not anticipate any cost increase over out previous baseline (prior to the breakage).