### PR TITLE
testing(bigquery): double test timeout for migration quickstart

### DIFF
--- a/bigquery/bigquery_migration_quickstart/main_test.go
+++ b/bigquery/bigquery_migration_quickstart/main_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 )
 
+var appTimeout = 60 * time.Second
+
 func TestApp(t *testing.T) {
 	tc := testutil.SystemTest(t)
 	m := testutil.BuildMain(t)
@@ -42,7 +44,7 @@ func TestApp(t *testing.T) {
 	}
 	defer cleanup()
 
-	stdOut, stdErr, err := m.Run(nil, 30*time.Second, fmt.Sprintf("--project_id=%s", tc.ProjectID), fmt.Sprintf("--output=%s", bucket))
+	stdOut, stdErr, err := m.Run(nil, appTimeout, fmt.Sprintf("--project_id=%s", tc.ProjectID), fmt.Sprintf("--output=%s", bucket))
 	if err != nil {
 		t.Errorf("execution failed: %v", err)
 	}


### PR DESCRIPTION
We've had multiple failures for this snippet running over time budget, but it's not clear that anything has changed.  PR doubles the timeout for running the quickstart, and hoists the timeout up as a variable rather than inline at the callsite.

Fixes: https://github.com/GoogleCloudPlatform/golang-samples/issues/3567