### PR TITLE
fix: update practices from deprecated ioutil to os 

### DIFF
--- a/documentai/documentai_quickstart/main.go
+++ b/documentai/documentai_quickstart/main.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
-
+	"os"
+	
 	documentai "cloud.google.com/go/documentai/apiv1"
 	"cloud.google.com/go/documentai/apiv1/documentaipb"
 	"google.golang.org/api/option"
@@ -46,9 +46,9 @@ func main() {
 	defer client.Close()
 
 	// Open local file.
-	data, err := ioutil.ReadFile(*filePath)
+	data, err := os.ReadFile(*filePath)
 	if err != nil {
-		fmt.Println(fmt.Errorf("ioutil.ReadFile: %w", err))
+		fmt.Println(fmt.Errorf("os.ReadFile: %w", err))
 	}
 
 	req := &documentaipb.ProcessRequest{


### PR DESCRIPTION
## Description

Fixes b/345846015

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
