### PR TITLE
chore(opentelemetry): simplify OpenTelemetry instrumentation logging sample

### DIFF
--- a/opentelemetry/instrumentation/app/logger.go
+++ b/opentelemetry/instrumentation/app/logger.go
@@ -16,14 +16,10 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
-	"os"
 
 	"go.opentelemetry.io/otel/trace"
 )
-
-var projectId = os.Getenv("GOOGLE_CLOUD_PROJECT")
 
 // handlerWithSpanContext adds attributes from the span context
 // [START opentelemetry_instrumentation_spancontext_logger]
@@ -45,7 +41,7 @@ func (t *spanContextLogHandler) Handle(ctx context.Context, record slog.Record) 
 		// Add trace context attributes following Cloud Logging structured log format described
 		// in https://cloud.google.com/logging/docs/structured-logging#special-payload-fields
 		record.AddAttrs(
-			slog.Any("logging.googleapis.com/trace", fmt.Sprintf("projects/%s/traces/%s", projectId, s.TraceID())),
+			slog.Any("logging.googleapis.com/trace", s.TraceID()),
 		)
 		record.AddAttrs(
 			slog.Any("logging.googleapis.com/spanId", s.SpanID()),

--- a/opentelemetry/instrumentation/docker-compose.yaml
+++ b/opentelemetry/instrumentation/docker-compose.yaml
@@ -7,7 +7,6 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otelcol:4318
       - OTEL_SERVICE_NAME=otel-quickstart-go
       - OTEL_GO_X_EXEMPLAR=true
-      - GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT?}
     volumes:
       - logs:/var/log:rw
     depends_on:

--- a/opentelemetry/instrumentation/otel-collector-config.yaml
+++ b/opentelemetry/instrumentation/otel-collector-config.yaml
@@ -28,7 +28,7 @@ receivers:
       - type: regex_parser
         parse_from: body["logging.googleapis.com/trace"]
         parse_to: body
-        regex: projects/.+/traces/(?P<trace_id>.*)
+        regex: (?P<trace_id>.*)
         trace:
           span_id:
             parse_from: body["logging.googleapis.com/spanId"]


### PR DESCRIPTION
## Description

Based on my testing, logging agents will prefix trace ids with the required projects/my-project/traces prefix if it isn't present.  This means we can simplify our logging code to just use the required attributes.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
