### PR TITLE
test(storage): unflake HMAC test again

### DIFF
--- a/storage/service_account/hmac/hmac_test.go
+++ b/storage/service_account/hmac/hmac_test.go
@@ -26,7 +26,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-	"github.com/googleapis/gax-go/v2/apierror"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
 )
 
@@ -170,9 +170,9 @@ func TestDeleteKey(t *testing.T) {
 			// 400 error with reason "invalid" means the key was already deleted;
 			// this can happen if there was a previous call that returned an error
 			// but succeeded on the server side.
-			var ae *apierror.APIError
-			if errors.As(err, &ae) {
-				if ae.HTTPCode() == 400 && ae.Reason() == "invalid" {
+			var ge *googleapi.Error
+			if errors.As(err, &ge) {
+				if ge.Code == 400 && len(ge.Errors) > 0 && ge.Errors[0].Reason == "invalid" {
 					return
 				}
 			}


### PR DESCRIPTION
apierror.APIError does not seem to be picking up the reason for the failure, so use googleapi.Error instead.

Fixes #3802

## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [ ] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
