### PR TITLE
chore(fixit): remove redundant region tags

### DIFF
--- a/functions/tips/lazy.go
+++ b/functions/tips/lazy.go
@@ -14,7 +14,6 @@
 
 // [START functions_tips_lazy_globals]
 // [START cloudrun_tips_global_lazy]
-// [START run_tips_global_lazy]
 
 // Package tips contains tips for writing Cloud Functions in Go.
 package tips
@@ -54,6 +53,5 @@ func LazyGlobal(w http.ResponseWriter, r *http.Request) {
 	// Use client.
 }
 
-// [END run_tips_global_lazy]
 // [END cloudrun_tips_global_lazy]
 // [END functions_tips_lazy_globals]

--- a/functions/tips/scope.go
+++ b/functions/tips/scope.go
@@ -24,7 +24,6 @@ import (
 
 // [START functions_tips_scopes]
 // [START cloudrun_tips_global_scope]
-// [START run_tips_global_scope]
 
 // h is in the global (instance-wide) scope.
 var h string
@@ -43,7 +42,6 @@ func ScopeDemo(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Global: %q, Local: %q", h, l)
 }
 
-// [END run_tips_global_scope]
 // [END cloudrun_tips_global_scope]
 // [END functions_tips_scopes]
 

--- a/run/authentication/auth.go
+++ b/run/authentication/auth.go
@@ -16,7 +16,6 @@
 package authentication
 
 // [START cloudrun_service_to_service_auth]
-// [START run_service_to_service_auth]
 import (
 	"fmt"
 	"net/http"
@@ -42,5 +41,4 @@ func makeGetRequest(serviceURL string) (*http.Response, error) {
 	return http.DefaultClient.Do(req)
 }
 
-// [END run_service_to_service_auth]
 // [END cloudrun_service_to_service_auth]

--- a/run/markdown-preview/editor/render.go
+++ b/run/markdown-preview/editor/render.go
@@ -15,7 +15,6 @@
 package main
 
 // [START cloudrun_secure_request]
-// [START run_secure_request]
 import (
 	"bytes"
 	"context"
@@ -65,11 +64,9 @@ func (s *RenderService) NewRequest(method string) (*http.Request, error) {
 	return req, nil
 }
 
-// [END run_secure_request]
 // [END cloudrun_secure_request]
 
 // [START cloudrun_secure_request_do]
-// [START run_secure_request_do]
 
 var renderClient = &http.Client{Timeout: 30 * time.Second}
 
@@ -99,5 +96,4 @@ func (s *RenderService) Render(in []byte) ([]byte, error) {
 	return out, nil
 }
 
-// [END run_secure_request_do]
 // [END cloudrun_secure_request_do]

--- a/run/system_package/graphviz.go
+++ b/run/system_package/graphviz.go
@@ -54,7 +54,6 @@ func main() {
 }
 
 // [START cloudrun_system_package_handler]
-// [START run_system_package_handler]
 
 // diagramHandler renders a diagram using HTTP request parameters and the dot command.
 func diagramHandler(w http.ResponseWriter, r *http.Request) {
@@ -88,11 +87,9 @@ func diagramHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// [END run_system_package_handler]
 // [END cloudrun_system_package_handler]
 
 // [START cloudrun_system_package_exec]
-// [START run_system_package_exec]
 
 // createDiagram generates a diagram image from the provided io.Reader written to the io.Writer.
 func createDiagram(w io.Writer, r io.Reader) error {
@@ -117,5 +114,4 @@ func createDiagram(w io.Writer, r io.Reader) error {
 	return nil
 }
 
-// [END run_system_package_exec]
 // [END cloudrun_system_package_exec]


### PR DESCRIPTION
Removed these tags:
run_tips_global_lazy
run_tips_global_scope
run_service_to_service_auth
run_secure_request
run_secure_request_do
run_system_package_handler
run_system_package_exec

Manually searched docs and confirmed no references remain.

## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
