### PR TITLE
fix: refactor spanner delete_data sample

### DIFF
--- a/spanner/spanner_snippets/spanner/spanner_delete_data.go
+++ b/spanner/spanner_snippets/spanner/spanner_delete_data.go
@@ -32,13 +32,16 @@ func delete(w io.Writer, db string) error {
 	defer client.Close()
 
 	m := []*spanner.Mutation{
-		// Delete individual rows.
+		// spanner.Key can be used to delete a specific set of rows.
+		// Delete the Albums with the key values (2,1) and (2,3).
 		spanner.Delete("Albums", spanner.Key{2, 1}),
 		spanner.Delete("Albums", spanner.Key{2, 3}),
-		// Delete a range of rows where the column key is >=3 and <5.
+		// spanner.KeyRange can be used to delete rows with a key in a specific range.
+		// Delete a range of rows where the column key is >=3 and <5
 		spanner.Delete("Singers", spanner.KeyRange{Start: spanner.Key{3}, End: spanner.Key{5}, Kind: spanner.ClosedOpen}),
-		// Delete remaining Singers rows, which will also delete the remaining
-		// Albums rows because Albums was defined with ON DELETE CASCADE.
+		// spanner.AllKeys can be used to delete all the rows in a table.
+		// Delete remaining Singers rows, which will also delete the remaining Albums rows since it was
+		// defined with ON DELETE CASCADE.
 		spanner.Delete("Singers", spanner.AllKeys()),
 	}
 	_, err = client.Apply(ctx, m)


### PR DESCRIPTION
## Description
Sync comments on the sample to be consistent with other languages https://cloud.google.com/spanner/docs/samples/spanner-delete-data#spanner_delete_data-java

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
