### PR TITLE
testing(eventarc): fix TestAuditStorageSinkService failure

### DIFF
--- a/eventarc/audit_storage/main.go
+++ b/eventarc/audit_storage/main.go
@@ -41,7 +41,6 @@ func HelloEventsStorage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s := fmt.Sprintf("Detected change in Cloud Storage bucket: %s", event.Subject())
-	log.Printf(s)
 	fmt.Fprintln(w, s)
 }
 

--- a/eventarc/audit_storage/main.go
+++ b/eventarc/audit_storage/main.go
@@ -36,9 +36,9 @@ func HelloEventsStorage(w http.ResponseWriter, r *http.Request) {
 
 	event, err := cloudevent.NewEventFromHTTPRequest(r)
 	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintln(w, "Failed to create CloudEvent from request.")
-		log.Fatal("cloudevent.NewEventFromHTTPRequest:", err)
+		log.Printf("cloudevent.NewEventFromHTTPRequest: %v", err)
+		http.Error(w, "Failed to create CloudEvent from request.", http.StatusBadRequest)
+		return
 	}
 	s := fmt.Sprintf("Detected change in Cloud Storage bucket: %s", event.Subject())
 	log.Printf(s)

--- a/eventarc/audit_storage/main.go
+++ b/eventarc/audit_storage/main.go
@@ -29,6 +29,11 @@ import (
 
 // HelloEventsStorage receives and processes a Cloud Audit Log event with Cloud Storage data.
 func HelloEventsStorage(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Expected HTTP POST request with CloudEvent payload", http.StatusBadRequest)
+		return
+	}
+
 	event, err := cloudevent.NewEventFromHTTPRequest(r)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)

--- a/eventarc/audit_storage/main.go
+++ b/eventarc/audit_storage/main.go
@@ -30,7 +30,7 @@ import (
 // HelloEventsStorage receives and processes a Cloud Audit Log event with Cloud Storage data.
 func HelloEventsStorage(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "Expected HTTP POST request with CloudEvent payload", http.StatusBadRequest)
+		http.Error(w, "Expected HTTP POST request with CloudEvent payload", http.StatusMethodNotAllowed)
 		return
 	}
 


### PR DESCRIPTION
## Description

Fixes #3188.

As noted in the issue triage, the following changes were made:

* Dedicated error handling for non-POST requests
* Do not crash on CloudEvent parsing errors
* Remove logging of potential user data in a web service

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
