### PR TITLE
fix(compute): 3597 and update computepb types location

### DIFF
--- a/compute/change_machine_type.go
+++ b/compute/change_machine_type.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 // changeMachineType changes the machine type of the instance.

--- a/compute/compute_test.go
+++ b/compute/compute_test.go
@@ -24,8 +24,8 @@ import (
 	"time"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 )
 
 func TestComputeSnippets(t *testing.T) {

--- a/compute/create_instance.go
+++ b/compute/create_instance.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/create_instance_from_template.go
+++ b/compute/create_instance_from_template.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/create_instance_from_template_test.go
+++ b/compute/create_instance_from_template_test.go
@@ -24,8 +24,8 @@ import (
 	"time"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/create_instance_from_template_with_overrides.go
+++ b/compute/create_instance_from_template_with_overrides.go
@@ -21,7 +21,8 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
+
 	"google.golang.org/protobuf/proto"
 )
 
@@ -57,8 +58,6 @@ func createInstanceFromTemplateWithOverrides(w io.Writer, projectID, zone, insta
 	if err != nil {
 		return fmt.Errorf("unable to get intance template: %w", err)
 	}
-
-	fmt.Printf("%s", "asdfadf")
 
 	for _, disk := range instanceTemplate.Properties.Disks {
 		diskType := disk.InitializeParams.GetDiskType()

--- a/compute/custom-hostname-instance/create_instance_with_custom_hostname.go
+++ b/compute/custom-hostname-instance/create_instance_with_custom_hostname.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/custom-hostname-instance/get_instance_hostname.go
+++ b/compute/custom-hostname-instance/get_instance_hostname.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 // getInstanceHostname prints the hostname of the Google Cloud VM instance.

--- a/compute/custom-hostname-instance/instance_hostname_test.go
+++ b/compute/custom-hostname-instance/instance_hostname_test.go
@@ -24,8 +24,8 @@ import (
 	"time"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 )
 
 func TestInstanceHostnameSnippets(t *testing.T) {

--- a/compute/delete_instance.go
+++ b/compute/delete_instance.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 // deleteInstance sends a delete request to the Compute Engine API and waits for it to complete.

--- a/compute/disable_usage_export.go
+++ b/compute/disable_usage_export.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 // disableUsageExport disables Compute Engine usage export bucket for the Cloud Project.

--- a/compute/disk-images/create_disk_image.go
+++ b/compute/disk-images/create_disk_image.go
@@ -22,7 +22,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 // Creates a disk image from an existing disk

--- a/compute/disk-images/delete_disk_image.go
+++ b/compute/disk-images/delete_disk_image.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 // Deletes the specified disk image

--- a/compute/disk-images/disk_image_test.go
+++ b/compute/disk-images/disk_image_test.go
@@ -24,8 +24,8 @@ import (
 	"time"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/disks/attach_regional_disk.go
+++ b/compute/disks/attach_regional_disk.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 // Attaches the provided regional disk in read-write mode to the given VM

--- a/compute/disks/attach_regional_disk_readonly.go
+++ b/compute/disks/attach_regional_disk_readonly.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 // Attaches the provided regional disk in read-only mode to the given VM.

--- a/compute/disks/clone_encrypted_disk.go
+++ b/compute/disks/clone_encrypted_disk.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/disks/clone_kms_encrypted_disk.go
+++ b/compute/disks/clone_kms_encrypted_disk.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/disks/create_disk_from_disk.go
+++ b/compute/disks/create_disk_from_disk.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/disks/create_disk_from_image.go
+++ b/compute/disks/create_disk_from_image.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/disks/create_disk_from_snapshot.go
+++ b/compute/disks/create_disk_from_snapshot.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/disks/create_empty_disk.go
+++ b/compute/disks/create_empty_disk.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/disks/create_encrypted_disk.go
+++ b/compute/disks/create_encrypted_disk.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/disks/create_kms_encrypted_disk.go
+++ b/compute/disks/create_kms_encrypted_disk.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/disks/create_regional.go
+++ b/compute/disks/create_regional.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/disks/create_regional_from_disk.go
+++ b/compute/disks/create_regional_from_disk.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/disks/create_regional_from_snapshot.go
+++ b/compute/disks/create_regional_from_snapshot.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/disks/delete_disk.go
+++ b/compute/disks/delete_disk.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 // deleteDisk deletes a disk from a project.

--- a/compute/disks/delete_regional_disk.go
+++ b/compute/disks/delete_regional_disk.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 // deleteRegionalDisk permanently deletes a regional disk.

--- a/compute/disks/resize_regional_disk.go
+++ b/compute/disks/resize_regional_disk.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 // resizeRegionalDisk changes the size of a regional disk.

--- a/compute/disks/set_disk_autodelete.go
+++ b/compute/disks/set_disk_autodelete.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 // setDiskAutodelete sets the autodelete flag of a disk to given value.

--- a/compute/firewall/create_firewall_rule.go
+++ b/compute/firewall/create_firewall_rule.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/firewall/delete_firewall_rule.go
+++ b/compute/firewall/delete_firewall_rule.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 // deleteFirewallRule deletes a firewall rule from the project.

--- a/compute/firewall/firewall_test.go
+++ b/compute/firewall/firewall_test.go
@@ -24,8 +24,8 @@ import (
 	"time"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 )
 
 func TestFirewallSnippets(t *testing.T) {

--- a/compute/firewall/list_firewall_rules.go
+++ b/compute/firewall/list_firewall_rules.go
@@ -21,8 +21,8 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/api/iterator"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 )
 
 // listFirewallRules prints the list of firewall names and their descriptions in specified project

--- a/compute/firewall/patch_firewall_priority.go
+++ b/compute/firewall/patch_firewall_priority.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/get_instance.go
+++ b/compute/get_instance.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 // getInstance prints a name of a VM instance in the given zone in the specified project.

--- a/compute/get_usage_export_bucket.go
+++ b/compute/get_usage_export_bucket.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/go.mod
+++ b/compute/go.mod
@@ -7,7 +7,6 @@ require (
 	cloud.google.com/go/storage v1.36.0
 	github.com/GoogleCloudPlatform/golang-samples v0.0.0-20240111005027-4c7a1933dce2
 	google.golang.org/api v0.156.0
-	google.golang.org/genproto v0.0.0-20240108191215-35c7eff3a6b1
 	google.golang.org/protobuf v1.32.0
 )
 
@@ -38,6 +37,7 @@ require (
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
+	google.golang.org/genproto v0.0.0-20240108191215-35c7eff3a6b1 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240102182953-50ed04b92917 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240102182953-50ed04b92917 // indirect
 	google.golang.org/grpc v1.60.1 // indirect

--- a/compute/instance-templates/create-instance-templates/create_instance_templates_test.go
+++ b/compute/instance-templates/create-instance-templates/create_instance_templates_test.go
@@ -24,8 +24,8 @@ import (
 	"time"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instance-templates/create-instance-templates/create_template.go
+++ b/compute/instance-templates/create-instance-templates/create_template.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instance-templates/create-instance-templates/create_template_from_instance.go
+++ b/compute/instance-templates/create-instance-templates/create_template_from_instance.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instance-templates/create-instance-templates/create_template_with_subnet.go
+++ b/compute/instance-templates/create-instance-templates/create_template_with_subnet.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instance-templates/create-instance-templates/delete_instance_template.go
+++ b/compute/instance-templates/create-instance-templates/delete_instance_template.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 // deleteInstanceTemplate deletes an instance template.

--- a/compute/instance-templates/create-instance-templates/get_instance_template.go
+++ b/compute/instance-templates/create-instance-templates/get_instance_template.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 // getInstanceTemplate retrieves an instance template, which you can use to create virtual machine

--- a/compute/instance-templates/create-instance-templates/list_instance_templates.go
+++ b/compute/instance-templates/create-instance-templates/list_instance_templates.go
@@ -21,8 +21,8 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/api/iterator"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 )
 
 // listInstanceTemplates prints a list of InstanceTemplate objects available in a project.

--- a/compute/instances/create-manage-windows-instances/create_firewall_rule_for_windows_activation_host.go
+++ b/compute/instances/create-manage-windows-instances/create_firewall_rule_for_windows_activation_host.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/create-manage-windows-instances/create_route_to_windows_activation_host.go
+++ b/compute/instances/create-manage-windows-instances/create_route_to_windows_activation_host.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/create-manage-windows-instances/create_windows_instances_test.go
+++ b/compute/instances/create-manage-windows-instances/create_windows_instances_test.go
@@ -24,8 +24,8 @@ import (
 	"time"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 )
 
 func deleteInstance(ctx context.Context, projectId, zone, instanceName string) error {

--- a/compute/instances/create-manage-windows-instances/create_windows_server_external_ip.go
+++ b/compute/instances/create-manage-windows-instances/create_windows_server_external_ip.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/create-manage-windows-instances/create_windows_server_internal_ip.go
+++ b/compute/instances/create-manage-windows-instances/create_windows_server_internal_ip.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/create-manage-windows-instances/get_instance_serial_port.go
+++ b/compute/instances/create-manage-windows-instances/get_instance_serial_port.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 // getInstanceSerialPort prints the serial port output for an instance.

--- a/compute/instances/create-start-instance/create_instance_from_custom_image.go
+++ b/compute/instances/create-start-instance/create_instance_from_custom_image.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/create-start-instance/create_instance_from_public_image.go
+++ b/compute/instances/create-start-instance/create_instance_from_public_image.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/create-start-instance/create_instance_from_snapshot.go
+++ b/compute/instances/create-start-instance/create_instance_from_snapshot.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/create-start-instance/create_instance_from_snapshot_test.go
+++ b/compute/instances/create-start-instance/create_instance_from_snapshot_test.go
@@ -24,8 +24,8 @@ import (
 	"time"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/create-start-instance/create_instance_test.go
+++ b/compute/instances/create-start-instance/create_instance_test.go
@@ -24,8 +24,8 @@ import (
 	"time"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/create-start-instance/create_instance_with_additional_disk.go
+++ b/compute/instances/create-start-instance/create_instance_with_additional_disk.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/create-start-instance/create_instance_with_existing_disks.go
+++ b/compute/instances/create-start-instance/create_instance_with_existing_disks.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/create-start-instance/create_instance_with_local_ssd.go
+++ b/compute/instances/create-start-instance/create_instance_with_local_ssd.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/create-start-instance/create_instance_with_snapshotted_data_disk.go
+++ b/compute/instances/create-start-instance/create_instance_with_snapshotted_data_disk.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/create-start-instance/create_instance_with_subnet.go
+++ b/compute/instances/create-start-instance/create_instance_with_subnet.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/create-start-instance/utils_test.go
+++ b/compute/instances/create-start-instance/utils_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 func deleteInstance(ctx context.Context, projectId, zone, instanceName string) error {

--- a/compute/instances/custom-machine-type/create_custom_machine_type.go
+++ b/compute/instances/custom-machine-type/create_custom_machine_type.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/custom-machine-type/create_shared_with_helper.go
+++ b/compute/instances/custom-machine-type/create_shared_with_helper.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/custom-machine-type/create_with_helper.go
+++ b/compute/instances/custom-machine-type/create_with_helper.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/custom-machine-type/create_without_helper.go
+++ b/compute/instances/custom-machine-type/create_without_helper.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/custom-machine-type/custom_machine_type_test.go
+++ b/compute/instances/custom-machine-type/custom_machine_type_test.go
@@ -24,8 +24,8 @@ import (
 	"time"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 )
 
 func deleteInstance(ctx context.Context, projectId, zone, instanceName string) error {

--- a/compute/instances/custom-machine-type/extra_mem_without_helper.go
+++ b/compute/instances/custom-machine-type/extra_mem_without_helper.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/custom-machine-type/update_memory.go
+++ b/compute/instances/custom-machine-type/update_memory.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/preemptible/create_preemtible.go
+++ b/compute/instances/preemptible/create_preemtible.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/preemptible/preemptible_history.go
+++ b/compute/instances/preemptible/preemptible_history.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/api/iterator"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/preemptible/preemptible_test.go
+++ b/compute/instances/preemptible/preemptible_test.go
@@ -24,8 +24,8 @@ import (
 	"time"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 )
 
 func deleteInstance(ctx context.Context, projectId, zone, instanceName string) error {

--- a/compute/instances/preemptible/print_preemtible.go
+++ b/compute/instances/preemptible/print_preemtible.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 // printPreemtible prints if a given instance is preemptible or not.

--- a/compute/instances/preventing-accidental-vm-deletion/create_instance.go
+++ b/compute/instances/preventing-accidental-vm-deletion/create_instance.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/preventing-accidental-vm-deletion/get_delete_protection.go
+++ b/compute/instances/preventing-accidental-vm-deletion/get_delete_protection.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 // getDeleteProtection prints the state of delete protection flag of given instance.

--- a/compute/instances/preventing-accidental-vm-deletion/preventing_accidental_vm_deletion_test.go
+++ b/compute/instances/preventing-accidental-vm-deletion/preventing_accidental_vm_deletion_test.go
@@ -24,8 +24,8 @@ import (
 	"time"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 )
 
 func TestPreventingAccidentalVMDeletionSnippets(t *testing.T) {

--- a/compute/instances/preventing-accidental-vm-deletion/set_delete_protection.go
+++ b/compute/instances/preventing-accidental-vm-deletion/set_delete_protection.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/suspend-resume/resume.go
+++ b/compute/instances/suspend-resume/resume.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 // resumeInstance resumes a suspended Google Compute Engine instance

--- a/compute/instances/suspend-resume/suspend.go
+++ b/compute/instances/suspend-resume/suspend.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 // suspendInstance suspends a running Google Compute Engine instance.

--- a/compute/instances/suspend-resume/suspend_resume_test.go
+++ b/compute/instances/suspend-resume/suspend_resume_test.go
@@ -24,8 +24,8 @@ import (
 	"time"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/windows/create-os-image/create_windows_os_image.go
+++ b/compute/instances/windows/create-os-image/create_windows_os_image.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/windows/create-os-image/create_windows_os_image_test.go
+++ b/compute/instances/windows/create-os-image/create_windows_os_image_test.go
@@ -24,8 +24,8 @@ import (
 	"time"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/instances/windows/create-os-image/utils_test.go
+++ b/compute/instances/windows/create-os-image/utils_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 func deleteInstance(ctx context.Context, projectId, zone, instanceName string) error {

--- a/compute/list_all_instances.go
+++ b/compute/list_all_instances.go
@@ -21,8 +21,8 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/api/iterator"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/list_instances.go
+++ b/compute/list_instances.go
@@ -21,8 +21,8 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/api/iterator"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 )
 
 // listInstances prints a list of instances created in given project in given zone.

--- a/compute/print_images_list.go
+++ b/compute/print_images_list.go
@@ -21,8 +21,8 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/api/iterator"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/print_images_list_by_page.go
+++ b/compute/print_images_list_by_page.go
@@ -21,8 +21,8 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/api/iterator"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/reset_instance.go
+++ b/compute/reset_instance.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 // resetInstance resets a running Google Compute Engine instance (with unencrypted disks).

--- a/compute/set_usage_export_bucket.go
+++ b/compute/set_usage_export_bucket.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/snapshots/create_snapshot.go
+++ b/compute/snapshots/create_snapshot.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/snapshots/delete_snapshot.go
+++ b/compute/snapshots/delete_snapshot.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 // deleteSnapshot deletes a snapshot of a disk.

--- a/compute/snapshots/delete_snapshots_by_filter.go
+++ b/compute/snapshots/delete_snapshots_by_filter.go
@@ -21,8 +21,8 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/api/iterator"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 )
 
 // Deletes ALL disk snapshots in the project that match the filter

--- a/compute/snapshots/get_snapshot.go
+++ b/compute/snapshots/get_snapshot.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 // getSnapshot prints a name of a disk snapshot in the specified project.

--- a/compute/snapshots/list_snapshots.go
+++ b/compute/snapshots/list_snapshots.go
@@ -21,8 +21,8 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/api/iterator"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 )
 
 // listSnapshots prints a list of disk snapshots in the given project

--- a/compute/snapshots/snapshots_test.go
+++ b/compute/snapshots/snapshots_test.go
@@ -24,8 +24,8 @@ import (
 	"time"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/start_instance.go
+++ b/compute/start_instance.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 // startInstance starts a stopped Google Compute Engine instance (with unencrypted disks).

--- a/compute/start_instance_with_enc_key.go
+++ b/compute/start_instance_with_enc_key.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/start_stop_instances_test.go
+++ b/compute/start_stop_instances_test.go
@@ -25,8 +25,8 @@ import (
 	"time"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/compute/stop_instance.go
+++ b/compute/stop_instance.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 )
 
 // stopInstance stops a started Google Compute Engine instance

--- a/compute/usage_export_test.go
+++ b/compute/usage_export_test.go
@@ -24,9 +24,9 @@ import (
 	"time"
 
 	compute "cloud.google.com/go/compute/apiv1"
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"cloud.google.com/go/storage"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
 )
 
 func createBucket(t *testing.T, projectID, bucketName string) error {


### PR DESCRIPTION
## Description

Fixes #3597 and update `computepb` types location

## Checklist
- [X] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [X] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [X] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [X] Please **merge** this PR for me once it is approved
