### PR TITLE
fix(pubsub): fix control flow error path

### DIFF
--- a/pubsub/subscriptions/subscription_test.go
+++ b/pubsub/subscriptions/subscription_test.go
@@ -979,7 +979,7 @@ func createOrGetStorageBucket(projectID, bucketID string) error {
 		if err := b.Create(ctx, projectID, nil); err != nil {
 			return fmt.Errorf("error creating bucket: %w", err)
 		}
-	} else {
+	} else if err != nil {
 		return fmt.Errorf("error retrieving existing bucket: %w", err)
 	}
 


### PR DESCRIPTION
## Description

Missing control flow statement means an error was always occurring. This only catches the case after the resource already exists, which is why previous presubmits didn't catch this.

Fixes #3229

