### PR TITLE
fix(healthcare): specify V3 parser version when creating HL7v2 store

### DIFF
--- a/healthcare/hl7v2_store_create.go
+++ b/healthcare/hl7v2_store_create.go
@@ -34,7 +34,8 @@ func createHL7V2Store(w io.Writer, projectID, location, datasetID, hl7V2StoreID 
 
 	storesService := healthcareService.Projects.Locations.Datasets.Hl7V2Stores
 
-	store := &healthcare.Hl7V2Store{}
+	// Set the HL7v2 store parser version to V3.
+	store := &healthcare.Hl7V2Store{ParserConfig: &healthcare.ParserConfig{Version: "V3"}}
 	parent := fmt.Sprintf("projects/%s/locations/%s/datasets/%s", projectID, location, datasetID)
 
 	resp, err := storesService.Create(parent, store).Hl7V2StoreId(hl7V2StoreID).Do()


### PR DESCRIPTION
## Description

Fixes b/253274073

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [X] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [X] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [X] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [X] Please **merge** this PR for me once it is approved
