### PR TITLE
chore(fixit): remove redundant region tags

### DIFF
--- a/run/grpc-ping/connection.go
+++ b/run/grpc-ping/connection.go
@@ -15,7 +15,6 @@
 package main
 
 // [START cloudrun_grpc_conn]
-// [START run_grpc_conn]
 
 import (
 	"crypto/tls"
@@ -51,5 +50,4 @@ func NewConn(host string, insecure bool) (*grpc.ClientConn, error) {
 	return grpc.Dial(host, opts...)
 }
 
-// [END run_grpc_conn]
 // [END cloudrun_grpc_conn]

--- a/run/grpc-ping/main.go
+++ b/run/grpc-ping/main.go
@@ -26,7 +26,6 @@ import (
 )
 
 // [START cloudrun_grpc_server]
-// [START run_grpc_server]
 func main() {
 	log.Printf("grpc-ping: starting server...")
 
@@ -48,7 +47,6 @@ func main() {
 	}
 }
 
-// [END run_grpc_server]
 // [END cloudrun_grpc_server]
 
 // conn holds an open connection to the ping service.

--- a/run/grpc-ping/request.go
+++ b/run/grpc-ping/request.go
@@ -15,7 +15,6 @@
 package main
 
 // [START cloudrun_grpc_request]
-// [START run_grpc_request]
 
 import (
 	"context"
@@ -34,7 +33,6 @@ func pingRequest(conn *grpc.ClientConn, p *pb.Request) (*pb.Response, error) {
 	return client.Send(ctx, p)
 }
 
-// [END run_grpc_request]
 // [END cloudrun_grpc_request]
 
 // PingRequest creates a new gRPC request to the upstream ping gRPC service.

--- a/run/grpc-ping/request_auth.go
+++ b/run/grpc-ping/request_auth.go
@@ -15,7 +15,6 @@
 package main
 
 // [START cloudrun_grpc_request_auth]
-// [START run_grpc_request_auth]
 
 import (
 	"context"
@@ -56,5 +55,4 @@ func pingRequestWithAuth(conn *grpc.ClientConn, p *pb.Request, audience string) 
 	return client.Send(ctx, p)
 }
 
-// [END run_grpc_request_auth]
 // [END cloudrun_grpc_request_auth]

--- a/run/hello-broken/main.go
+++ b/run/hello-broken/main.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 // [START cloudrun_broken_service]
-// [START run_broken_service]
 
 // Sample hello demonstrates a difficult to troubleshoot service.
 package main
@@ -30,11 +29,9 @@ func main() {
 
 	http.HandleFunc("/", helloHandler)
 
-	// [END run_broken_service]
 	// [END cloudrun_broken_service]
 	http.HandleFunc("/improved", improvedHandler)
 	// [START cloudrun_broken_service]
-	// [START run_broken_service]
 
 	port := os.Getenv("PORT")
 	if port == "" {
@@ -50,33 +47,28 @@ func helloHandler(w http.ResponseWriter, r *http.Request) {
 	log.Print("hello: received request")
 
 	// [START cloudrun_broken_service_problem]
-	// [START run_broken_service_problem]
 	name := os.Getenv("NAME")
 	if name == "" {
 		log.Printf("Missing required server parameter")
 		// The panic stack trace appears in Cloud Error Reporting.
 		panic("Missing required server parameter")
 	}
-	// [END run_broken_service_problem]
 	// [END cloudrun_broken_service_problem]
 
 	fmt.Fprintf(w, "Hello %s!\n", name)
 }
 
-// [END run_broken_service]
 // [END cloudrun_broken_service]
 
 func improvedHandler(w http.ResponseWriter, r *http.Request) {
 	log.Print("hello: received request")
 
 	// [START cloudrun_broken_service_upgrade]
-	// [START run_broken_service_upgrade]
 	name := os.Getenv("NAME")
 	if name == "" {
 		name = "World"
 		log.Printf("warning: NAME not set, default to %s", name)
 	}
-	// [END run_broken_service_upgrade]
 	// [END cloudrun_broken_service_upgrade]
 
 	fmt.Fprintf(w, "Hello %s!\n", name)

--- a/run/helloworld/main.go
+++ b/run/helloworld/main.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 // [START cloudrun_helloworld_service]
-// [START run_helloworld_service]
 
 // Sample run-helloworld is a minimal Cloud Run service.
 package main
@@ -51,5 +50,4 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Hello %s!\n", name)
 }
 
-// [END run_helloworld_service]
 // [END cloudrun_helloworld_service]

--- a/run/image-processing/imagemagick/imagemagick.go
+++ b/run/image-processing/imagemagick/imagemagick.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 // [START cloudrun_imageproc_handler_setup]
-// [START run_imageproc_handler_setup]
 
 // Package imagemagick contains an example of using ImageMagick to process a
 // file uploaded to Cloud Storage.
@@ -53,11 +52,9 @@ func init() {
 	}
 }
 
-// [END run_imageproc_handler_setup]
 // [END cloudrun_imageproc_handler_setup]
 
 // [START cloudrun_imageproc_handler_analyze]
-// [START run_imageproc_handler_analyze]
 
 // GCSEvent is the payload of a GCS event.
 type GCSEvent struct {
@@ -87,11 +84,9 @@ func BlurOffensiveImages(ctx context.Context, e GCSEvent) error {
 	return nil
 }
 
-// [END run_imageproc_handler_analyze]
 // [END cloudrun_imageproc_handler_analyze]
 
 // [START cloudrun_imageproc_handler_blur]
-// [START run_imageproc_handler_blur]
 
 // blur blurs the image stored at gs://inputBucket/name and stores the result in
 // gs://outputBucket/name.
@@ -120,5 +115,4 @@ func blur(ctx context.Context, inputBucket, outputBucket, name string) error {
 	return nil
 }
 
-// [END run_imageproc_handler_blur]
 // [END cloudrun_imageproc_handler_blur]

--- a/run/image-processing/main.go
+++ b/run/image-processing/main.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 // [START cloudrun_imageproc_controller]
-// [START run_imageproc_controller]
 
 // Sample image-processing is a Cloud Run service which performs asynchronous processing on images.
 package main
@@ -87,5 +86,4 @@ func HelloPubSub(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// [END run_imageproc_controller]
 // [END cloudrun_imageproc_controller]

--- a/run/logging-manual/main.go
+++ b/run/logging-manual/main.go
@@ -52,7 +52,6 @@ func main() {
 }
 
 // [START cloudrun_manual_logging_object]
-// [START run_manual_logging_object]
 
 // Entry defines a log entry.
 type Entry struct {
@@ -76,11 +75,9 @@ func (e Entry) String() string {
 	return string(out)
 }
 
-// [END run_manual_logging_object]
 // [END cloudrun_manual_logging_object]
 
 // [START cloudrun_manual_logging]
-// [START run_manual_logging]
 
 func init() {
 	// Disable log prefixes such as the default timestamp.
@@ -113,5 +110,4 @@ func indexHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintln(w, "Hello Logger!")
 }
 
-// [END run_manual_logging]
 // [END cloudrun_manual_logging]

--- a/run/pubsub/main.go
+++ b/run/pubsub/main.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 // [START cloudrun_pubsub_server]
-// [START run_pubsub_server]
 
 // Sample run-pubsub is a Cloud Run service which handles Pub/Sub messages.
 package main
@@ -41,11 +40,9 @@ func main() {
 	}
 }
 
-// [END run_pubsub_server]
 // [END cloudrun_pubsub_server]
 
 // [START cloudrun_pubsub_handler]
-// [START run_pubsub_handler]
 
 // PubSubMessage is the payload of a Pub/Sub event.
 // See the documentation for more details:
@@ -81,5 +78,4 @@ func HelloPubSub(w http.ResponseWriter, r *http.Request) {
 	log.Printf("Hello %s!", name)
 }
 
-// [END run_pubsub_handler]
 // [END cloudrun_pubsub_handler]


### PR DESCRIPTION
## Description

Removed these tags:
run_pubsub_server
run_pubsub_handler
run_manual_logging_object
run_manual_logging
run_imageproc_handler_setup
run_imageproc_handler_blur
run_imageproc_handler_analyze
run_imageproc_controller
run_helloworld_service
run_grpc_server
run_grpc_request_auth
run_grpc_request
run_grpc_conn
run_broken_service_upgrade
run_broken_service_problem
run_broken_service

Manually searched docs and confirmed no references remain.


## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [ x **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
