### PR TITLE
feat(spanner): add transaction timeout sample

### DIFF
--- a/spanner/spanner_snippets/spanner/integration_test.go
+++ b/spanner/spanner_snippets/spanner/integration_test.go
@@ -273,6 +273,9 @@ func TestSample(t *testing.T) {
 	out = runSample(t, setCustomTimeoutAndRetry, dbName, "failed to insert using DML with custom timeout and retry")
 	assertContains(t, out, "record(s) inserted")
 
+	out = runSample(t, transactionTimeout, dbName, "failed to run transaction with a timeout")
+	assertContains(t, out, "Transaction with timeout was executed successfully")
+
 	out = runSample(t, updateUsingDML, dbName, "failed to update using DML")
 	assertContains(t, out, "record(s) updated")
 

--- a/spanner/spanner_snippets/spanner/spanner_transaction_timeout.go
+++ b/spanner/spanner_snippets/spanner/spanner_transaction_timeout.go
@@ -1,0 +1,90 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanner
+
+// [START spanner_transaction_timeout]
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"google.golang.org/api/iterator"
+	"google.golang.org/grpc/codes"
+	"io"
+	"time"
+
+	"cloud.google.com/go/spanner"
+)
+
+func transactionTimeout(w io.Writer, db string) error {
+	ctx := context.Background()
+	client, err := spanner.NewClient(ctx, db)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	// Create a context with a 60-second timeout and use this context to run a read/write transaction.
+	// This context timeout will be applied to the entire transaction, and the transaction will fail
+	// if it cannot finish within the specified timeout value.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	_, err = client.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
+		selectStmt := spanner.Statement{
+			SQL: `SELECT SingerId, FirstName, LastName FROM Singers ORDER BY LastName, FirstName`,
+		}
+		iter := txn.Query(ctx, selectStmt)
+		defer iter.Stop()
+		for {
+			row, err := iter.Next()
+			if errors.Is(err, iterator.Done) {
+				break
+			}
+			if err != nil {
+				return err
+			}
+			var singerID int64
+			var firstName, lastName string
+			if err := row.Columns(&singerID, &firstName, &lastName); err != nil {
+				return err
+			}
+			fmt.Fprintf(w, "%d %s %s\n", singerID, firstName, lastName)
+		}
+		stmt := spanner.Statement{
+			SQL: `INSERT INTO Singers (SingerId, FirstName, LastName)
+					VALUES (20, 'George', 'Washington')`,
+		}
+		rowCount, err := txn.Update(ctx, stmt)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(w, "%d record(s) inserted.\n", rowCount)
+		return nil
+	})
+	// Check if an error was returned by the transaction.
+	// The spanner.ErrCode(err) function will return codes.OK if err == nil.
+	code := spanner.ErrCode(err)
+	if code == codes.OK {
+		fmt.Fprintf(w, "Transaction with timeout was executed successfully\n")
+	} else if code == codes.DeadlineExceeded {
+		fmt.Fprintf(w, "Transaction timed out\n")
+	} else {
+		fmt.Fprintf(w, "Transaction failed with error code %v\n", code)
+	}
+	return err
+}
+
+// [END spanner_transaction_timeout]

--- a/spanner/spanner_snippets/spanner/spanner_transaction_timeout.go
+++ b/spanner/spanner_snippets/spanner/spanner_transaction_timeout.go
@@ -38,7 +38,8 @@ func transactionTimeout(w io.Writer, db string) error {
 
 	// Create a context with a 60-second timeout and use this context to run a read/write transaction.
 	// This context timeout will be applied to the entire transaction, and the transaction will fail
-	// if it cannot finish within the specified timeout value.
+	// if it cannot finish within the specified timeout value. The Spanner client library applies the
+	// (remainder of the) timeout to each statement that is executed in the transaction.
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
@@ -46,6 +47,8 @@ func transactionTimeout(w io.Writer, db string) error {
 		selectStmt := spanner.Statement{
 			SQL: `SELECT SingerId, FirstName, LastName FROM Singers ORDER BY LastName, FirstName`,
 		}
+		// The context that is passed in to the transaction function should be used for each statement
+		// is executed.
 		iter := txn.Query(ctx, selectStmt)
 		defer iter.Stop()
 		for {

--- a/spanner/spanner_snippets/spanner/spanner_transaction_timeout.go
+++ b/spanner/spanner_snippets/spanner/spanner_transaction_timeout.go
@@ -65,7 +65,7 @@ func transactionTimeout(w io.Writer, db string) error {
 		}
 		stmt := spanner.Statement{
 			SQL: `INSERT INTO Singers (SingerId, FirstName, LastName)
-					VALUES (20, 'George', 'Washington')`,
+					VALUES (38, 'George', 'Washington')`,
 		}
 		rowCount, err := txn.Update(ctx, stmt)
 		if err != nil {

--- a/spanner/spanner_snippets/spanner/spanner_transaction_timeout.go
+++ b/spanner/spanner_snippets/spanner/spanner_transaction_timeout.go
@@ -20,12 +20,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"google.golang.org/api/iterator"
-	"google.golang.org/grpc/codes"
 	"io"
 	"time"
 
 	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+	"google.golang.org/grpc/codes"
 )
 
 func transactionTimeout(w io.Writer, db string) error {


### PR DESCRIPTION
Adds a sample for setting a timeout for an entire read/write transaction when using Spanner. This sample is needed for the Spanner documentation pages, as this is a recurring question from Spanner customers.
