### PR TITLE
test(profiler): add tests for ListProfiles sample

### DIFF
--- a/profiler/export/main_test.go
+++ b/profiler/export/main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiler/export/main_test.go
+++ b/profiler/export/main_test.go
@@ -1,0 +1,78 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/profiler"
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+)
+
+func TestDownloadProfiles(t *testing.T) {
+	testutil.EndToEndTest(t)
+	projectID := os.Getenv("GOLANG_SAMPLES_PROJECT_ID")
+	if projectID == "" {
+		t.Skip("Skipping download profiles test. Set GOLANG_SAMPLES_PROJECT_ID.")
+	}
+	ctx := context.Background()
+	serviceVersion := fmt.Sprintf("v%v", time.Now().Unix())
+
+	// We profile this test run to generate profiles which can later be fetched
+	err := profiler.Start(profiler.Config{
+		Service:              "aaa-test-download-profiles",
+		ServiceVersion:       serviceVersion,
+		NoHeapProfiling:      true,
+		NoAllocProfiling:     true,
+		NoGoroutineProfiling: true,
+		DebugLogging:         true,
+		ProjectID:            projectID,
+	})
+	if err != nil {
+		t.Fatalf("failed to start the profiler: %v", err)
+	}
+	// do some work that generates profiles
+	busyloop(t)
+	var b bytes.Buffer
+	// Download a single profile
+	err = downloadProfiles(ctx, &b, projectID, "", 1, 1)
+	if err != nil {
+		t.Fatalf("download profiles failed: %v", err)
+	}
+	if output := b.String(); !strings.Contains(output, ProfilesDownloadedSuccessfully) || !strings.Contains(output, serviceVersion) {
+		t.Errorf("downloadProfiles: expected output: %q to contain %q and %q", output, ProfilesDownloadedSuccessfully, serviceVersion)
+	}
+}
+
+// Helper functions to keep CPU busy
+// See profiler_quickstart for details on how this works.
+func busyloop(t *testing.T) {
+	t.Helper()
+	for start := time.Now(); time.Since(start) < time.Minute*2; {
+		load()
+		runtime.Gosched()
+	}
+}
+
+func load() {
+	for i := 0; i < (1 << 20); i++ {
+	}
+}

--- a/profiler/export/main_test.go
+++ b/profiler/export/main_test.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -28,11 +27,8 @@ import (
 )
 
 func TestDownloadProfiles(t *testing.T) {
-	testutil.EndToEndTest(t)
-	projectID := os.Getenv("GOLANG_SAMPLES_PROJECT_ID")
-	if projectID == "" {
-		t.Skip("Skipping download profiles test. Set GOLANG_SAMPLES_PROJECT_ID.")
-	}
+	tc := testutil.EndToEndTest(t)
+	projectID := tc.ProjectID
 	ctx := context.Background()
 	serviceVersion := fmt.Sprintf("v%v", time.Now().Unix())
 

--- a/profiler/go.mod
+++ b/profiler/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	cloud.google.com/go/cloudprofiler v0.2.0
 	cloud.google.com/go/profiler v0.3.1
+	github.com/GoogleCloudPlatform/golang-samples v0.0.0-20230627093437-1cdc08c167bb
 	google.golang.org/api v0.150.0
 )
 
