### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/internal/aeintegrate/aeintegrate.go
+++ b/internal/aeintegrate/aeintegrate.go
@@ -47,7 +47,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -192,7 +191,7 @@ func (p *App) envAppYaml() (string, error) {
 		return p.tempAppYaml, nil
 	}
 
-	b, err := ioutil.ReadFile(filepath.Join(p.Dir, base))
+	b, err := os.ReadFile(filepath.Join(p.Dir, base))
 	if err != nil {
 		return "", err
 	}
@@ -232,7 +231,7 @@ func (p *App) envAppYaml() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := ioutil.WriteFile(filepath.Join(p.Dir, tmp), b, 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(p.Dir, tmp), b, 0755); err != nil {
 		return "", err
 	}
 
@@ -270,7 +269,7 @@ func (p *App) readService() error {
 		return nil
 	}
 
-	b, err := ioutil.ReadFile(filepath.Join(p.Dir, p.appYaml()))
+	b, err := os.ReadFile(filepath.Join(p.Dir, p.appYaml()))
 	if err != nil {
 		return err
 	}

--- a/internal/e2e/standard_test.go
+++ b/internal/e2e/standard_test.go
@@ -17,7 +17,7 @@
 package e2e
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"strings"
 	"testing"
@@ -58,7 +58,7 @@ func bodyShouldContain(t *testing.T, p *aeintegrate.App, path, shouldContain str
 			r.Errorf("Get: %v", err)
 			return
 		}
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			r.Errorf("could not read body: %v", err)
 			return

--- a/internal/testutil/runmain.go
+++ b/internal/testutil/runmain.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -34,7 +33,7 @@ func BuildMain(t *testing.T) *Runner {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tmp, err := ioutil.TempDir("", "runmain-"+filepath.Base(wd)+"-")
+	tmp, err := os.MkdirTemp("", "runmain-"+filepath.Base(wd)+"-")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Description
"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16
Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [ ] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
