### PR TITLE
fix(vertexai): use gs:// in safety-settings-multimodal

### DIFF
--- a/vertexai/safety-settings-multimodal/safety-settings-multimodal.go
+++ b/vertexai/safety-settings-multimodal/safety-settings-multimodal.go
@@ -84,3 +84,5 @@ func generateMultimodalContent(w io.Writer, prompt, image, projectID, location, 
 	fmt.Fprintf(w, "generated response: %s\n", res.Candidates[0].Content.Parts[0])
 	return nil
 }
+
+// [END aiplatform_gemini_safety_settings]

--- a/vertexai/safety-settings-multimodal/safety-settings-multimodal.go
+++ b/vertexai/safety-settings-multimodal/safety-settings-multimodal.go
@@ -20,10 +20,9 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net/http"
-	"net/url"
+	"mime"
 	"os"
-	"strings"
+	"path/filepath"
 
 	"cloud.google.com/go/vertexai/genai"
 )
@@ -32,39 +31,33 @@ func main() {
 	projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
 	location := "us-central1"
 	modelName := "gemini-pro-vision"
-	temperature := 0.4
+
+	prompt := "describe what is in this picture"
+	image := "gs://generativeai-downloads/images/scones.jpg"
 
 	if projectID == "" {
 		log.Fatal("require environment variable GOOGLE_CLOUD_PROJECT")
 	}
 
-	cat, _ := partFromImageURL("https://storage.googleapis.com/cloud-samples-data/generative-ai/image/320px-Felis_catus-cat_on_snow.jpg")
-
-	// create a multipart (multimodal) prompt
-	prompt := []genai.Part{
-		genai.Text("say something nice about this "),
-		cat,
-	}
-
-	err := generateContent(os.Stdout, prompt, projectID, location, modelName, float32(temperature))
+	err := generateMultimodalContent(os.Stdout, prompt, image, projectID, location, modelName)
 	if err != nil {
-		fmt.Printf("unable to generate: %v\n", err)
+		log.Fatalf("unable to generate: %v", err)
 	}
 }
 
