### PR TITLE
fix(functions): remove old region tag

### DIFF
--- a/functions/helloworld/hello_world.go
+++ b/functions/helloworld/hello_world.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 // [START functions_helloworld_get_gen1]
-// [START functions_helloworld_get]
 
 // Package helloworld provides a set of Cloud Functions samples.
 package helloworld
@@ -28,5 +27,4 @@ func HelloGet(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, "Hello, World!")
 }
 
-// [END functions_helloworld_get]
 // [END functions_helloworld_get_gen1]


### PR DESCRIPTION
Follow up to #3324 

This PR removes the old region tag reserved for the [2nd gen version of the sample](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/functions/functionsv2/helloworld/hello_world.go)