### PR TITLE
feat(dlp): added a sample for dlp inspect image listed info types

### DIFF
--- a/dlp/snippets/inspect/inspect_image_listed_infotypes.go
+++ b/dlp/snippets/inspect/inspect_image_listed_infotypes.go
@@ -1,0 +1,94 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package inspect
+
+// [START dlp_inspect_image_listed_infotypes]
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	dlp "cloud.google.com/go/dlp/apiv2"
+	"cloud.google.com/go/dlp/apiv2/dlppb"
+)
+
+// inspectImageFileListedInfoTypes inspects an image for sensitive data listed infoTypes
+func inspectImageFileListedInfoTypes(w io.Writer, projectID, filePath string) error {
+	// projectId := "my-project-id"
+	// filePath := "inspect/testdata/image.jpg"
+
+	ctx := context.Background()
+
+	// Initialize a client once and reuse it to send multiple requests. Clients
+	// are safe to use across goroutines. When the client is no longer needed,
+	// call the Close method to cleanup its resources.
+	client, err := dlp.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Closing the client safely cleans up background resources.
+	defer client.Close()
+
+	// Read a image file
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+
+	// Specify the type and content to be inspected.
+	item := &dlppb.ContentItem{
+		DataItem: &dlppb.ContentItem_ByteItem{
+			ByteItem: &dlppb.ByteContentItem{
+				Type: dlppb.ByteContentItem_IMAGE_JPEG,
+				Data: data,
+			},
+		},
+	}
+
+	// Construct the configuration for the Inspect request.
+	inspectConfig := &dlppb.InspectConfig{
+		InfoTypes: []*dlppb.InfoType{
+			{Name: "PHONE_NUMBER"},
+			{Name: "EMAIL_ADDRESS"},
+			{Name: "US_SOCIAL_SECURITY_NUMBER"},
+		},
+		IncludeQuote: true,
+	}
+
+	// Construct the Inspect request to be sent by the client.
+	req := &dlppb.InspectContentRequest{
+		Parent:        fmt.Sprintf("projects/%s/locations/global", projectID),
+		Item:          item,
+		InspectConfig: inspectConfig,
+	}
+
+	// Send the request.
+	resp, err := client.InspectContent(ctx, req)
+	if err != nil {
+		return fmt.Errorf("InspectContent: %v", err)
+	}
+
+	// Process the results.
+	fmt.Fprintf(w, "Findings: %d\n", len(resp.Result.Findings))
+	for _, f := range resp.Result.Findings {
+		fmt.Fprintf(w, "\tQoute: %s\n", f.Quote)
+		fmt.Fprintf(w, "\tInfo type: %s\n", f.InfoType.Name)
+		fmt.Fprintf(w, "\tLikelihood: %s\n", f.Likelihood)
+	}
+	return nil
+}
+
+// [END dlp_inspect_image_listed_infotypes]

--- a/dlp/snippets/inspect/inspect_image_listed_infotypes.go
+++ b/dlp/snippets/inspect/inspect_image_listed_infotypes.go
@@ -24,7 +24,7 @@ import (
 	"cloud.google.com/go/dlp/apiv2/dlppb"
 )
 
-// inspectImageFileListedInfoTypes inspects an image for sensitive data listed infoTypes
+// inspectImageFileListedInfoTypes inspects an image for sensitive data listed infoTypes.
 func inspectImageFileListedInfoTypes(w io.Writer, projectID, filePath string) error {
 	// projectId := "my-project-id"
 	// filePath := "inspect/testdata/image.jpg"

--- a/dlp/snippets/inspect/inspect_test.go
+++ b/dlp/snippets/inspect/inspect_test.go
@@ -360,3 +360,24 @@ func TestInspectStringCustomOmitOverlap(t *testing.T) {
 		t.Errorf("inspectStringCustomOmitOverlap got %q, want %q", got, want)
 	}
 }
+
+func TestInspectImageFileListedInfoTypes(t *testing.T) {
+	tc := testutil.SystemTest(t)
+	buf := new(bytes.Buffer)
+	pathToImage := "./testdata/image.jpg"
+
+	if err := inspectImageFileListedInfoTypes(buf, tc.ProjectID, pathToImage); err != nil {
+		t.Fatal(err)
+	}
+
+	got := buf.String()
+	if want := "Info type: PHONE_NUMBER"; !strings.Contains(got, want) {
+		t.Errorf("inspectTextFile got %q, want %q", got, want)
+	}
+	if want := "Info type: EMAIL_ADDRESS"; !strings.Contains(got, want) {
+		t.Errorf("inspectTextFile got %q, want %q", got, want)
+	}
+	if want := "Info type: US_SOCIAL_SECURITY_NUMBER"; !strings.Contains(got, want) {
+		t.Errorf("inspectTextFile got %q, want %q", got, want)
+	}
+}