-// generateContent generates text from prompt and configurations provided.
-func generateContent(w io.Writer, prompt []genai.Part, projectID, location, modelName string, temperature float32) error {
+// generateMultimodalContent generates a response into w, based upon the prompt
+// and image provided.
+func generateMultimodalContent(w io.Writer, prompt, image, projectID, location, modelName string) error {
 	ctx := context.Background()
 
 	client, err := genai.NewClient(ctx, projectID, location)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to create client: %v", err)
 	}
 	defer client.Close()
 
 	model := client.GenerativeModel(modelName)
-	model.Temperature = temperature
-
+	model.Temperature = 0.4
 	// configure the safety settings thresholds
 	model.SafetySettings = []*genai.SafetySetting{
 		{
@@ -77,43 +70,17 @@ func generateContent(w io.Writer, prompt []genai.Part, projectID, location, mode
 		},
 	}
 
-	res, err := model.GenerateContent(ctx, prompt...)
+	// Given an image file URL, prepare image file as genai.Part
+	img := genai.FileData{
+		MIMEType: mime.TypeByExtension(filepath.Ext(image)),
+		FileURI:  image,
+	}
+
+	res, err := model.GenerateContent(ctx, img, genai.Text(prompt))
 	if err != nil {
-		return fmt.Errorf("unable to generate content: %v", err)
-	}
-	fmt.Fprintf(w, "generate-content response: %v\n", res.Candidates[0].Content.Parts[0])
-
-	fmt.Fprintf(w, "safety ratings:\n")
-	for _, r := range res.Candidates[0].SafetyRatings {
-		fmt.Fprintf(w, "\t%+v\n", r)
+		return fmt.Errorf("unable to generate contents: %v", err)
 	}
 
+	fmt.Fprintf(w, "generated response: %s\n", res.Candidates[0].Content.Parts[0])
 	return nil
 }
-
-// partFromImageURL create a multimodal prompt part from an image URL
-func partFromImageURL(image string) (genai.Part, error) {
-	imageURL, err := url.Parse(image)
-	if err != nil {
-		return nil, err
-	}
-	res, err := http.Get(image)
-	if err != nil || res.StatusCode != 200 {
-		return nil, err
-	}
-	defer res.Body.Close()
-	data, err := io.ReadAll(res.Body)
-	if err != nil {
-		return nil, fmt.Errorf("unable to read from http: %v", err)
-	}
-
-	position := strings.LastIndex(imageURL.Path, ".")
-	if position == -1 {
-		return nil, fmt.Errorf("couldn't find a period to indicate a file extension")
-	}
-	ext := imageURL.Path[position+1:]
-
-	return genai.ImageData(ext, data), nil
-}
-
-// [END aiplatform_gemini_safety_settings]

--- a/vertexai/safety-settings-multimodal/safety-settings-multimodal.go
+++ b/vertexai/safety-settings-multimodal/safety-settings-multimodal.go
@@ -78,7 +78,7 @@ func generateMultimodalContent(w io.Writer, prompt, image, projectID, location, 
 
 	res, err := model.GenerateContent(ctx, img, genai.Text(prompt))
 	if err != nil {
-		return fmt.Errorf("unable to generate contents: %v", err)
+		return fmt.Errorf("unable to generate contents: %w", err)
 	}
 
 	fmt.Fprintf(w, "generated response: %s\n", res.Candidates[0].Content.Parts[0])

--- a/vertexai/safety-settings-multimodal/safety-settings-multimodal_test.go
+++ b/vertexai/safety-settings-multimodal/safety-settings-multimodal_test.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 	"testing"
 
-	"cloud.google.com/go/vertexai/genai"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 )
 
@@ -27,30 +26,24 @@ func TestGenerateContent(t *testing.T) {
 	t.Skip("TODO(muncus): remove skip")
 	tc := testutil.SystemTest(t)
 
+	prompt := "describe this image."
 	projectID := tc.ProjectID
 	location := "us-central1"
 
 	model := "gemini-pro-vision"
-	temp := 0.8
 
-	cat, _ := partFromImageURL("https://storage.googleapis.com/cloud-samples-data/generative-ai/image/320px-Felis_catus-cat_on_snow.jpg")
-
-	// create a multipart (multimodal) prompt
-	prompt := []genai.Part{
-		genai.Text("say something nice about this "),
-		cat,
-	}
+	image := "https://storage.googleapis.com/cloud-samples-data/generative-ai/image/320px-Felis_catus-cat_on_snow.jpg"
 
 	if projectID == "" {
 		t.Fatal("require environment variable GOOGLE_CLOUD_PROJECT")
 	}
 
 	var buf bytes.Buffer
-	if err := generateContent(&buf, prompt, projectID, location, model, float32(temp)); err != nil {
+	if err := generateMultimodalContent(&buf, prompt, image, projectID, location, model); err != nil {
 		t.Fatal(err)
 	}
 
-	if got := buf.String(); !strings.Contains(got, "generate-content response") {
+	if got := buf.String(); !strings.Contains(got, "generated response: ") {
 		t.Error("generated text content not found in response")
 	}
 }

--- a/vertexai/safety-settings-multimodal/safety-settings-multimodal_test.go
+++ b/vertexai/safety-settings-multimodal/safety-settings-multimodal_test.go
@@ -32,7 +32,7 @@ func TestGenerateContent(t *testing.T) {
 
 	model := "gemini-pro-vision"
 
-	image := "https://storage.googleapis.com/cloud-samples-data/generative-ai/image/320px-Felis_catus-cat_on_snow.jpg"
+	image := "gs://cloud-samples-data/generative-ai/image/320px-Felis_catus-cat_on_snow.jpg"
 
 	if projectID == "" {
 		t.Fatal("require environment variable GOOGLE_CLOUD_PROJECT")


### PR DESCRIPTION
Also make it generally more consistent with the multimodal sample

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
