### PR TITLE
fix(otel-instrumentation): fix severity mapping to work with Cloud Logging agent

### DIFF
--- a/opentelemetry/instrumentation/app/logger.go
+++ b/opentelemetry/instrumentation/app/logger.go
@@ -57,11 +57,16 @@ func replacer(groups []string, a slog.Attr) slog.Attr {
 	// Rename attribute keys to match Cloud Logging structured log format
 	switch a.Key {
 	case slog.LevelKey:
-		return slog.Any("severity", a.Value)
+		a.Key = "severity"
+		// Map slog.Level string values to Cloud Logging LogSeverity
+		// https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity
+		if level := a.Value.Any().(slog.Level); level == slog.LevelWarn {
+			a.Value = slog.StringValue("WARNING")
+		}
 	case slog.TimeKey:
-		return slog.Any("timestamp", a.Value)
+		a.Key = "timestamp"
 	case slog.MessageKey:
-		return slog.Any("message", a.Value)
+		a.Key = "message"
 	}
 	return a
 }

--- a/opentelemetry/instrumentation/app/logger_test.go
+++ b/opentelemetry/instrumentation/app/logger_test.go
@@ -1,0 +1,86 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandlerSeverity(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		expectSeverity string
+		logFunc        func(*slog.Logger)
+	}{
+		{
+			expectSeverity: "DEBUG",
+			logFunc:        func(l *slog.Logger) { l.DebugContext(ctx, "debug") },
+		},
+		{
+			expectSeverity: "INFO",
+			logFunc:        func(l *slog.Logger) { l.InfoContext(ctx, "info") },
+		},
+		{
+			expectSeverity: "WARNING",
+			logFunc:        func(l *slog.Logger) { l.WarnContext(ctx, "warn") },
+		},
+		{
+			expectSeverity: "ERROR",
+			logFunc:        func(l *slog.Logger) { l.ErrorContext(ctx, "error") },
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.expectSeverity, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			jsonHandler := slog.NewJSONHandler(
+				buf,
+				&slog.HandlerOptions{ReplaceAttr: replacer, Level: slog.LevelDebug},
+			)
+			logger := slog.New(jsonHandler)
+			tc.logFunc(logger)
+
+			line := &expectedLogFormat{}
+			require.NoError(t, json.Unmarshal(buf.Bytes(), line))
+			require.Equal(t, tc.expectSeverity, line.Severity)
+		})
+	}
+}
+
+func TestHandlerTimestamp(t *testing.T) {
+	ctx := context.Background()
+
+	buf := &bytes.Buffer{}
+	jsonHandler := slog.NewJSONHandler(
+		buf,
+		&slog.HandlerOptions{ReplaceAttr: replacer, Level: slog.LevelDebug},
+	)
+	logger := slog.New(jsonHandler)
+	logger.InfoContext(ctx, "foo")
+
+	line := &expectedLogFormat{}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), line))
+	require.NotEmpty(t, line.Timestamp)
+
+	_, err := time.Parse(time.RFC3339Nano, line.Timestamp)
+	require.NoErrorf(t, err, "could not parse timestamp as RFC3339 with nanos")
+}

--- a/opentelemetry/instrumentation/otel-collector-config.yaml
+++ b/opentelemetry/instrumentation/otel-collector-config.yaml
@@ -17,6 +17,18 @@ receivers:
           layout: '%Y-%m-%dT%H:%M:%S.%fZ'
         severity:
           parse_from: body.severity
+          preset: none
+          # parse minimal set of severity strings that Cloud Logging explicitly supports
+          # https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity
+          mapping:
+            debug: debug
+            info: info
+            info3: notice
+            warn: warning
+            error: error
+            fatal: critical
+            fatal3: alert
+            fatal4: emergency
 
       # set trace_flags to SAMPLED if GCP attribute is set to true
       - type: add


### PR DESCRIPTION
## Description
- Updated the slog handler to print levels/severities matching the [LogSeverity enum](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity), which the logging agents can parse. The only changes required were `WARN` -> `WARNING`. The agent [may also parse other common severity strings](https://cloud.google.com/logging/docs/structured-logging#structured_logging_special_fields:~:text=The%20Logging%20agent%20attempts%20to%20match%20a%20variety%20of%20common%20severity%20strings%2C%20which%20includes%20the%20list%20of%20LogSeverity%20strings%20recognized%20by%20the%20Logging%20API.), but those other strings are not documented.
- Updated the OTel collector config to parse the LogSeverity enum values and manually verified that they are mapped correctly to Cloud Logging's format: 
![image](https://github.com/GoogleCloudPlatform/golang-samples/assets/1510004/474c83db-4465-4ab1-847b-bd13511fae57)


## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