@@ -14,10 +15,13 @@ require (
 	cloud.google.com/go v0.110.9 // indirect
 	cloud.google.com/go/compute v1.23.2 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
+	cloud.google.com/go/iam v1.1.4 // indirect
+	cloud.google.com/go/storage v1.30.1 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/pprof v0.0.0-20230728192033-2ba5b33183c6 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
+	github.com/google/uuid v1.4.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.14.0 // indirect
@@ -27,6 +31,7 @@ require (
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
+	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20231030173426-d783a09b4405 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20231106174013-bbf56f31fb17 // indirect

--- a/profiler/go.sum
+++ b/profiler/go.sum
@@ -8,10 +8,14 @@ cloud.google.com/go/compute v1.23.2/go.mod h1:JJ0atRC0J/oWYiiVBmsSsrRnh92DhZPG4h
 cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
 cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
 cloud.google.com/go/iam v1.1.4 h1:K6n/GZHFTtEoKT5aUG3l9diPi0VduZNQ1PfdnpkkIFk=
+cloud.google.com/go/iam v1.1.4/go.mod h1:l/rg8l1AaA+VFMho/HYx2Vv6xinPSLMF8qfhRPIZ0L8=
 cloud.google.com/go/profiler v0.3.1 h1:b5got9Be9Ia0HVvyt7PavWxXEht15B9lWnigdvHtxOc=
 cloud.google.com/go/profiler v0.3.1/go.mod h1:GsG14VnmcMFQ9b+kq71wh3EKMZr3WRMgLzNiFRpW7tE=
 cloud.google.com/go/storage v1.30.1 h1:uOdMxAs8HExqBlnLtnQyP0YkvbiDpdGShGKtx6U/oNM=
+cloud.google.com/go/storage v1.30.1/go.mod h1:NfxhC0UJE1aXSx7CIIbCf7y9HKT7BiccwkR7+P7gN8E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/GoogleCloudPlatform/golang-samples v0.0.0-20230627093437-1cdc08c167bb h1:H2XnEH+Qp2HifRMChUvc7GLkjQ0jjbPsZLB0DunNwDI=
+github.com/GoogleCloudPlatform/golang-samples v0.0.0-20230627093437-1cdc08c167bb/go.mod h1:qoJeuUD3OhUVTIWsewOJg1sCSrCAOObUE3CRTIlPXfo=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -48,12 +52,14 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/martian/v3 v3.3.2 h1:IqNFLAmvJOgVlpdEBiQbDc2EwKW77amAycfTuWKdfvw=
 github.com/google/pprof v0.0.0-20230728192033-2ba5b33183c6 h1:ZgoomqkdjGbQ3+qQXCkvYMCDvGDNg2k5JJDjjdTB6jY=
 github.com/google/pprof v0.0.0-20230728192033-2ba5b33183c6/go.mod h1:Jh3hGz2jkYak8qXPD19ryItVnUgpgeqzdkY/D0EaeuA=
 github.com/google/s2a-go v0.1.7 h1:60BLSyTrOV4/haCDW4zb1guZItoSq8foHCXrAnjBo/o=
 github.com/google/s2a-go v0.1.7/go.mod h1:50CgR4k1jNlWBu4UfS4AcfhVe1r6pdZPygJ3R8F0Qdw=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
+github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/enterprise-certificate-proxy v0.3.2 h1:Vie5ybvEvT75RniqhfFxPRy3Bf7vr3h0cechB90XaQs=
 github.com/googleapis/enterprise-certificate-proxy v0.3.2/go.mod h1:VLSiSSBs/ksPL8kq3OBOQ6WRI2QnaFynd1DCjZ62+V0=
 github.com/googleapis/gax-go/v2 v2.12.0 h1:A+gCJKdRfqXkr+BIRGtZLibNXf0m1f9E4HG56etFpas=
@@ -113,6 +119,7 @@ golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
+golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 google.golang.org/api v0.150.0 h1:Z9k22qD289SZ8gCJrk4DrWXkNjtfvKAUo/l1ma8eBYE=
 google.golang.org/api v0.150.0/go.mod h1:ccy+MJ6nrYFgE3WgRx/AMXOxOmU8Q4hSa+jjibzhxcg=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/testing/kokoro/system_tests.sh
+++ b/testing/kokoro/system_tests.sh
@@ -108,6 +108,8 @@ export GOLANG_SAMPLES_BIGTABLE_PROJECT=golang-samples-tests
 export GOLANG_SAMPLES_BIGTABLE_INSTANCE=testing-instance
 
 export GOLANG_SAMPLES_FIRESTORE_PROJECT=golang-samples-fire-0
+# This flag is added to avoid protobuf conflicts while running tests for profiler.
+# TODO: Remove this after https://github.com/googleapis/google-cloud-go/issues/9207 is resolved.
 export GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn
 
 set -x

--- a/testing/kokoro/system_tests.sh
+++ b/testing/kokoro/system_tests.sh
@@ -108,6 +108,7 @@ export GOLANG_SAMPLES_BIGTABLE_PROJECT=golang-samples-tests
 export GOLANG_SAMPLES_BIGTABLE_INSTANCE=testing-instance
 
 export GOLANG_SAMPLES_FIRESTORE_PROJECT=golang-samples-fire-0
+export GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn
 
 set -x
 


### PR DESCRIPTION
## Description

Adds test for the ListProfiles API sample for Google Cloud Profiler.

#### NOTE:
*Due to a protobuf registration conflict between the profiler agent and profiler client library, currently to run the test successfully,* `GOLANG_PROTOBUF_REGISTRATION_CONFLICT` *environment variable needs to be set.* 

Run tests locally via -  
```
GOLANG_PROTOBUF_REGISTRATION_CONFLICT=warn go test -v
```

### Additional Requirements:
 - This test requires Cloud Profiler API to be enabled to pass.

## Checklist
- [X] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [x] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
