### PR TITLE
chore: refactor exportlogs samples to stand alone

### DIFF
--- a/logging/exportlogs/create_sink.go
+++ b/logging/exportlogs/create_sink.go
@@ -1,0 +1,40 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// [START logging_create_sink]
+import (
+	"context"
+	"log"
+
+	"cloud.google.com/go/logging/logadmin"
+)
+
+func createSink(projectID string) (*logadmin.Sink, error) {
+	ctx := context.Background()
+	client, err := logadmin.NewClient(ctx, projectID)
+	if err != nil {
+		log.Fatalf("logadmin.NewClient: %v", err)
+	}
+	defer client.Close()
+	sink, err := client.CreateSink(ctx, &logadmin.Sink{
+		ID:          "severe-errors-to-gcs",
+		Destination: "storage.googleapis.com/logsinks-bucket",
+		Filter:      "severity >= ERROR",
+	})
+	return sink, err
+}
+
+// [END logging_create_sink]

--- a/logging/exportlogs/delete_sink.go
+++ b/logging/exportlogs/delete_sink.go
@@ -1,0 +1,38 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// [START logging_delete_sink]
+import (
+	"context"
+	"log"
+
+	"cloud.google.com/go/logging/logadmin"
+)
+
+func deleteSink(projectID string) error {
+	ctx := context.Background()
+	client, err := logadmin.NewClient(ctx, projectID)
+	if err != nil {
+		log.Fatalf("logadmin.NewClient: %v", err)
+	}
+	defer client.Close()
+	if err := client.DeleteSink(ctx, "severe-errors-to-gcs"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// [END logging_delete_sink]

--- a/logging/exportlogs/list_sink.go
+++ b/logging/exportlogs/list_sink.go
@@ -1,0 +1,50 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// [START logging_list_sinks]
+import (
+	"context"
+	"log"
+
+	"google.golang.org/api/iterator"
+
+	"cloud.google.com/go/logging/logadmin"
+)
+
+func listSinks(projectID string) ([]string, error) {
+	ctx := context.Background()
+	client, err := logadmin.NewClient(ctx, projectID)
+	if err != nil {
+		log.Fatalf("logadmin.NewClient: %v", err)
+	}
+	defer client.Close()
+
+	var sinks []string
+	it := client.Sinks(ctx)
+	for {
+		sink, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		sinks = append(sinks, sink.ID)
+	}
+	return sinks, nil
+}
+
+// [END logging_list_sinks]

--- a/logging/exportlogs/update_sink.go
+++ b/logging/exportlogs/update_sink.go
@@ -1,0 +1,40 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// [START logging_update_sink]
+import (
+	"context"
+	"log"
+
+	"cloud.google.com/go/logging/logadmin"
+)
+
+func updateSink(projectID string) (*logadmin.Sink, error) {
+	ctx := context.Background()
+	client, err := logadmin.NewClient(ctx, projectID)
+	if err != nil {
+		log.Fatalf("logadmin.NewClient: %v", err)
+	}
+	defer client.Close()
+	sink, err := client.UpdateSink(ctx, &logadmin.Sink{
+		ID:          "severe-errors-to-gcs",
+		Destination: "storage.googleapis.com/logsinks-new-bucket",
+		Filter:      "severity >= INFO",
+	})
+	return sink, err
+}
+
+// [END logging_update_sink]


### PR DESCRIPTION
To better align with the style guide, these regions have moved to their own
files.

these region tags are currently frozen in the docs, so this change is safe.
