### PR TITLE
Add helloworld sample for Go 1.18 preview

### DIFF
--- a/appengine_flexible/preview/helloworld/app.yaml
+++ b/appengine_flexible/preview/helloworld/app.yaml
@@ -1,0 +1,32 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+runtime: go
+env: flex
+
+runtime_config:
+  operating_system: 'ubuntu22'
+  runtime_version: '1.18'
+
+# This sample incurs costs to run on the App Engine flexible environment. 
+# The settings below are to reduce costs during testing and are not appropriate
+# for production use. For more information, see:
+# https://cloud.google.com/appengine/docs/flexible/python/configuring-your-app-with-app-yaml
+manual_scaling:
+  instances: 1
+resources:
+  cpu: 1
+  memory_gb: 0.5
+  disk_size_gb: 10
+

--- a/appengine_flexible/preview/helloworld/go.mod
+++ b/appengine_flexible/preview/helloworld/go.mod
@@ -1,0 +1,4 @@
+module helloworld
+
+go 1.18
+

--- a/appengine_flexible/preview/helloworld/helloworld.go
+++ b/appengine_flexible/preview/helloworld/helloworld.go
@@ -1,0 +1,44 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Sample helloworld is a basic App Engine flexible app.
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	http.HandleFunc("/", handle)
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	log.Printf("Listening on port %s", port)
+	if err := http.ListenAndServe(":"+port, nil); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func handle(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	fmt.Fprint(w, "Hello world!")
+}
+


### PR DESCRIPTION
Add a simple sample for Go 1.18 preview version on GAE Flex.

This sample app will work out of the box once it is released -- of course, it is not released yet. Later, this can replace the existing helloworld sample, by moving it out of the preview folder. I plan to migrate the other samples into the preview folder, too.

This app was essentially created by taking the existing helloworld app for Flex, bumping it up to 1.18, adding a `go.mod` file, and adding the appropriate `app.yaml` settings.