### PR TITLE
chore(fixit): Go Error Visibility for videointelligence/video_analyze

### DIFF
--- a/videointelligence/video_analyze/video_analyze.go
+++ b/videointelligence/video_analyze/video_analyze.go
@@ -31,7 +31,7 @@ func label(w io.Writer, file string) error {
 	ctx := context.Background()
 	client, err := video.NewClient(ctx)
 	if err != nil {
-		return fmt.Errorf("video.NewClient: %v", err)
+		return fmt.Errorf("video.NewClient: %w", err)
 	}
 	defer client.Close()
 
@@ -47,12 +47,12 @@ func label(w io.Writer, file string) error {
 		InputContent: fileBytes,
 	})
 	if err != nil {
-		return fmt.Errorf("AnnotateVideo: %v", err)
+		return fmt.Errorf("AnnotateVideo: %w", err)
 	}
 
 	resp, err := op.Wait(ctx)
 	if err != nil {
-		return fmt.Errorf("Wait: %v", err)
+		return fmt.Errorf("Wait: %w", err)
 	}
 
 	printLabels := func(labels []*videopb.LabelAnnotation) {

--- a/videointelligence/video_analyze/video_analyze_gcs.go
+++ b/videointelligence/video_analyze/video_analyze_gcs.go
@@ -30,7 +30,7 @@ func labelURI(w io.Writer, file string) error {
 	ctx := context.Background()
 	client, err := video.NewClient(ctx)
 	if err != nil {
-		return fmt.Errorf("video.NewClient: %v", err)
+		return fmt.Errorf("video.NewClient: %w", err)
 	}
 	defer client.Close()
 
@@ -41,12 +41,12 @@ func labelURI(w io.Writer, file string) error {
 		InputUri: file,
 	})
 	if err != nil {
-		return fmt.Errorf("AnnotateVideo: %v", err)
+		return fmt.Errorf("AnnotateVideo: %w", err)
 	}
 
 	resp, err := op.Wait(ctx)
 	if err != nil {
-		return fmt.Errorf("Wait: %v", err)
+		return fmt.Errorf("Wait: %w", err)
 	}
 
 	printLabels := func(labels []*videopb.LabelAnnotation) {


### PR DESCRIPTION
## Description

Fixes b/281110472

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [ ] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
