### PR TITLE
chore(functions/security): use go 1.18, not 1.13

### DIFF
--- a/functions/security/go.mod
+++ b/functions/security/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/functions/security
 
-go 1.19
+go 1.18
 
 require google.golang.org/api v0.104.0
 

--- a/functions/security/security_system_test.go
+++ b/functions/security/security_system_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 )
 
-const RuntimeVersion = "go113"
+const RuntimeVersion = "go118"
 const FunctionsRegion = "us-central1"
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
fixes #2817