### PR TITLE
test: enable the 'loopvar' experiment to prepare for 1.22

### DIFF
--- a/testing/kokoro/system_tests.sh
+++ b/testing/kokoro/system_tests.sh
@@ -34,6 +34,8 @@ date
 cd "${1:-github/golang-samples}"
 PROJECT_ROOT=$(pwd)
 
+# Test the loop variable change that may appear in 1.22: https://go.dev/wiki/LoopvarExperiment
+export GOEXPERIMENT=loopvar
 export GO111MODULE=on # Always use modules.
 export GOPROXY=https://proxy.golang.org
 TIMEOUT=60m


### PR DESCRIPTION
This PR should shake out any tests that need changes prior to the release of
go1.22, which introduces a change to the way loop variables are scoped.

see https://go.dev/wiki/LoopvarExperiment for details.