--- a/dlp/snippets/inspect/inspect_test.go
+++ b/dlp/snippets/inspect/inspect_test.go
@@ -279,9 +279,9 @@ func TestInspectBigquery(t *testing.T) {
 
 func TestInspectPhoneNumber(t *testing.T) {
 	tc := testutil.SystemTest(t)
-	buf := new(bytes.Buffer)
+	var buf bytes.Buffer
 
-	if err := inspectPhoneNumber(buf, tc.ProjectID, "I'm Gary and my phone number is (415) 555-0890"); err != nil {
+	if err := inspectPhoneNumber(&buf, tc.ProjectID, "I'm Gary and my phone number is (415) 555-0890"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -293,9 +293,9 @@ func TestInspectPhoneNumber(t *testing.T) {
 
 func TestInspectStringCustomHotWord(t *testing.T) {
 	tc := testutil.SystemTest(t)
-	buf := new(bytes.Buffer)
+	var buf bytes.Buffer
 
-	if err := inspectStringCustomHotWord(buf, tc.ProjectID, "patient name: John Doe", "patient", "PERSON_NAME"); err != nil {
+	if err := inspectStringCustomHotWord(&buf, tc.ProjectID, "patient name: John Doe", "patient", "PERSON_NAME"); err != nil {
 		t.Errorf("inspectStringCustomHotWord: %v", err)
 	}
 	got := buf.String()
@@ -306,9 +306,9 @@ func TestInspectStringCustomHotWord(t *testing.T) {
 
 func TestInspectStringWithExclusionDictSubstring(t *testing.T) {
 	tc := testutil.SystemTest(t)
-	buf := new(bytes.Buffer)
+	var buf bytes.Buffer
 
-	if err := inspectStringWithExclusionDictSubstring(buf, tc.ProjectID, "Some email addresses: gary@example.com, TEST@example.com", []string{"TEST"}); err != nil {
+	if err := inspectStringWithExclusionDictSubstring(&buf, tc.ProjectID, "Some email addresses: gary@example.com, TEST@example.com", []string{"TEST"}); err != nil {
 		t.Fatal(err)
 	}
 	got := buf.String()
@@ -324,9 +324,9 @@ func TestInspectStringWithExclusionDictSubstring(t *testing.T) {
 
 func TestInspectStringOmitOverlap(t *testing.T) {
 	tc := testutil.SystemTest(t)
-	buf := new(bytes.Buffer)
+	var buf bytes.Buffer
 
-	if err := inspectStringOmitOverlap(buf, tc.ProjectID, "gary@example.com"); err != nil {
+	if err := inspectStringOmitOverlap(&buf, tc.ProjectID, "gary@example.com"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -342,9 +342,9 @@ func TestInspectStringOmitOverlap(t *testing.T) {
 
 func TestInspectStringCustomOmitOverlap(t *testing.T) {
 	tc := testutil.SystemTest(t)
-	buf := new(bytes.Buffer)
+	var buf bytes.Buffer
 
-	if err := inspectStringCustomOmitOverlap(buf, tc.ProjectID, "Name: Jane Doe. Name: Larry Page.", "VIP_DETECTOR", "PERSON_NAME", "Larry Page|Sergey Brin"); err != nil {
+	if err := inspectStringCustomOmitOverlap(&buf, tc.ProjectID, "Name: Jane Doe. Name: Larry Page.", "VIP_DETECTOR", "PERSON_NAME", "Larry Page|Sergey Brin"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -363,10 +363,10 @@ func TestInspectStringCustomOmitOverlap(t *testing.T) {
 
 func TestInspectImageFileListedInfoTypes(t *testing.T) {
 	tc := testutil.SystemTest(t)
-	buf := new(bytes.Buffer)
-	pathToImage := "./testdata/image.jpg"
+	var buf bytes.Buffer
+	pathToImage := "testdata/test.png"
 
-	if err := inspectImageFileListedInfoTypes(buf, tc.ProjectID, pathToImage); err != nil {
+	if err := inspectImageFileListedInfoTypes(&buf, tc.ProjectID, pathToImage); err != nil {
 		t.Fatal(err)
 	}
 
@@ -377,7 +377,7 @@ func TestInspectImageFileListedInfoTypes(t *testing.T) {
 	if want := "Info type: EMAIL_ADDRESS"; !strings.Contains(got, want) {
 		t.Errorf("inspectTextFile got %q, want %q", got, want)
 	}
-	if want := "Info type: US_SOCIAL_SECURITY_NUMBER"; !strings.Contains(got, want) {
+	if want := "Info type: US_SOCIAL_SECURITY_NUMBER"; strings.Contains(got, want) {
 		t.Errorf("inspectTextFile got %q, want %q", got, want)
 	}
 }

--- a/dlp/snippets/jobs/delete.go
+++ b/dlp/snippets/jobs/delete.go
@@ -30,14 +30,14 @@ func deleteJob(w io.Writer, jobName string) error {
 	ctx := context.Background()
 	client, err := dlp.NewClient(ctx)
 	if err != nil {
-		return fmt.Errorf("dlp.NewClient: %v", err)
+		return fmt.Errorf("dlp.NewClient: %w", err)
 	}
 	defer client.Close()
 	req := &dlppb.DeleteDlpJobRequest{
 		Name: jobName,
 	}
 	if err = client.DeleteDlpJob(ctx, req); err != nil {
-		return fmt.Errorf("DeleteDlpJob: %v", err)
+		return fmt.Errorf("DeleteDlpJob: %w", err)
 	}
 	fmt.Fprintf(w, "Successfully deleted job")
 	return nil


### PR DESCRIPTION
## Description

- Added a sample for [dlp inspect image file](https://cloud.google.com/dlp/docs/samples/dlp-inspect-image-listed-infotypes) with a unit test case.

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [X] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [X] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [X] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
