### PR TITLE
fix: use go1.21, without a toolchain directive-  avoiding diffs in go.mod

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -33,7 +33,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '~1.20'
+        go-version: '~1.21'
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Install goimports
@@ -41,6 +41,8 @@ jobs:
     - run: goimports -w .
     - name: Run go mod tidy on all modules
       run: find . -name go.mod -execdir go mod tidy \;
+    - name: Remove any toolchain lines
+      run: find . -name go.mod -execdir go get toolchain@none \;
     # If there are any diffs from goimports or go mod tidy, fail.
     - name: Verify no changes from goimports and go mod tidy.
       run: |
@@ -58,7 +60,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '~1.20'
+        go-version: '~1.21'
     - name: Checkout code
       uses: actions/checkout@v2
     - name: go vet
@@ -76,7 +78,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '~1.20'
+          go-version: '~1.21'
       - name: Check code
         uses: actions/checkout@v2
       - run: go test -v

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '^1.19'
+        go-version: '~1.19'
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Build code
@@ -33,7 +33,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '^1.19'
+        go-version: '~1.19'
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Install goimports
@@ -58,7 +58,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '^1.19'
+        go-version: '~1.19'
     - name: Checkout code
       uses: actions/checkout@v2
     - name: go vet
@@ -76,7 +76,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.19'
+          go-version: '~1.19'
       - name: Check code
         uses: actions/checkout@v2
       - run: go test -v

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '~1.19'
+        go-version: '~1.20'
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Build code
@@ -33,7 +33,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '~1.19'
+        go-version: '~1.20'
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Install goimports
@@ -58,7 +58,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '~1.19'
+        go-version: '~1.20'
     - name: Checkout code
       uses: actions/checkout@v2
     - name: go vet
@@ -76,7 +76,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '~1.19'
+          go-version: '~1.20'
       - name: Check code
         uses: actions/checkout@v2
       - run: go test -v

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '~1.20'
+        go-version: '~1.21'
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Build code


### PR DESCRIPTION
diffs are caused by 1.22's introduction of the 'toolchain' directive.

`go get toolchain@none` explicitly removes the toolchain lines, which cause build errors in prior versions.

Part of #3739
