### PR TITLE
chore(deps): update all Dockerfile golang images to 1.21

### DIFF
--- a/appengine/go11x/tasks/handle_task/Dockerfile
+++ b/appengine/go11x/tasks/handle_task/Dockerfile
@@ -1,7 +1,7 @@
 # Use the offical Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.17 as builder
+FROM golang:1.21 as builder
 
 # Copy local code to the container image.
 RUN mkdir /app

--- a/cloudsql/mysql/database-sql/Dockerfile
+++ b/cloudsql/mysql/database-sql/Dockerfile
@@ -15,7 +15,7 @@
 # Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.17-buster as builder
+FROM golang:1.21-buster as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/cloudsql/postgres/database-sql/Dockerfile
+++ b/cloudsql/postgres/database-sql/Dockerfile
@@ -15,7 +15,7 @@
 # Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.17-buster as builder
+FROM golang:1.21-buster as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/cloudsql/sqlserver/database-sql/Dockerfile
+++ b/cloudsql/sqlserver/database-sql/Dockerfile
@@ -15,7 +15,7 @@
 # Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.17-buster as builder
+FROM golang:1.21-buster as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/eventarc/audit_storage/Dockerfile
+++ b/eventarc/audit_storage/Dockerfile
@@ -17,7 +17,7 @@
 # Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.17-buster as builder
+FROM golang:1.21-buster as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/eventarc/generic/Dockerfile
+++ b/eventarc/generic/Dockerfile
@@ -17,7 +17,7 @@
 # Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.17-buster as builder
+FROM golang:1.21-buster as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/eventarc/pubsub/Dockerfile
+++ b/eventarc/pubsub/Dockerfile
@@ -17,7 +17,7 @@
 # Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.17-buster as builder
+FROM golang:1.21-buster as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/functions/security/security_system_test.go
+++ b/functions/security/security_system_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 )
 
-const RuntimeVersion = "go118"
+const RuntimeVersion = "go119"
 const FunctionsRegion = "us-central1"
 
 func TestMain(m *testing.M) {

--- a/getting-started/devflowapp/Dockerfile
+++ b/getting-started/devflowapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.21
 
 COPY devflowapp.go .
 COPY services/ /go/src/github.com/GoogleCloudPlatform/golang-samples/getting-started/devflowapp/services/

--- a/getting-started/gopher-run/Dockerfile
+++ b/getting-started/gopher-run/Dockerfile
@@ -1,7 +1,7 @@
 # Use the offical Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.17 as builder
+FROM golang:1.21 as builder
 
 # Copy local code to the container image.
 WORKDIR /app

--- a/internal/cloudrunci/testingapp/Dockerfile
+++ b/internal/cloudrunci/testingapp/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.17 as builder
+FROM golang:1.21 as builder
 WORKDIR /app
 COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o server

--- a/memorystore/redis/cloud_run_deployment/Dockerfile
+++ b/memorystore/redis/cloud_run_deployment/Dockerfile
@@ -17,7 +17,7 @@
 # Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.17-buster as builder
+FROM golang:1.21-buster as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/memorystore/redis/gke_deployment/Dockerfile
+++ b/memorystore/redis/gke_deployment/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine
+FROM golang:1.21-alpine
 
 RUN apk update && apk add git
 

--- a/profiler/hotapp/Dockerfile
+++ b/profiler/hotapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.7-alpine
+FROM golang:1.21-alpine
 
 WORKDIR /go/src
 COPY ./go.mod ./

--- a/profiler/hotmid/Dockerfile
+++ b/profiler/hotmid/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.7-alpine
+FROM golang:1.21-alpine
 
 WORKDIR /go/src
 COPY ./go.mod .

--- a/run/custom-metrics/Dockerfile
+++ b/run/custom-metrics/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # [START cloudrun_mc_custom_metrics_dockerfile]
-FROM golang:1.20 as builder
+FROM golang:1.21 as builder
 WORKDIR /app
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o sample-app

--- a/run/grpc-ping/Dockerfile
+++ b/run/grpc-ping/Dockerfile
@@ -18,7 +18,7 @@
 # Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.17-buster as builder
+FROM golang:1.21-buster as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/run/grpc-server-streaming/Dockerfile
+++ b/run/grpc-server-streaming/Dockerfile
@@ -18,7 +18,7 @@
 # Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.17-buster as builder
+FROM golang:1.21-buster as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/run/hello-broken/Dockerfile
+++ b/run/hello-broken/Dockerfile
@@ -18,7 +18,7 @@
 # Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.17-buster as builder
+FROM golang:1.21-buster as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/run/helloworld/Dockerfile
+++ b/run/helloworld/Dockerfile
@@ -18,7 +18,7 @@
 # Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.19-buster as builder
+FROM golang:1.21-buster as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/run/image-processing/Dockerfile
+++ b/run/image-processing/Dockerfile
@@ -15,7 +15,7 @@
 # Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.17-buster as builder
+FROM golang:1.21-buster as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/run/logging-manual/Dockerfile
+++ b/run/logging-manual/Dockerfile
@@ -15,7 +15,7 @@
 # Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.17-buster as builder
+FROM golang:1.21-buster as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/run/markdown-preview/editor/Dockerfile
+++ b/run/markdown-preview/editor/Dockerfile
@@ -15,7 +15,7 @@
 # Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.17-buster as builder
+FROM golang:1.21-buster as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/run/markdown-preview/renderer/Dockerfile
+++ b/run/markdown-preview/renderer/Dockerfile
@@ -15,7 +15,7 @@
 # Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.17-buster as builder
+FROM golang:1.21-buster as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/run/pubsub/Dockerfile
+++ b/run/pubsub/Dockerfile
@@ -18,7 +18,7 @@
 # Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.17-buster as builder
+FROM golang:1.21-buster as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/run/sigterm-handler/Dockerfile
+++ b/run/sigterm-handler/Dockerfile
@@ -15,7 +15,7 @@
 # Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.17-buster as builder
+FROM golang:1.21-buster as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/run/system_package/Dockerfile
+++ b/run/system_package/Dockerfile
@@ -14,7 +14,7 @@
 
 # Use the offical Golang image to create a build artifact.
 # https://hub.docker.com/_/golang
-FROM golang:1.17-buster as builder
+FROM golang:1.21-buster as builder
 
 # Create and change to the app directory.
 WORKDIR /app


### PR DESCRIPTION
this is blocking #3566, which upgrades GRPC to v1.59, which requires go 1.19
