### PR TITLE
fix(kms): completing a todo per user feedback

### DIFF
--- a/kms/sign_asymmetric.go
+++ b/kms/sign_asymmetric.go
@@ -85,10 +85,9 @@ func signAsymmetric(w io.Writer, name string, message string) error {
 	if result.VerifiedDigestCrc32C == false {
 		return fmt.Errorf("AsymmetricSign: request corrupted in-transit")
 	}
-	// TODO(iamtamjam) Uncomment when this field is populated by the server
-	// if result.Name != req.Name {
-	//	return fmt.Errorf("AsymmetricSign: request corrupted in-transit")
-	// }
+	if result.Name != req.Name {
+		return fmt.Errorf("AsymmetricSign: request corrupted in-transit")
+	}
 	if int64(crc32c(result.Signature)) != result.SignatureCrc32C.Value {
 		return fmt.Errorf("AsymmetricSign: response corrupted in-transit")
 	}


### PR DESCRIPTION
## Description

Fixes b/259150501

"TODO([iamtamjam](https://teams.googleplex.com/iamtamjam))" comment can be uncommented now, server sends the data now.

## Checklist
- [X] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [X] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [X] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [X] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [X] Please **merge** this PR for me once it is approved
