### PR TITLE
docs(storage): fix precondition comments

### DIFF
--- a/storage/objects/change_file_storage_class.go
+++ b/storage/objects/change_file_storage_class.go
@@ -41,7 +41,7 @@ func changeObjectStorageClass(w io.Writer, bucket, object string) error {
 	o := client.Bucket(bucket).Object(object)
 
 	// Optional: set a generation-match precondition to avoid potential race
-	// conditions and data corruptions. The request to upload is aborted if the
+	// conditions and data corruptions. The request to copy is aborted if the
 	// object's generation number does not match your precondition.
 	attrs, err := o.Attrs(ctx)
 	if err != nil {

--- a/storage/objects/change_object_csek_to_cmek.go
+++ b/storage/objects/change_object_csek_to_cmek.go
@@ -49,7 +49,7 @@ func сhangeObjectCSEKToKMS(w io.Writer, bucket, object string, encryptionKey []
 	o := client.Bucket(bucket).Object(object)
 
 	// Optional: set a generation-match precondition to avoid potential race
-	// conditions and data corruptions. The request to upload is aborted if the
+	// conditions and data corruptions. The request to copy is aborted if the
 	// object's generation number does not match your precondition.
 	attrs, err := o.Attrs(ctx)
 	if err != nil {

--- a/storage/objects/copy_file.go
+++ b/storage/objects/copy_file.go
@@ -44,7 +44,7 @@ func copyFile(w io.Writer, dstBucket, srcBucket, srcObject string) error {
 	dst := client.Bucket(dstBucket).Object(dstObject)
 
 	// Optional: set a generation-match precondition to avoid potential race
-	// conditions and data corruptions. The request to upload is aborted if the
+	// conditions and data corruptions. The request to copy is aborted if the
 	// object's generation number does not match your precondition.
 	// For a dst object that does not yet exist, set the DoesNotExist precondition.
 	dst = dst.If(storage.Conditions{DoesNotExist: true})

--- a/storage/objects/copy_file_archived_generation.go
+++ b/storage/objects/copy_file_archived_generation.go
@@ -46,7 +46,7 @@ func copyOldVersionOfObject(w io.Writer, bucket, srcObject, dstObject string, ge
 	dst := client.Bucket(bucket).Object(dstObject)
 
 	// Optional: set a generation-match precondition to avoid potential race
-	// conditions and data corruptions. The request to upload is aborted if the
+	// conditions and data corruptions. The request to copy is aborted if the
 	// object's generation number does not match your precondition.
 	// For a dst object that does not yet exist, set the DoesNotExist precondition.
 	dst = dst.If(storage.Conditions{DoesNotExist: true})

--- a/storage/objects/delete_file.go
+++ b/storage/objects/delete_file.go
@@ -41,8 +41,8 @@ func deleteFile(w io.Writer, bucket, object string) error {
 	o := client.Bucket(bucket).Object(object)
 
 	// Optional: set a generation-match precondition to avoid potential race
-	// conditions and data corruptions. The request to upload is aborted if the
-	// object's generation number does not match your precondition.
+	// conditions and data corruptions. The request to delete the file is aborted
+	// if the object's generation number does not match your precondition.
 	attrs, err := o.Attrs(ctx)
 	if err != nil {
 		return fmt.Errorf("object.Attrs: %v", err)

--- a/storage/objects/move_file.go
+++ b/storage/objects/move_file.go
@@ -43,8 +43,8 @@ func moveFile(w io.Writer, bucket, object string) error {
 	dst := client.Bucket(bucket).Object(dstName)
 
 	// Optional: set a generation-match precondition to avoid potential race
-	// conditions and data corruptions. The request to upload is aborted if the
-	// object's generation number does not match your precondition.
+	// conditions and data corruptions. The request to copy the file is aborted
+	// if the object's generation number does not match your precondition.
 	// For a dst object that does not yet exist, set the DoesNotExist precondition.
 	dst = dst.If(storage.Conditions{DoesNotExist: true})
 	// If the destination object already exists in your bucket, set instead a

--- a/storage/objects/release_event_based_hold.go
+++ b/storage/objects/release_event_based_hold.go
@@ -40,9 +40,9 @@ func releaseEventBasedHold(w io.Writer, bucket, object string) error {
 
 	o := client.Bucket(bucket).Object(object)
 
-	// Optional: set a generation-match precondition to avoid potential race
-	// conditions and data corruptions. The request to upload is aborted if the
-	// object's generation number does not match your precondition.
+	// Optional: set a metageneration-match precondition to avoid potential race
+	// conditions and data corruptions. The request to update is aborted if the
+	// object's metageneration does not match your precondition.
 	attrs, err := o.Attrs(ctx)
 	if err != nil {
 		return fmt.Errorf("object.Attrs: %v", err)

--- a/storage/objects/release_temporary_hold.go
+++ b/storage/objects/release_temporary_hold.go
@@ -40,9 +40,9 @@ func releaseTemporaryHold(w io.Writer, bucket, object string) error {
 
 	o := client.Bucket(bucket).Object(object)
 
-	// Optional: set a generation-match precondition to avoid potential race
-	// conditions and data corruptions. The request to upload is aborted if the
-	// object's generation number does not match your precondition.
+	// Optional: set a metageneration-match precondition to avoid potential race
+	// conditions and data corruptions. The request to update is aborted if the
+	// object's metageneration does not match your precondition.
 	attrs, err := o.Attrs(ctx)
 	if err != nil {
 		return fmt.Errorf("object.Attrs: %v", err)

--- a/storage/objects/rotate_encryption_key.go
+++ b/storage/objects/rotate_encryption_key.go
@@ -43,7 +43,7 @@ func rotateEncryptionKey(w io.Writer, bucket, object string, key, newKey []byte)
 	o := client.Bucket(bucket).Object(object)
 
 	// Optional: set a generation-match precondition to avoid potential race
-	// conditions and data corruptions. The request to upload is aborted if the
+	// conditions and data corruptions. The request to copy is aborted if the
 	// object's generation number does not match your precondition.
 	attrs, err := o.Attrs(ctx)
 	if err != nil {

--- a/storage/objects/set_event_based_hold.go
+++ b/storage/objects/set_event_based_hold.go
@@ -40,9 +40,9 @@ func setEventBasedHold(w io.Writer, bucket, object string) error {
 
 	o := client.Bucket(bucket).Object(object)
 
-	// Optional: set a generation-match precondition to avoid potential race
-	// conditions and data corruptions. The request to upload is aborted if the
-	// object's generation number does not match your precondition.
+	// Optional: set a metageneration-match precondition to avoid potential race
+	// conditions and data corruptions. The request to update is aborted if the
+	// object's metageneration does not match your precondition.
 	attrs, err := o.Attrs(ctx)
 	if err != nil {
 		return fmt.Errorf("object.Attrs: %v", err)

--- a/storage/objects/set_metadata.go
+++ b/storage/objects/set_metadata.go
@@ -40,9 +40,9 @@ func setMetadata(w io.Writer, bucket, object string) error {
 
 	o := client.Bucket(bucket).Object(object)
 
-	// Optional: set a generation-match precondition to avoid potential race
-	// conditions and data corruptions. The request to upload is aborted if the
-	// object's generation number does not match your precondition.
+	// Optional: set a metageneration-match precondition to avoid potential race
+	// conditions and data corruptions. The request to update is aborted if the
+	// object's metageneration does not match your precondition.
 	attrs, err := o.Attrs(ctx)
 	if err != nil {
 		return fmt.Errorf("object.Attrs: %v", err)

--- a/storage/objects/set_temporary_hold.go
+++ b/storage/objects/set_temporary_hold.go
@@ -40,9 +40,9 @@ func setTemporaryHold(w io.Writer, bucket, object string) error {
 
 	o := client.Bucket(bucket).Object(object)
 
-	// Optional: set a generation-match precondition to avoid potential race
-	// conditions and data corruptions. The request to upload is aborted if the
-	// object's generation number does not match your precondition.
+	// Optional: set a metageneration-match precondition to avoid potential race
+	// conditions and data corruptions. The request to update is aborted if the
+	// object's metageneration does not match your precondition.
 	attrs, err := o.Attrs(ctx)
 	if err != nil {
 		return fmt.Errorf("object.Attrs: %v", err)


### PR DESCRIPTION
- fix comments that reference "upload" to reflect the correct operation being performed
- fix comments that mention "generation" instead of "metageneration" where applicable