### PR TITLE
fix(functions): new region tag for 1st gen functions sample 

### DIFF
--- a/functions/helloworld/hello_world.go
+++ b/functions/helloworld/hello_world.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// [START functions_helloworld_get_gen1]
 // [START functions_helloworld_get]
 
 // Package helloworld provides a set of Cloud Functions samples.
@@ -28,3 +29,4 @@ func HelloGet(w http.ResponseWriter, r *http.Request) {
 }
 
 // [END functions_helloworld_get]
+// [END functions_helloworld_get_gen1]


### PR DESCRIPTION
This PR will add a different region tag for the Cloud Functions sample. The same region tag is used in [2nd gen version of the sample](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/functions/functionsv2/helloworld/hello_world.go)

**A follow up PR will be submitted removing the old region tag**