### PR TITLE
test(pubsub): make resource cleanup fire and forget

### DIFF
--- a/pubsub/subscriptions/subscription_test.go
+++ b/pubsub/subscriptions/subscription_test.go
@@ -85,9 +85,8 @@ func setup(t *testing.T) *pubsub.Client {
 				}
 				timeTCreated := time.Unix(0, timestamp)
 				if time.Since(timeTCreated) > expireAge {
-					if err := t.Delete(ctx); err != nil {
-						fmt.Printf("Delete topic err: %v: %v", t.String(), err)
-					}
+					// Topic deletion can be fire and forget
+					t.Delete(ctx)
 				}
 			}
 		}
@@ -112,9 +111,8 @@ func setup(t *testing.T) *pubsub.Client {
 				}
 				timeTCreated := time.Unix(0, timestamp)
 				if time.Since(timeTCreated) > expireAge {
-					if err := s.Delete(ctx); err != nil {
-						fmt.Printf("Delete sub err: %v: %v", s.String(), err)
-					}
+					// Subscription deletion can be fire and forget
+					s.Delete(ctx)
 				}
 			}
 		}


### PR DESCRIPTION
## Description

We cleanup stale resources at the start of each test run. Currently, an error message is printed out when a delete operation fails, but often times this is just a `not found` error. Making this fire and forget (not checking returned error) is safe since the stale resources can be deleted in a future test invocation.

Fixes #3970

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] Please **merge** this PR for me once it is approved
