### PR TITLE
fix(testing): stop running all tests on insignificant changes

### DIFF
--- a/testing/kokoro/system_tests.sh
+++ b/testing/kokoro/system_tests.sh
@@ -43,7 +43,7 @@ SIGNIFICANT_CHANGES=$(git --no-pager diff --name-only main..HEAD | grep -Ev '(\.
 # CHANGED_DIRS is the list of significant top-level directories that changed,
 # but weren't deleted by the current PR.
 # CHANGED_DIRS will be empty when run on main.
-CHANGED_DIRS=$(echo "$SIGNIFICANT_CHANGES" | tr ' ' '\n' | grep "/" | cut -d/ -f1 | sort -u | tr '\n' ' ' | xargs ls -d 2>/dev/null || true)
+CHANGED_DIRS=$(echo "$SIGNIFICANT_CHANGES" | tr ' ' '\n' | grep "/" | cut -d/ -f1 | sort -u | tr '\n' ' ' | xargs --no-run-if-empty ls -d 2>/dev/null || true)
 
 # List all modules in changed directories.
 # If running on main will collect all modules in the repo, including the root module.


### PR DESCRIPTION
When changing .github, for example, the prior behavor resulted in
CHANGED_DIRS=., which would find all modules below, and run all tests.

this was observed in the presubmit testing of #3002

