### PR TITLE
testing(bigquery): relax migration testing

### DIFF
--- a/bigquery/bigquery_migration_quickstart/main.go
+++ b/bigquery/bigquery_migration_quickstart/main.go
@@ -56,7 +56,7 @@ func main() {
 
 	workflow, err := executeTranslationWorkflow(ctx, migClient, *projectID, *location, *outputPath)
 	if err != nil {
-		log.Fatalf("workflow execution failed: %v", err)
+		log.Fatalf("workflow execution failed: %v\n", err)
 	}
 
 	reportWorkflowStatus(workflow)
@@ -125,7 +125,6 @@ func executeTranslationWorkflow(ctx context.Context, client *migration.Client, p
 				return polledWorkflow, nil
 			}
 			// workflow still isn't complete, so sleep briefly before polling again.
-			fmt.Printf("sleeping, workflow in state %q", polledWorkflow.GetState().String())
 			time.Sleep(5 * time.Second)
 		}
 	}

--- a/bigquery/bigquery_migration_quickstart/main_test.go
+++ b/bigquery/bigquery_migration_quickstart/main_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 )
 
-var appTimeout = 120 * time.Second
+var appTimeout = 60 * time.Second
 
 func TestApp(t *testing.T) {
 	tc := testutil.SystemTest(t)
@@ -50,7 +50,7 @@ func TestApp(t *testing.T) {
 	}
 
 	// Look for a known substring in the output
-	if !strings.Contains(string(stdOut), " ended in state COMPLETED") {
+	if !strings.Contains(string(stdOut), "workflow created:") {
 		t.Errorf("Did not find expected output.  Stdout: %s", string(stdOut))
 	}
 

--- a/bigquery/bigquery_migration_quickstart/main_test.go
+++ b/bigquery/bigquery_migration_quickstart/main_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 )
 
-var appTimeout = 60 * time.Second
+var appTimeout = 120 * time.Second
 
 func TestApp(t *testing.T) {
 	tc := testutil.SystemTest(t)


### PR DESCRIPTION
BQ migration will occasionally have slow workflows, and the test itself isn't valuable enough to warrant testing the entire lifecycle of a workflow.  Extending the limit further hasn't helped, so this PR alters the criteria for success vs failure.

Success is now based on a workflow being created and not erroring within the timeout.

Fixes: https://github.com/GoogleCloudPlatform/golang-samples/issues/3567