### PR TITLE
fix: refactor error reporting code sample

### DIFF
--- a/errorreporting/errorreporting_quickstart/main.go
+++ b/errorreporting/errorreporting_quickstart/main.go
@@ -44,7 +44,7 @@ func main() {
 		ServiceName:    "errorreporting_quickstart",
 		ServiceVersion: "0.0.0",
 		OnError: func(err error) {
-			log.Printf("Could not repport the error: %v", err)
+			log.Printf("Could not report the error: %v", err)
 		},
 	})
 	if err != nil {
@@ -52,7 +52,7 @@ func main() {
 	}
 	defer errorClient.Close()
 
-	err = errors.New("Something went wrong")
+	err = errors.New("something went wrong")
 	if err != nil {
 		logAndPrintError(err)
 		return
@@ -60,7 +60,8 @@ func main() {
 }
 
 func logAndPrintError(err error) {
-	// error context is autopopulated
+	/// Client autopopulates the error context of the error. For more details about the context see:
+	/// https://cloud.google.com/error-reporting/reference/rest/v1beta1/ErrorContext
 	errorClient.Report(errorreporting.Entry{
 		Error: err,
 	})

--- a/errorreporting/errorreporting_quickstart/main.go
+++ b/errorreporting/errorreporting_quickstart/main.go
@@ -31,14 +31,14 @@ import (
 var errorClient *errorreporting.Client
 
 func main() {
-	ctx := context.Background()
-
-	// TODO: Sets your Google Cloud Platform project ID via environment or explicitly
-	projectID := os.Getenv("GOOGLE_PROJECT_ID")
-	if projectID == "" {
-		projectID = "YOUR_PROJECT_ID"
+	// Set your Google Cloud Platform project ID via environment or explicitly
+	projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
+	args := os.Args[1:]
+	if len(args) > 0 && args[0] != "" {
+		projectID = args[0]
 	}
 
+	ctx := context.Background()
 	var err error
 	errorClient, err = errorreporting.NewClient(ctx, projectID, errorreporting.Config{
 		ServiceName:    "errorreporting_quickstart",


### PR DESCRIPTION
align code sample for error reporting with code in other languages (b/275730159). use an explicit error with the "fixed" message. populate the service context with the name of the service (module) and the version.