### PR TITLE
fix: prefer using fmt.Errorf with %w

### DIFF
--- a/aiplatform/snippets/import_data_image_classification.go
+++ b/aiplatform/snippets/import_data_image_classification.go
@@ -41,7 +41,7 @@ func importDataImageClassification(w io.Writer, projectID, location, datasetID, 
 	ctx := context.Background()
 	aiplatformClient, err := aiplatform.NewDatasetClient(ctx, clientOption)
 	if err != nil {
-		return fmt.Errorf("aiplatform.NewDatasetClient: %v", err)
+		return fmt.Errorf("aiplatform.NewDatasetClient: %w", err)
 	}
 	defer aiplatformClient.Close()
 
@@ -59,7 +59,7 @@ func importDataImageClassification(w io.Writer, projectID, location, datasetID, 
 		ImportConfigs: importConfigs,
 	})
 	if err != nil {
-		return fmt.Errorf("ImportData: %v", err)
+		return fmt.Errorf("ImportData: %w", err)
 	}
 	fmt.Fprintf(os.Stdout, "Processing operation name: %q\n", op.Name())
 

--- a/dlp/snippets/deid/deid_table_fpe.go
+++ b/dlp/snippets/deid/deid_table_fpe.go
@@ -95,7 +95,7 @@ func deidentifyTableFPE(w io.Writer, projectID string, kmsKeyName, wrappedAESKey
 	// Specify an encrypted AES-256 key and the name of the Cloud KMS key that encrypted it.
 	kmsKeyDecode, err := base64.StdEncoding.DecodeString(wrappedAESKey)
 	if err != nil {
-		return fmt.Errorf("error in decoding key: %v", err)
+		return fmt.Errorf("error in decoding key: %w", err)
 	}
 
 	kmsWrappedCryptoKey := &dlppb.KmsWrappedCryptoKey{

--- a/dlp/snippets/inspect/inspect_image_all_infotypes.go
+++ b/dlp/snippets/inspect/inspect_image_all_infotypes.go
@@ -65,7 +65,7 @@ func inspectImageFileAllInfoTypes(w io.Writer, projectID, inputPath string) erro
 	// Send the request.
 	resp, err := client.InspectContent(ctx, req)
 	if err != nil {
-		return fmt.Errorf("InspectContent: %v", err)
+		return fmt.Errorf("InspectContent: %w", err)
 	}
 
 	// Process the results.

--- a/media/videostitcher/get_cdn_key.go
+++ b/media/videostitcher/get_cdn_key.go
@@ -43,7 +43,7 @@ func getCDNKey(w io.Writer, projectID, keyID string) error {
 	// Gets the CDN key.
 	response, err := client.GetCdnKey(ctx, req)
 	if err != nil {
-		return fmt.Errorf("client.GetCdnKey: %v", err)
+		return fmt.Errorf("client.GetCdnKey: %w", err)
 	}
 	b, err := json.MarshalIndent(response, "", " ")
 	if err != nil {

--- a/profiler/export/main.go
+++ b/profiler/export/main.go
@@ -89,7 +89,7 @@ func downloadProfiles(ctx context.Context, w io.Writer, project, pageToken strin
 			break
 		}
 		if err != nil {
-			return fmt.Errorf("error reading profile from response: %v", err)
+			return fmt.Errorf("error reading profile from response: %w", err)
 		}
 		profileCount++
 
@@ -97,7 +97,7 @@ func downloadProfiles(ctx context.Context, w io.Writer, project, pageToken strin
 		err = os.WriteFile(filename, profile.ProfileBytes, 0640)
 
 		if err != nil {
-			return fmt.Errorf("unable to write file %s: %v", filename, err)
+			return fmt.Errorf("unable to write file %s: %w", filename, err)
 		}
 		fmt.Fprintf(w, "deployment target: %v\n", profile.Deployment.Labels)
 

--- a/securitycenter/muteconfig/update_mute_rule.go
+++ b/securitycenter/muteconfig/update_mute_rule.go
@@ -64,7 +64,7 @@ func updateMuteRule(w io.Writer, muteConfigName string) error {
 
 	response, err := client.UpdateMuteConfig(ctx, req)
 	if err != nil {
-		return fmt.Errorf("mute rule update failed! %v", err)
+		return fmt.Errorf("mute rule update failed! %w", err)
 	}
 	fmt.Fprintf(w, "Mute rule updated %s", response.Name)
 	return nil

--- a/spanner/spanner_snippets/spanner/spanner_update_database.go
+++ b/spanner/spanner_snippets/spanner/spanner_update_database.go
@@ -30,7 +30,7 @@ func updateDatabase(ctx context.Context, w io.Writer, db string) error {
 	// Instantiate database admin client.
 	adminClient, err := database.NewDatabaseAdminClient(ctx)
 	if err != nil {
-		return fmt.Errorf("updateDatabase.NewDatabaseAdminClient: %v", err)
+		return fmt.Errorf("updateDatabase.NewDatabaseAdminClient: %w", err)
 	}
 	defer adminClient.Close()
 
@@ -45,13 +45,13 @@ func updateDatabase(ctx context.Context, w io.Writer, db string) error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("updateDatabase.UpdateDatabase: %v", err)
+		return fmt.Errorf("updateDatabase.UpdateDatabase: %w", err)
 	}
 
 	// Wait for update database operation to complete.
 	fmt.Fprintf(w, "Waiting for update database operation to complete [%s]\n", db)
 	if _, err := op.Wait(ctx); err != nil {
-		return fmt.Errorf("updateDatabase.Wait: %v", err)
+		return fmt.Errorf("updateDatabase.Wait: %w", err)
 	}
 	fmt.Fprintf(w, "Updated database [%s]\n", db)
 	return nil

--- a/speech/snippets/transcribe_diarization.go
+++ b/speech/snippets/transcribe_diarization.go
@@ -64,7 +64,7 @@ func transcribe_diarization_gcs_beta(w io.Writer, gcsUri string) error {
 
 	operation, err := client.LongRunningRecognize(ctx, longRunningRecognizeRequest)
 	if err != nil {
-		return fmt.Errorf("error running recognize %v", err)
+		return fmt.Errorf("error running recognize %w", err)
 	}
 
 	response, err := operation.Wait(ctx)

--- a/speech/snippets/transcribe_diarization_beta.go
+++ b/speech/snippets/transcribe_diarization_beta.go
@@ -54,7 +54,7 @@ func transcribe_diarization(w io.Writer, filename string) error {
 	// Get the contents of the local audio file
 	content, err := os.ReadFile(filename)
 	if err != nil {
-		return fmt.Errorf("error reading file %v", err)
+		return fmt.Errorf("error reading file %w", err)
 	}
 	audio := &speechpb.RecognitionAudio{
 		AudioSource: &speechpb.RecognitionAudio_Content{Content: content},
@@ -67,7 +67,7 @@ func transcribe_diarization(w io.Writer, filename string) error {
 
 	operation, err := client.LongRunningRecognize(ctx, longRunningRecognizeRequest)
 	if err != nil {
-		return fmt.Errorf("error running recognize %v", err)
+		return fmt.Errorf("error running recognize %w", err)
 	}
 
 	response, err := operation.Wait(ctx)

--- a/speech/snippets/transcribe_model_selection_gcs.go
+++ b/speech/snippets/transcribe_model_selection_gcs.go
@@ -61,7 +61,7 @@ func transcribe_model_selection_gcs(w io.Writer, gcsUri string, model string) er
 
 	operation, err := client.LongRunningRecognize(ctx, longRunningRecognizeRequest)
 	if err != nil {
-		return fmt.Errorf("error running recognize %v", err)
+		return fmt.Errorf("error running recognize %w", err)
 	}
 
 	response, err := operation.Wait(ctx)

--- a/speech/snippets/transcribe_streaming_v2.go
+++ b/speech/snippets/transcribe_streaming_v2.go
@@ -89,7 +89,7 @@ func transcribeStreamingV2(w io.Writer, projectID string, path string) error {
 						Audio: buf[:n],
 					},
 				}); err != nil {
-					return fmt.Errorf("could not send audio: %v", err)
+					return fmt.Errorf("could not send audio: %w", err)
 				}
 			}
 			if err == io.EOF {
@@ -112,7 +112,7 @@ func transcribeStreamingV2(w io.Writer, projectID string, path string) error {
 			break
 		}
 		if err != nil {
-			return fmt.Errorf("cannot stream results: %v", err)
+			return fmt.Errorf("cannot stream results: %w", err)
 		}
 		for i, result := range resp.Results {
 			fmt.Fprintf(w, "%s\n", strings.Repeat("-", 20))

--- a/speech/snippets/transcribe_streaming_v2_explicit_decoding.go
+++ b/speech/snippets/transcribe_streaming_v2_explicit_decoding.go
@@ -96,7 +96,7 @@ func transcribeStreamingSpecificDecodingV2(w io.Writer, projectID string, path s
 						Audio: buf[:n],
 					},
 				}); err != nil {
-					return fmt.Errorf("could not send audio: %v", err)
+					return fmt.Errorf("could not send audio: %w", err)
 				}
 			}
 			if err == io.EOF {
@@ -119,7 +119,7 @@ func transcribeStreamingSpecificDecodingV2(w io.Writer, projectID string, path s
 			break
 		}
 		if err != nil {
-			return fmt.Errorf("cannot stream results: %v", err)
+			return fmt.Errorf("cannot stream results: %w", err)
 		}
 		for i, result := range resp.Results {
 			fmt.Fprintf(w, "%s\n", strings.Repeat("-", 20))

--- a/vertexai/function-calling/functioncalling.go
+++ b/vertexai/function-calling/functioncalling.go
@@ -45,7 +45,7 @@ func functionCallsChat(w io.Writer, projectID, location, modelName string) error
 	ctx := context.Background()
 	client, err := genai.NewClient(ctx, projectID, location)
 	if err != nil {
-		return fmt.Errorf("unable to create client: %v", err)
+		return fmt.Errorf("unable to create client: %w", err)
 	}
 	defer client.Close()
 

--- a/vertexai/multimodal-multiple/multiple-multimodal.go
+++ b/vertexai/multimodal-multiple/multiple-multimodal.go
@@ -92,7 +92,7 @@ func generateMultimodalContent(w io.Writer, parts []genai.Part, projectID, locat
 
 	res, err := model.GenerateContent(ctx, parts...)
 	if err != nil {
-		return fmt.Errorf("unable to generate contents: %v", err)
+		return fmt.Errorf("unable to generate contents: %w", err)
 	}
 
 	fmt.Fprintf(w, "generated response: %s\n", res.Candidates[0].Content.Parts[0])
@@ -115,7 +115,7 @@ func partFromImageURL(image string) (genai.Part, error) {
 	defer res.Body.Close()
 	data, err := io.ReadAll(res.Body)
 	if err != nil {
-		return img, fmt.Errorf("unable to read from http: %v", err)
+		return img, fmt.Errorf("unable to read from http: %w", err)
 	}
 
 	position := strings.LastIndex(imageURL.Path, ".")

--- a/vertexai/multimodal-video/multimodalvideo.go
+++ b/vertexai/multimodal-video/multimodalvideo.go
@@ -40,7 +40,7 @@ func generateMultimodalContent(w io.Writer, prompt, video, projectID, location, 
 
 	client, err := genai.NewClient(ctx, projectID, location)
 	if err != nil {
-		return fmt.Errorf("unable to create client: %v", err)
+		return fmt.Errorf("unable to create client: %w", err)
 	}
 	defer client.Close()
 
@@ -55,7 +55,7 @@ func generateMultimodalContent(w io.Writer, prompt, video, projectID, location, 
 
 	res, err := model.GenerateContent(ctx, part, genai.Text(prompt))
 	if err != nil {
-		return fmt.Errorf("unable to generate contents: %v", err)
+		return fmt.Errorf("unable to generate contents: %w", err)
 	}
 
 	if len(res.Candidates) == 0 ||

--- a/vertexai/safety-settings-multimodal/safety-settings-multimodal.go
+++ b/vertexai/safety-settings-multimodal/safety-settings-multimodal.go
@@ -37,7 +37,7 @@ func generateMultimodalContent(w io.Writer, prompt, image, projectID, location, 
 
 	client, err := genai.NewClient(ctx, projectID, location)
 	if err != nil {
-		return fmt.Errorf("unable to create client: %v", err)
+		return fmt.Errorf("unable to create client: %w", err)
 	}
 	defer client.Close()
 

--- a/vertexai/token-count/tokencount.go
+++ b/vertexai/token-count/tokencount.go
@@ -36,7 +36,7 @@ func countTokens(w io.Writer, prompt, projectID, location, modelName string) err
 
 	client, err := genai.NewClient(ctx, projectID, location)
 	if err != nil {
-		return fmt.Errorf("unable to create client: %v", err)
+		return fmt.Errorf("unable to create client: %w", err)
 	}
 	defer client.Close()
 


### PR DESCRIPTION
See https://go.dev/wiki/ErrorValueFAQ#i-am-already-using-fmterrorf-with-v-or-s-to-provide-context-for-an-error-when-should-i-switch-to-w

Change applied accross many samples, where the code was returning an `error` by wrapping another `error` using `fmt.Errorf` and the verb `%v`.

Some other uses of `%v` are not in the scope of this PR:
- When using `log.Printf` (because `log.Printf` does not support `%w`)
- When using `*testing.T.Errorf` (because `*testing.T.Errorf` does not support `%w`)
- When using `*testing.T.Fatalf` (because `*testing.T.Fatalf` does not support `%w`)
- When the argument has a non-error type