### PR TITLE
fix(videointelligence): use retryable Error method

### DIFF
--- a/videointelligence/video_analyze/video_analyze_test.go
+++ b/videointelligence/video_analyze/video_analyze_test.go
@@ -43,7 +43,7 @@ func TestAnalyzeShotChange(t *testing.T) {
 		err := shotChangeURI(&buf, catVideo)
 
 		if err != nil {
-			t.Error(err)
+			r.Errorf("%v", err)
 		}
 		assert(buf, want, t)
 	})
@@ -57,7 +57,7 @@ func TestAnalyzeLabelURI(t *testing.T) {
 		var buf bytes.Buffer
 		err := labelURI(&buf, catVideo)
 		if err != nil {
-			t.Error(err)
+			r.Errorf("%v", err)
 		}
 		assert(buf, want, t)
 	})
@@ -71,7 +71,7 @@ func TestAnalyzeExplicitContentURI(t *testing.T) {
 		var buf bytes.Buffer
 		err := explicitContentURI(&buf, catVideo)
 		if err != nil {
-			t.Error(err)
+			r.Errorf("%v", err)
 		}
 		assert(buf, want, t)
 	})
@@ -85,7 +85,7 @@ func TestAnalyzeSpeechTranscriptionURI(t *testing.T) {
 		var buf bytes.Buffer
 		err := speechTranscriptionURI(&buf, googleworkVideo)
 		if err != nil {
-			t.Error(err)
+			r.Errorf("%v", err)
 		}
 		assert(buf, want, t)
 	})


### PR DESCRIPTION
t.Error() fails the test, and does not permit retry. r.Errorf() will trigger a retry instead of a test failure.

