### PR TITLE
test(storage): add retry to HMAC key deletion

### DIFF
--- a/storage/service_account/hmac/hmac_test.go
+++ b/storage/service_account/hmac/hmac_test.go
@@ -167,11 +167,11 @@ func TestDeleteKey(t *testing.T) {
 	testutil.Retry(t, 18, 10*time.Second, func(r *testutil.R) {
 		err = deleteHMACKey(io.Discard, key.AccessID, key.ProjectID)
 		if err != nil {
-			t.Errorf("Error in deleteHMACKey: %s", err)
+			r.Errorf("Error in deleteHMACKey: %s", err)
 		}
 		key, _ = handle.Get(ctx)
 		if key != nil && key.State != "DELETED" {
-			t.Errorf("State of key is %s, should be DELETED", key.State)
+			r.Errorf("State of key is %s, should be DELETED", key.State)
 		}
 
 	})

--- a/storage/service_account/hmac/hmac_test.go
+++ b/storage/service_account/hmac/hmac_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -157,17 +158,23 @@ func TestDeleteKey(t *testing.T) {
 	// Keys must be in INACTIVE state before deletion.
 	ctx := context.Background()
 	handle := storageClient.HMACKeyHandle(key.ProjectID, key.AccessID)
-	handle.Update(ctx, storage.HMACKeyAttrsToUpdate{State: "INACTIVE"})
-
-	err = deleteHMACKey(ioutil.Discard, key.AccessID, key.ProjectID)
+	_, err = handle.Update(ctx, storage.HMACKeyAttrsToUpdate{State: "INACTIVE"})
 	if err != nil {
-		t.Errorf("Error in deleteHMACKey: %s", err)
-	}
-	key, _ = handle.Get(ctx)
-	if key != nil && key.State != "DELETED" {
-		t.Errorf("State of key is %s, should be DELETED", key.State)
+		t.Errorf("Error updating HMAC key: %s", err)
 	}
 
+	// Retry as HMAC key updates can take up to 3 minutes to propagate.
+	testutil.Retry(t, 18, 10*time.Second, func(r *testutil.R) {
+		err = deleteHMACKey(io.Discard, key.AccessID, key.ProjectID)
+		if err != nil {
+			t.Errorf("Error in deleteHMACKey: %s", err)
+		}
+		key, _ = handle.Get(ctx)
+		if key != nil && key.State != "DELETED" {
+			t.Errorf("State of key is %s, should be DELETED", key.State)
+		}
+
+	})
 }
 
 // Delete all HMAC keys in the project.


### PR DESCRIPTION
## Description
Retry as HMAC key updates can take up to 3 minutes to propagate.

Fixes #3751

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
