### PR TITLE
chore: remove explicit mod=vendor

### DIFF
--- a/internal/cloudrunci/testingapp/Dockerfile
+++ b/internal/cloudrunci/testingapp/Dockerfile
@@ -15,7 +15,7 @@
 FROM golang:1.17 as builder
 WORKDIR /app
 COPY . ./
-RUN CGO_ENABLED=0 GOOS=linux go build -mod=vendor -v -o server
+RUN CGO_ENABLED=0 GOOS=linux go build -v -o server
 
 FROM alpine:3
 RUN apk add --no-cache ca-certificates


### PR DESCRIPTION
vendoring is causing test failures due to direct/indirect dependencies.
