### PR TITLE
docs(samples): passing data out of firestore transaction in go

### DIFF
--- a/firestore/save_test.go
+++ b/firestore/save_test.go
@@ -105,7 +105,7 @@ func TestSave(t *testing.T) {
 	if err = runSimpleTransaction(ctx, client); err != nil {
 		t.Fatalf("runSimpleTransaction: %v", err)
 	}
-	if err = infoTransaction(ctx, client); err != nil {
+	if _, err = infoTransaction(ctx, client); err != nil {
 		t.Fatalf("infoTransaction: %v", err)
 	}
 	if err = batchWrite(ctx, client); err != nil {


### PR DESCRIPTION
Fixes #3777

## Checklist

  * [x]  I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
  * [ ]  **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
  * [x]  **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
  * [ ]  **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
  * [ ]  These samples need a new **API enabled** in testing projects to pass (let us know which ones)
  * [ ]  These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
  * [ ]  This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
  * [ ]  This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
  * [x]  Please **merge** this PR for me once it is approved