### PR TITLE
testing(run): migrate ioutil to io functions

### DIFF
--- a/run/testing/h2c.e2e_test.go
+++ b/run/testing/h2c.e2e_test.go
@@ -15,7 +15,7 @@
 package cloudruntests
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -61,7 +61,7 @@ func TestHTTP2Server(t *testing.T) {
 			r.Errorf("http2.Get: unexpected response status: %s", resp.Status)
 		}
 		defer resp.Body.Close()
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err != nil {
 			r.Errorf("resp.Body.Read failed: %v", err)
 		}

--- a/run/testing/helloworld.e2e_test.go
+++ b/run/testing/helloworld.e2e_test.go
@@ -15,7 +15,7 @@
 package cloudruntests
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -35,9 +35,9 @@ func TestHelloworldService(t *testing.T) {
 	defer service.Clean()
 
 	resp, err := service.Request("GET", "/")
-	out, err := ioutil.ReadAll(resp.Body)
+	out, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Errorf("ioutil.ReadAll: %v", err)
+		t.Errorf("io.ReadAll: %v", err)
 	}
 
 	if got, want := string(out), "Hello Override!\n"; got != want {

--- a/run/testing/markdown_preview_editor.e2e_test.go
+++ b/run/testing/markdown_preview_editor.e2e_test.go
@@ -17,7 +17,7 @@ package cloudruntests
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -90,7 +90,7 @@ func caseEditorServiceRender(t *testing.T) {
 	if err != nil {
 		t.Fatalf("json.Marshall: %v", err)
 	}
-	req.Body = ioutil.NopCloser(bytes.NewReader(b))
+	req.Body = io.NopCloser(bytes.NewReader(b))
 
 	resp, err := editorService.Do(req)
 	if err != nil {
@@ -104,9 +104,9 @@ func caseEditorServiceRender(t *testing.T) {
 		t.Errorf("response status: got %d, want %d", got, wantStatus)
 	}
 
-	out, err := ioutil.ReadAll(resp.Body)
+	out, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Fatalf("ioutil.ReadAll: %v", err)
+		t.Fatalf("io.ReadAll: %v", err)
 	}
 
 	want := "<p><strong>strong text</strong></p>\n"

--- a/run/testing/markdown_preview_renderer.e2e_test.go
+++ b/run/testing/markdown_preview_renderer.e2e_test.go
@@ -15,7 +15,7 @@
 package cloudruntests
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -55,7 +55,7 @@ func TestRendererService(t *testing.T) {
 		if err != nil {
 			t.Fatalf("service.NewRequest: %q", err)
 		}
-		req.Body = ioutil.NopCloser(strings.NewReader(test.input))
+		req.Body = io.NopCloser(strings.NewReader(test.input))
 
 		resp, err := service.Do(req)
 		if err != nil {
@@ -68,9 +68,9 @@ func TestRendererService(t *testing.T) {
 			t.Errorf("response status: got %d, want %d", got, http.StatusOK)
 		}
 
-		out, err := ioutil.ReadAll(resp.Body)
+		out, err := io.ReadAll(resp.Body)
 		if err != nil {
-			t.Errorf("ioutil.ReadAll: %v", err)
+			t.Errorf("io.ReadAll: %v", err)
 			return
 		}
 


### PR DESCRIPTION
## Description

ioutil.NopCloser and ioutil.ReadAll were deprecated in favor of re-homing these functions in the io package.

This happened in go 1.16.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
