### PR TITLE
fix(videointelligence): skip failing tests.

### DIFF
--- a/videointelligence/video_analyze/video_analyze_test.go
+++ b/videointelligence/video_analyze/video_analyze_test.go
@@ -35,6 +35,7 @@ func assert(buf bytes.Buffer, want string, t *testing.T) {
 }
 
 func TestAnalyzeShotChange(t *testing.T) {
+	t.Skip("see GoogleCloudPlatform/golang-samples#3049")
 	testutil.EndToEndTest(t)
 
 	testutil.Retry(t, 10, time.Minute, func(r *testutil.R) {
@@ -50,6 +51,7 @@ func TestAnalyzeShotChange(t *testing.T) {
 }
 
 func TestAnalyzeLabelURI(t *testing.T) {
+	t.Skip("see GoogleCloudPlatform/golang-samples#3049")
 	testutil.EndToEndTest(t)
 
 	testutil.Retry(t, 10, time.Minute, func(r *testutil.R) {
@@ -64,6 +66,7 @@ func TestAnalyzeLabelURI(t *testing.T) {
 }
 
 func TestAnalyzeExplicitContentURI(t *testing.T) {
+	t.Skip("see GoogleCloudPlatform/golang-samples#3049")
 	testutil.EndToEndTest(t)
 
 	testutil.Retry(t, 10, time.Minute, func(r *testutil.R) {
@@ -78,6 +81,7 @@ func TestAnalyzeExplicitContentURI(t *testing.T) {
 }
 
 func TestAnalyzeSpeechTranscriptionURI(t *testing.T) {
+	t.Skip("see GoogleCloudPlatform/golang-samples#3049")
 	testutil.EndToEndTest(t)
 
 	testutil.Retry(t, 10, time.Minute, func(r *testutil.R) {


### PR DESCRIPTION
see #3049 for longer context. skipping these tests until we fix them.
