### PR TITLE
chore(fixit): Go Error Visibility for getting-started/bookshelf

### DIFF
--- a/getting-started/bookshelf/bookshelf.go
+++ b/getting-started/bookshelf/bookshelf.go
@@ -81,7 +81,7 @@ func NewBookshelf(projectID string, db BookDatabase) (*Bookshelf, error) {
 	bucketName := projectID + "_bucket"
 	storageClient, err := storage.NewClient(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("storage.NewClient: %v", err)
+		return nil, fmt.Errorf("storage.NewClient: %w", err)
 	}
 
 	errorClient, err := errorreporting.NewClient(ctx, projectID, errorreporting.Config{
@@ -91,7 +91,7 @@ func NewBookshelf(projectID string, db BookDatabase) (*Bookshelf, error) {
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("errorreporting.NewClient: %v", err)
+		return nil, fmt.Errorf("errorreporting.NewClient: %w", err)
 	}
 
 	b := &Bookshelf{

--- a/getting-started/bookshelf/db_firestore.go
+++ b/getting-started/bookshelf/db_firestore.go
@@ -46,7 +46,7 @@ func newFirestoreDB(client *firestore.Client) (*firestoreDB, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("firestoredb: could not connect: %v", err)
+		return nil, fmt.Errorf("firestoredb: could not connect: %w", err)
 	}
 	return &firestoreDB{
 		client:     client,
@@ -63,7 +63,7 @@ func (db *firestoreDB) Close(context.Context) error {
 func (db *firestoreDB) GetBook(ctx context.Context, id string) (*Book, error) {
 	ds, err := db.client.Collection(db.collection).Doc(id).Get(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("firestoredb: Get: %v", err)
+		return nil, fmt.Errorf("firestoredb: Get: %w", err)
 	}
 	b := &Book{}
 	ds.DataTo(b)
@@ -77,7 +77,7 @@ func (db *firestoreDB) AddBook(ctx context.Context, b *Book) (id string, err err
 	ref := db.client.Collection(db.collection).NewDoc()
 	b.ID = ref.ID
 	if _, err := ref.Create(ctx, b); err != nil {
-		return "", fmt.Errorf("Create: %v", err)
+		return "", fmt.Errorf("Create: %w", err)
 	}
 	return ref.ID, nil
 }
@@ -85,7 +85,7 @@ func (db *firestoreDB) AddBook(ctx context.Context, b *Book) (id string, err err
 // DeleteBook removes a given book by its ID.
 func (db *firestoreDB) DeleteBook(ctx context.Context, id string) error {
 	if _, err := db.client.Collection(db.collection).Doc(id).Delete(ctx); err != nil {
-		return fmt.Errorf("firestore: Delete: %v", err)
+		return fmt.Errorf("firestore: Delete: %w", err)
 	}
 	return nil
 }
@@ -93,7 +93,7 @@ func (db *firestoreDB) DeleteBook(ctx context.Context, id string) error {
 // UpdateBook updates the entry for a given book.
 func (db *firestoreDB) UpdateBook(ctx context.Context, b *Book) error {
 	if _, err := db.client.Collection(db.collection).Doc(b.ID).Set(ctx, b); err != nil {
-		return fmt.Errorf("firestsore: Set: %v", err)
+		return fmt.Errorf("firestsore: Set: %w", err)
 	}
 	return nil
 }
@@ -109,7 +109,7 @@ func (db *firestoreDB) ListBooks(ctx context.Context) ([]*Book, error) {
 			break
 		}
 		if err != nil {
-			return nil, fmt.Errorf("firestoredb: could not list books: %v", err)
+			return nil, fmt.Errorf("firestoredb: could not list books: %w", err)
 		}
 		b := &Book{}
 		doc.DataTo(b)

--- a/getting-started/bookshelf/main.go
+++ b/getting-started/bookshelf/main.go
@@ -129,7 +129,7 @@ func (b *Bookshelf) bookFromRequest(r *http.Request) (*Book, error) {
 	}
 	book, err := b.DB.GetBook(ctx, id)
 	if err != nil {
-		return nil, fmt.Errorf("could not find book: %v", err)
+		return nil, fmt.Errorf("could not find book: %w", err)
 	}
 	return book, nil
 }
@@ -167,7 +167,7 @@ func (b *Bookshelf) bookFromForm(r *http.Request) (*Book, error) {
 	ctx := r.Context()
 	imageURL, err := b.uploadFileFromForm(ctx, r)
 	if err != nil {
-		return nil, fmt.Errorf("could not upload file: %v", err)
+		return nil, fmt.Errorf("could not upload file: %w", err)
 	}
 	if imageURL == "" {
 		imageURL = r.FormValue("imageURL")
@@ -203,7 +203,7 @@ func (b *Bookshelf) uploadFileFromForm(ctx context.Context, r *http.Request) (ur
 		if err == storage.ErrBucketNotExist {
 			return "", fmt.Errorf("bucket %q does not exist: check bookshelf.go", b.StorageBucketName)
 		}
-		return "", fmt.Errorf("could not get bucket: %v", err)
+		return "", fmt.Errorf("could not get bucket: %w", err)
 	}
 
 	// random filename, retaining existing extension.

--- a/getting-started/bookshelf/template.go
+++ b/getting-started/bookshelf/template.go
@@ -30,7 +30,7 @@ func parseTemplate(filename string) *appTemplate {
 	path := filepath.Join("templates", filename)
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
-		panic(fmt.Errorf("could not read template: %v", err))
+		panic(fmt.Errorf("could not read template: %w", err))
 	}
 	template.Must(tmpl.New("body").Parse(string(b)))
 


### PR DESCRIPTION
## Description

chore(fixit): Go Error Visibility for getting-started/bookshelf. It converts %v to %w whenever it's supported.

## Checklist
- [X] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [X] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [X] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [X] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [X] Please **merge** this PR for me once it is approved
