### PR TITLE
feat(otel): use Cloud Logging structured log conventions

### DIFF
--- a/opentelemetry/instrumentation/app/logger.go
+++ b/opentelemetry/instrumentation/app/logger.go
@@ -16,10 +16,14 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"os"
 
 	"go.opentelemetry.io/otel/trace"
 )
+
+var projectId = os.Getenv("GOOGLE_CLOUD_PROJECT")
 
 // handerWithSpanContext adds attributes from the span context
 // [START opentelemetry_instrumentation_spancontext_logger]
@@ -38,27 +42,32 @@ type spanContextLogHandler struct {
 func (t *spanContextLogHandler) Handle(ctx context.Context, record slog.Record) error {
 	// Get the SpanContext from the golang Context.
 	if s := trace.SpanContextFromContext(ctx); s.IsValid() {
-		// Add the trace_id attribute from the SpanContext.
-		if s.HasTraceID() {
-			record.AddAttrs(
-				slog.Any("trace_id", s.TraceID()),
-			)
-		}
-
-		// Add the span_id attribute from the SpanContext.
-		if s.HasSpanID() {
-			record.AddAttrs(
-				slog.Any("span_id", s.SpanID()),
-			)
-		}
-
-		// Add the trace_flags attribute from the SpanContext.
-		// This includes whether or not the trace is sampled.
+		// Add trace context attributes following Cloud Logging structured log format described
+		// in https://cloud.google.com/logging/docs/structured-logging#special-payload-fields
 		record.AddAttrs(
-			slog.Any("trace_flags", s.TraceFlags()),
+			slog.Any("logging.googleapis.com/trace", fmt.Sprintf("projects/%s/traces/%s", projectId, s.TraceID())),
+		)
+		record.AddAttrs(
+			slog.Any("logging.googleapis.com/spanId", s.SpanID()),
+		)
+		record.AddAttrs(
+			slog.Bool("logging.googleapis.com/trace_sampled", s.TraceFlags().IsSampled()),
 		)
 	}
 	return t.Handler.Handle(ctx, record)
+}
+
+func replacer(groups []string, a slog.Attr) slog.Attr {
+	// Rename attribute keys to match Cloud Logging structured log format
+	switch a.Key {
+	case slog.LevelKey:
+		return slog.Any("severity", a.Value)
+	case slog.TimeKey:
+		return slog.Any("timestamp", a.Value)
+	case slog.MessageKey:
+		return slog.Any("message", a.Value)
+	}
+	return a
 }
 
 // [END opentelemetry_instrumentation_spancontext_logger]

--- a/opentelemetry/instrumentation/app/main_test.go
+++ b/opentelemetry/instrumentation/app/main_test.go
@@ -132,13 +132,13 @@ func TestWriteTelemetry(t *testing.T) {
 }
 
 type expectedLogFormat struct {
-	Time        string `json:"time"`
-	Level       string `json:"level"`
-	Msg         string `json:"msg"`
-	SubRequests int    `json:"subRequests"`
-	TraceID     string `json:"trace_id"`
-	SpanID      string `json:"span_id"`
-	TraceFlags  string `json:"trace_flags"`
+	Timestamp    string `json:"timestamp"`
+	Severity     string `json:"severity"`
+	Message      string `json:"message"`
+	SubRequests  int    `json:"subRequests"`
+	TraceID      string `json:"logging.googleapis.com/trace"`
+	SpanID       string `json:"logging.googleapis.com/spanId"`
+	TraceSampled bool   `json:"logging.googleapis.com/trace_sampled"`
 }
 
 const expectedLogMessage = "handle /multi request"
@@ -153,16 +153,16 @@ func verifyStdoutLogs(t *testing.T, stdout []byte) {
 			continue
 		}
 		t.Logf("stdout line: %v; parsed: %+v", line, contents)
-		if contents.Msg != expectedLogMessage {
+		if contents.Message != expectedLogMessage {
 			continue
 		}
-		assert.NotEmpty(t, contents.Time)
-		assert.NotEmpty(t, contents.Level)
-		assert.NotEmpty(t, contents.Msg)
+		assert.NotEmpty(t, contents.Timestamp)
+		assert.NotEmpty(t, contents.Severity)
+		assert.NotEmpty(t, contents.Message)
 		assert.NotEmpty(t, contents.SubRequests)
 		assert.NotEmpty(t, contents.TraceID)
 		assert.NotEmpty(t, contents.SpanID)
-		assert.NotEmpty(t, contents.TraceFlags)
+		assert.NotEmpty(t, contents.TraceSampled)
 		return
 	}
 	t.Errorf("Did not find log message: %v", expectedLogMessage)

--- a/opentelemetry/instrumentation/app/setup.go
+++ b/opentelemetry/instrumentation/app/setup.go
@@ -79,7 +79,7 @@ func setupOpenTelemetry(ctx context.Context) (shutdown func(context.Context) err
 // [START opentelemetry_instrumentation_setup_logging]
 func setupLogging() {
 	// Use json as our base logging format.
-	jsonHandler := slog.NewJSONHandler(os.Stdout, nil)
+	jsonHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{ReplaceAttr: replacer})
 	// Add span context attributes when Context is passed to logging calls.
 	instrumentedHandler := handerWithSpanContext(jsonHandler)
 	// Set this handler as the global slog handler.

--- a/opentelemetry/instrumentation/docker-compose.yaml
+++ b/opentelemetry/instrumentation/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
     environment:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4318
       - OTEL_SERVICE_NAME=otel-quickstart-go
+      - GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT?}
     volumes:
       - logs:/var/log:rw
     depends_on:

--- a/opentelemetry/instrumentation/otel-collector-config.yaml
+++ b/opentelemetry/instrumentation/otel-collector-config.yaml
@@ -12,24 +12,42 @@ receivers:
     operators:
       - type: json_parser
         parse_to: body
-        # Parse the timestamp from the "time" field
         timestamp:
-          parse_from: body.time
+          parse_from: body.timestamp
           layout: '%Y-%m-%dT%H:%M:%S.%fZ'
-        # Parse the severity from the "level" field
         severity:
-          parse_from: body.level
-      # Parse trace_id, span_id, and trace_flags into the log's span context
-      - type: trace_parser
-      # Google Cloud Logging uses "message" instead of "msg".
-      - type: move
-        from: body.msg
-        to: body.message
-      # Remove fields that we have translated above.
+          parse_from: body.severity
+
+      # set trace_flags to SAMPLED if GCP attribute is set to true
+      - type: add
+        field: body.trace_flags
+        value: "01"
+        if: body["logging.googleapis.com/trace_sampled"] == true
+
+      # parse the trace context fields from GCP attributes
+      - type: regex_parser
+        parse_from: body["logging.googleapis.com/trace"]
+        parse_to: body
+        regex: projects/.+/traces/(?P<trace_id>.*)
+        trace:
+          span_id:
+            parse_from: body["logging.googleapis.com/spanId"]
+
+      # Remove fields that are redundant from translation above
       - type: remove
-        field: body.time
+        field: body.timestamp
       - type: remove
-        field: body.level
+        field: body.trace_id
+      - type: remove
+        field: body.trace_flags
+      - type: remove
+        field: body.severity
+      - type: remove
+        field: body["logging.googleapis.com/trace"]
+      - type: remove
+        field: body["logging.googleapis.com/spanId"]
+      - type: remove
+        field: body["logging.googleapis.com/trace_sampled"]
 
 exporters:
   # Export logs and traces using the standard googelcloud exporter


### PR DESCRIPTION
## Description

Update the OTel example to output logs in Cloud Logging structured log format described in https://cloud.google.com/logging/docs/structured-logging#special-payload-fields. This makes the example code compatible with Cloud Logging agents in GKE/GCE/Cloud Run etc.

I also updated the OTel config to mimic Cloud Logging agents for the example.

cc @dashpole

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
