### PR TITLE
fix(appengine): fix missing context initiatilization in capability.go

### DIFF
--- a/docs/appengine/capabilities/capability.go
+++ b/docs/appengine/capabilities/capability.go
@@ -18,13 +18,14 @@ import (
 	"context"
 	"net/http"
 
-	"google.golang.org/appengine"
-	"google.golang.org/appengine/capability"
+	"google.golang.org/appengine/v2"
+	"google.golang.org/appengine/v2/capability"
 )
 
 // [START gae_go_capabilities_lookup]
 func handler(w http.ResponseWriter, r *http.Request) {
 	ctx := appengine.NewContext(r)
+	// Check if the Datastore API is available
 	if !capability.Enabled(ctx, "datastore_v3", "*") {
 		http.Error(w, "This service is currently unavailable.", 503)
 		return
@@ -35,11 +36,11 @@ func handler(w http.ResponseWriter, r *http.Request) {
 // [END gae_go_capabilities_lookup]
 
 // [START gae_go_capabilities_mode]
-func example() {
-	var ctx context.Context
-
+func checkDatastoreMode(w http.ResponseWriter, r *http.Request) {
+	ctx := appengine.NewContext(r)
+	// Check if the Datastore service is in read-only mode.
 	if !capability.Enabled(ctx, "datastore_v3", "write") {
-		// Datastore is in read-only mode.
+               // Datastore is in read-only mode. 
 	}
 
 }

--- a/docs/appengine/capabilities/capability.go
+++ b/docs/appengine/capabilities/capability.go
@@ -39,7 +39,7 @@ func checkDatastoreMode(w http.ResponseWriter, r *http.Request) {
 	ctx := appengine.NewContext(r)
 	// Check if the Datastore service is in read-only mode.
 	if !capability.Enabled(ctx, "datastore_v3", "write") {
-               // Datastore is in read-only mode. 
+		// Datastore is in read-only mode.
 	}
 
 }

--- a/docs/appengine/capabilities/capability.go
+++ b/docs/appengine/capabilities/capability.go
@@ -15,7 +15,6 @@
 package sample
 
 import (
-	"context"
 	"net/http"
 
 	"google.golang.org/appengine/v2"


### PR DESCRIPTION
## Description

making this code runnable for c.g.c; 

Discussion about whether we should include these samples and we should probably revisit as the API docs https://cloud.google.com/appengine/docs/standard/go/reference/services/bundled/latest/capability have almost the exact same detail, so might be better to archive these samples. That's a longer effort, so in the short term, fix this sample so it's runnable in the docs with a little more user friendly comments.

Totally worked with @grayside on this, but all the mistakes are all my fault/misunderstanding (if there are any). 

## Checklist
- [X] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [X] Please **merge** this PR for me once it is approved
