### PR TITLE
fix(video,testing): use Error, so retries actually happen

### DIFF
--- a/videointelligence/video_analyze/video_analyze_test.go
+++ b/videointelligence/video_analyze/video_analyze_test.go
@@ -43,7 +43,7 @@ func TestAnalyzeShotChange(t *testing.T) {
 		err := shotChangeURI(&buf, catVideo)
 
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 		assert(buf, want, t)
 	})
@@ -57,7 +57,7 @@ func TestAnalyzeLabelURI(t *testing.T) {
 		var buf bytes.Buffer
 		err := labelURI(&buf, catVideo)
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 		assert(buf, want, t)
 	})
@@ -71,7 +71,7 @@ func TestAnalyzeExplicitContentURI(t *testing.T) {
 		var buf bytes.Buffer
 		err := explicitContentURI(&buf, catVideo)
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 		assert(buf, want, t)
 	})
@@ -85,7 +85,7 @@ func TestAnalyzeSpeechTranscriptionURI(t *testing.T) {
 		var buf bytes.Buffer
 		err := speechTranscriptionURI(&buf, googleworkVideo)
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 		assert(buf, want, t)
 	})


### PR DESCRIPTION
Fatal() bypasses the retry mechanism, so we dont actually get retried.

