### PR TITLE
test(storage): add retry to flaky SignedURL test

### DIFF
--- a/storage/objects/objects_test.go
+++ b/storage/objects/objects_test.go
@@ -391,16 +391,13 @@ func TestKMSObjects(t *testing.T) {
 func TestV4SignedURL(t *testing.T) {
 	tc := testutil.SystemTest(t)
 	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		t.Fatalf("storage.NewClient: %v", err)
-	}
-	defer client.Close()
 
 	bucketName := tc.ProjectID + "-signed-url-bucket-name"
 	objectName := "foo.txt"
 
 	testutil.CleanBucket(ctx, t, tc.ProjectID, bucketName)
+
+	// Generate PUT URL.
 	putBuf := new(bytes.Buffer)
 	putURL, err := generateV4PutObjectSignedURL(putBuf, bucketName, objectName)
 	if err != nil {
@@ -411,17 +408,7 @@ func TestV4SignedURL(t *testing.T) {
 		t.Errorf("got %q, want %q", got, want)
 	}
 
-	httpClient := &http.Client{}
-	request, err := http.NewRequest("PUT", putURL, strings.NewReader("hello world"))
-	if err != nil {
-		t.Fatalf("failed to compose HTTP request: %v", err)
-	}
-	request.ContentLength = 11
-	request.Header.Set("Content-Type", "application/octet-stream")
-	_, err = httpClient.Do(request)
-	if err != nil {
-		t.Errorf("httpClient.Do: %v", err)
-	}
+	// Generate GET URL.
 	getBuf := new(bytes.Buffer)
 	getURL, err := generateV4GetObjectSignedURL(getBuf, bucketName, objectName)
 	if err != nil {
@@ -432,20 +419,37 @@ func TestV4SignedURL(t *testing.T) {
 		t.Errorf("got %q, want %q", got, want)
 	}
 
-	response, err := http.Get(getURL)
+	// Create PUT request.
+	httpClient := &http.Client{}
+	request, err := http.NewRequest("PUT", putURL, strings.NewReader("hello world"))
 	if err != nil {
-		t.Errorf("http.Get: %v", err)
+		t.Fatalf("failed to compose HTTP request: %v", err)
 	}
-	defer response.Body.Close()
+	request.ContentLength = 11
+	request.Header.Set("Content-Type", "application/octet-stream")
 
-	body, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		t.Errorf("ioutil.ReadAll: %v", err)
-	}
+	// Test PUT and GET requests.
+	testutil.Retry(t, 10, time.Second, func(r *testutil.R) {
+		_, err = httpClient.Do(request)
+		if err != nil {
+			t.Errorf("httpClient.Do: %v", err)
+		}
 
-	if got, want := string(body), "hello world"; got != want {
-		t.Errorf("object content = %q; want %q", got, want)
-	}
+		response, err := http.Get(getURL)
+		if err != nil {
+			t.Errorf("http.Get: %v", err)
+		}
+		defer response.Body.Close()
+
+		body, err := io.ReadAll(response.Body)
+		if err != nil {
+			t.Errorf("io.ReadAll: %v", err)
+		}
+
+		if got, want := string(body), "hello world"; got != want {
+			t.Errorf("object content = %q; want %q", got, want)
+		}
+	})
 }
 
 func TestPostPolicyV4(t *testing.T) {

--- a/storage/objects/objects_test.go
+++ b/storage/objects/objects_test.go
@@ -432,22 +432,22 @@ func TestV4SignedURL(t *testing.T) {
 	testutil.Retry(t, 10, time.Second, func(r *testutil.R) {
 		_, err = httpClient.Do(request)
 		if err != nil {
-			t.Errorf("httpClient.Do: %v", err)
+			r.Errorf("httpClient.Do: %v", err)
 		}
 
 		response, err := http.Get(getURL)
 		if err != nil {
-			t.Errorf("http.Get: %v", err)
+			r.Errorf("http.Get: %v", err)
 		}
 		defer response.Body.Close()
 
 		body, err := io.ReadAll(response.Body)
 		if err != nil {
-			t.Errorf("io.ReadAll: %v", err)
+			r.Errorf("io.ReadAll: %v", err)
 		}
 
 		if got, want := string(body), "hello world"; got != want {
-			t.Errorf("object content = %q; want %q", got, want)
+			r.Errorf("object content = %q; want %q", got, want)
 		}
 	})
 }


### PR DESCRIPTION
Adds a retry around the signed URL http calls. Moves code around a bit so that only the necessary bits are retried.

Fixes #3737

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
