### PR TITLE
fix(vertexai): in safety samples, do not write a main func

### DIFF
--- a/vertexai/safety-settings-multimodal/safety-settings-multimodal.go
+++ b/vertexai/safety-settings-multimodal/safety-settings-multimodal.go
@@ -12,38 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // safety-settings-multimodal shows how to adjust safety settings for mixed text and image input
-package main
+package safetysettingsmultimodal
 
 // [START aiplatform_gemini_safety_settings]
 import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"mime"
-	"os"
 	"path/filepath"
 
 	"cloud.google.com/go/vertexai/genai"
 )
-
-func main() {
-	projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
-	location := "us-central1"
-	modelName := "gemini-pro-vision"
-
-	prompt := "describe what is in this picture"
-	image := "gs://generativeai-downloads/images/scones.jpg"
-
-	if projectID == "" {
-		log.Fatal("require environment variable GOOGLE_CLOUD_PROJECT")
-	}
-
-	err := generateMultimodalContent(os.Stdout, prompt, image, projectID, location, modelName)
-	if err != nil {
-		log.Fatalf("unable to generate: %v", err)
-	}
-}
 
 // generateMultimodalContent generates a response into w, based upon the prompt
 // and image provided.

--- a/vertexai/safety-settings-multimodal/safety-settings-multimodal_test.go
+++ b/vertexai/safety-settings-multimodal/safety-settings-multimodal_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package safetysettingsmultimodal
 
 import (
 	"bytes"
@@ -23,7 +23,6 @@ import (
 )
 
 func TestGenerateContent(t *testing.T) {
-	t.Skip("TODO(muncus): remove skip")
 	tc := testutil.SystemTest(t)
 
 	prompt := "describe this image."

--- a/vertexai/safety-settings/safety-settings.go
+++ b/vertexai/safety-settings/safety-settings.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,35 +13,15 @@
 // limitations under the License.
 // safety-settings shows how to adjust safety settings for a generative model
 
-package main
+package safetysettings
 
 import (
 	"context"
 	"fmt"
 	"io"
-	"log"
-	"os"
 
 	"cloud.google.com/go/vertexai/genai"
 )
-
-func main() {
-	projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
-	location := "us-central1"
-	modelName := "gemini-pro"
-	temperature := 0.4
-
-	prompt := "say something nice to me, but be angry"
-
-	if projectID == "" {
-		log.Fatal("require environment variable GOOGLE_CLOUD_PROJECT")
-	}
-
-	err := generateContent(os.Stdout, prompt, projectID, location, modelName, float32(temperature))
-	if err != nil {
-		fmt.Printf("unable to generate: %v\n", err)
-	}
-}
 
 // generateContent generates text from prompt and configurations provided.
 func generateContent(w io.Writer, prompt, projectID, location, modelName string, temperature float32) error {

--- a/vertexai/safety-settings/safety-settings_test.go
+++ b/vertexai/safety-settings/safety-settings_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package safetysettings
 
 import (
 	"bytes"


### PR DESCRIPTION
Removing main, to conform to style. Note that the sample values won't be displayed anymore at
[Configure safety attributes](https://cloud.google.com/vertex-ai/docs/generative-ai/multimodal/configure-safety-attributes#gemini-TASK-samples-go).
