### PR TITLE
fix(cloudrun): remove unused region tags

### DIFF
--- a/eventarc/generic/Dockerfile
+++ b/eventarc/generic/Dockerfile
@@ -5,14 +5,13 @@
 # You may obtain a copy of the License at
 #
 #    https://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START eventarc_generic_dockerfile]
 
 # Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
@@ -47,5 +46,3 @@ COPY --from=builder /app/server /server
 
 # Run the web service on container startup.
 CMD ["/server"]
-
-# [END eventarc_generic_dockerfile]

--- a/eventarc/pubsub/Dockerfile
+++ b/eventarc/pubsub/Dockerfile
@@ -5,14 +5,12 @@
 # You may obtain a copy of the License at
 #
 #    https://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# [START eventarc_pubsub_dockerfile]
 
 # Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
@@ -47,5 +45,3 @@ COPY --from=builder /app/server /server
 
 # Run the web service on container startup.
 CMD ["/server"]
-
-# [END eventarc_pubsub_dockerfile]

--- a/run/grpc-ping/Dockerfile
+++ b/run/grpc-ping/Dockerfile
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START cloudrun_grpc_dockerfile]
-# [START run_grpc_dockerfile]
-
 # Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
@@ -48,6 +45,3 @@ COPY --from=builder /app/server /server
 
 # Run the web service on container startup.
 CMD ["/server"]
-
-# [END run_grpc_dockerfile]
-# [END cloudrun_grpc_dockerfile]

--- a/run/grpc-server-streaming/Dockerfile
+++ b/run/grpc-server-streaming/Dockerfile
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START cloudrun_grpc_dockerfile]
-# [START run_grpc_dockerfile]
 
 # Use the offical golang image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
@@ -48,6 +46,3 @@ COPY --from=builder /bin/server /server
 
 # Run the web service on container startup.
 CMD ["/server"]
-
-# [END run_grpc_dockerfile]
-# [END cloudrun_grpc_dockerfile]


### PR DESCRIPTION
Removes unused region tags: 

eventarc_generic_dockerfile
eventarc_pubsub_dockerfile
cloudrun_grpc_dockerfile
run_grpc_dockerfile



- [x] Please **merge** this PR for me once it is approved
