### PR TITLE
fix(compute): debian-10 image family EoL.

### DIFF
--- a/compute/address/assign_static_address_to_new_vm.go
+++ b/compute/address/assign_static_address_to_new_vm.go
@@ -50,7 +50,7 @@ func assignStaticExternalToNewVM(w io.Writer, projectID, zone, instanceName, ipA
 	// List of public operating system (OS) images: https://cloud.google.com/compute/docs/images/os-details.
 	newestDebianReq := &computepb.GetFromFamilyImageRequest{
 		Project: "debian-cloud",
-		Family:  "debian-10",
+		Family:  "debian-12",
 	}
 	newestDebian, err := imagesClient.GetFromFamily(ctx, newestDebianReq)
 	if err != nil {

--- a/compute/compute_test.go
+++ b/compute/compute_test.go
@@ -36,7 +36,7 @@ func TestComputeSnippets(t *testing.T) {
 	instanceName := "test-" + fmt.Sprint(seededRand.Int())
 	instanceName2 := "test-" + fmt.Sprint(seededRand.Int())
 	machineType := "n1-standard-1"
-	sourceImage := "projects/debian-cloud/global/images/family/debian-10"
+	sourceImage := "projects/debian-cloud/global/images/family/debian-12"
 	networkName := "global/networks/default"
 
 	buf := &bytes.Buffer{}

--- a/compute/create_instance.go
+++ b/compute/create_instance.go
@@ -31,7 +31,7 @@ func createInstance(w io.Writer, projectID, zone, instanceName, machineType, sou
 	// zone := "europe-central2-b"
 	// instanceName := "your_instance_name"
 	// machineType := "n1-standard-1"
-	// sourceImage := "projects/debian-cloud/global/images/family/debian-10"
+	// sourceImage := "projects/debian-cloud/global/images/family/debian-12"
 	// networkName := "global/networks/default"
 
 	ctx := context.Background()

--- a/compute/create_instance_from_template_test.go
+++ b/compute/create_instance_from_template_test.go
@@ -51,7 +51,7 @@ func TestCreateInstanceFromTemplateSnippets(t *testing.T) {
 	instanceName2 := "test-instance-" + fmt.Sprint(seededRand.Int())
 	instanceTemplateName := "test-instance-template" + fmt.Sprint(seededRand.Int())
 	machineType := "n1-standard-1"
-	sourceImage := "projects/debian-cloud/global/images/family/debian-10"
+	sourceImage := "projects/debian-cloud/global/images/family/debian-12"
 	networkName := "global/networks/default"
 
 	insertTemplateReq := &computepb.InsertInstanceTemplateRequest{

--- a/compute/create_instance_from_template_with_overrides.go
+++ b/compute/create_instance_from_template_with_overrides.go
@@ -33,7 +33,7 @@ func createInstanceFromTemplateWithOverrides(w io.Writer, projectID, zone, insta
 	// instanceName := "your_instance_name"
 	// instanceTemplateName := "your_instance_template_name"
 	// machineType := "n1-standard-2"
-	// newDiskSourceImage := "projects/debian-cloud/global/images/family/debian-10"
+	// newDiskSourceImage := "projects/debian-cloud/global/images/family/debian-12"
 
 	ctx := context.Background()
 	instancesClient, err := compute.NewInstancesRESTClient(ctx)

--- a/compute/custom-hostname-instance/create_instance_with_custom_hostname.go
+++ b/compute/custom-hostname-instance/create_instance_with_custom_hostname.go
@@ -32,7 +32,7 @@ func createInstanceWithCustomHostname(w io.Writer, projectID, zone, instanceName
 	// instanceName := "your_instance_name"
 	// hostname := "host.example.com" // Custom hostnames must conform to RFC 1035 requirements for valid hostnames.
 	// machineType := "n1-standard-1"
-	// sourceImage := "projects/debian-cloud/global/images/family/debian-10"
+	// sourceImage := "projects/debian-cloud/global/images/family/debian-12"
 	// networkName := "global/networks/default"
 
 	ctx := context.Background()

--- a/compute/custom-hostname-instance/instance_hostname_test.go
+++ b/compute/custom-hostname-instance/instance_hostname_test.go
@@ -37,7 +37,7 @@ func TestInstanceHostnameSnippets(t *testing.T) {
 	customHostname := "host.domain.com"
 	instanceName := "test-" + fmt.Sprint(seededRand.Int())
 	machineType := "n1-standard-1"
-	sourceImage := "projects/debian-cloud/global/images/family/debian-10"
+	sourceImage := "projects/debian-cloud/global/images/family/debian-12"
 	networkName := "global/networks/default"
 	instancesClient, err := compute.NewInstancesRESTClient(ctx)
 	if err != nil {

--- a/compute/instance-templates/create-instance-templates/create_instance_templates_test.go
+++ b/compute/instance-templates/create-instance-templates/create_instance_templates_test.go
@@ -40,7 +40,7 @@ func TestCreateInstanceTemplatesSnippets(t *testing.T) {
 	templateName2 := "test-template-" + fmt.Sprint(seededRand.Int())
 	templateName3 := "test-template-" + fmt.Sprint(seededRand.Int())
 	machineType := "n1-standard-1"
-	sourceImage := "projects/debian-cloud/global/images/family/debian-10"
+	sourceImage := "projects/debian-cloud/global/images/family/debian-12"
 	networkName := "global/networks/default-compute"
 	subnetworkName := "regions/asia-east1/subnetworks/default-compute"
 

--- a/compute/instances/create-start-instance/create_instance_from_public_image.go
+++ b/compute/instances/create-start-instance/create_instance_from_public_image.go
@@ -47,7 +47,7 @@ func createInstanceFromPublicImage(w io.Writer, projectID, zone, instanceName st
 	// List of public operating system (OS) images: https://cloud.google.com/compute/docs/images/os-details.
 	newestDebianReq := &computepb.GetFromFamilyImageRequest{
 		Project: "debian-cloud",
-		Family:  "debian-10",
+		Family:  "debian-12",
 	}
 	newestDebian, err := imagesClient.GetFromFamily(ctx, newestDebianReq)
 	if err != nil {

--- a/compute/instances/create-start-instance/create_instance_with_additional_disk.go
+++ b/compute/instances/create-start-instance/create_instance_with_additional_disk.go
@@ -47,7 +47,7 @@ func createWithAdditionalDisk(w io.Writer, projectID, zone, instanceName string)
 	// List of public operating system (OS) images: https://cloud.google.com/compute/docs/images/os-details.
 	newestDebianReq := &computepb.GetFromFamilyImageRequest{
 		Project: "debian-cloud",
-		Family:  "debian-10",
+		Family:  "debian-12",
 	}
 	newestDebian, err := imagesClient.GetFromFamily(ctx, newestDebianReq)
 	if err != nil {

--- a/compute/instances/create-start-instance/create_instance_with_local_ssd.go
+++ b/compute/instances/create-start-instance/create_instance_with_local_ssd.go
@@ -47,7 +47,7 @@ func createWithLocalSSD(w io.Writer, projectID, zone, instanceName string) error
 	// List of public operating system (OS) images: https://cloud.google.com/compute/docs/images/os-details.
 	newestDebianReq := &computepb.GetFromFamilyImageRequest{
 		Project: "debian-cloud",
-		Family:  "debian-10",
+		Family:  "debian-12",
 	}
 	newestDebian, err := imagesClient.GetFromFamily(ctx, newestDebianReq)
 	if err != nil {

--- a/compute/instances/create-start-instance/create_instance_with_snapshotted_data_disk.go
+++ b/compute/instances/create-start-instance/create_instance_with_snapshotted_data_disk.go
@@ -48,7 +48,7 @@ func createInstanceWithSnapshottedDataDisk(w io.Writer, projectID, zone, instanc
 	// List of public operating system (OS) images: https://cloud.google.com/compute/docs/images/os-details.
 	newestDebianReq := &computepb.GetFromFamilyImageRequest{
 		Project: "debian-cloud",
-		Family:  "debian-10",
+		Family:  "debian-12",
 	}
 	newestDebian, err := imagesClient.GetFromFamily(ctx, newestDebianReq)
 	if err != nil {

--- a/compute/instances/create-start-instance/create_instance_with_subnet.go
+++ b/compute/instances/create-start-instance/create_instance_with_subnet.go
@@ -49,7 +49,7 @@ func createInstanceWithSubnet(w io.Writer, projectID, zone, instanceName, networ
 	// List of public operating system (OS) images: https://cloud.google.com/compute/docs/images/os-details.
 	newestDebianReq := &computepb.GetFromFamilyImageRequest{
 		Project: "debian-cloud",
-		Family:  "debian-10",
+		Family:  "debian-12",
 	}
 	newestDebian, err := imagesClient.GetFromFamily(ctx, newestDebianReq)
 	if err != nil {

--- a/compute/instances/custom-machine-type/create_custom_machine_type.go
+++ b/compute/instances/custom-machine-type/create_custom_machine_type.go
@@ -53,7 +53,7 @@ func createInstanceWithCustomMachineType(
 					InitializeParams: &computepb.AttachedDiskInitializeParams{
 						DiskSizeGb: proto.Int64(10),
 						SourceImage: proto.String(
-							"projects/debian-cloud/global/images/family/debian-10",
+							"projects/debian-cloud/global/images/family/debian-12",
 						),
 					},
 					AutoDelete: proto.Bool(true),

--- a/compute/instances/custom-machine-type/create_shared_with_helper.go
+++ b/compute/instances/custom-machine-type/create_shared_with_helper.go
@@ -218,7 +218,7 @@ func createInstanceWithCustomSharedCore(
 					InitializeParams: &computepb.AttachedDiskInitializeParams{
 						DiskSizeGb: proto.Int64(10),
 						SourceImage: proto.String(
-							"projects/debian-cloud/global/images/family/debian-10",
+							"projects/debian-cloud/global/images/family/debian-12",
 						),
 					},
 					AutoDelete: proto.Bool(true),

--- a/compute/instances/custom-machine-type/create_with_helper.go
+++ b/compute/instances/custom-machine-type/create_with_helper.go
@@ -218,7 +218,7 @@ func createInstanceWithCustomMachineTypeWithHelper(
 					InitializeParams: &computepb.AttachedDiskInitializeParams{
 						DiskSizeGb: proto.Int64(10),
 						SourceImage: proto.String(
-							"projects/debian-cloud/global/images/family/debian-10",
+							"projects/debian-cloud/global/images/family/debian-12",
 						),
 					},
 					AutoDelete: proto.Bool(true),

--- a/compute/instances/custom-machine-type/create_without_helper.go
+++ b/compute/instances/custom-machine-type/create_without_helper.go
@@ -56,7 +56,7 @@ func createInstanceWithCustomMachineTypeWithoutHelper(
 				InitializeParams: &computepb.AttachedDiskInitializeParams{
 					DiskSizeGb: proto.Int64(10),
 					SourceImage: proto.String(
-						"projects/debian-cloud/global/images/family/debian-10",
+						"projects/debian-cloud/global/images/family/debian-12",
 					),
 				},
 				AutoDelete: proto.Bool(true),

--- a/compute/instances/custom-machine-type/extra_mem_without_helper.go
+++ b/compute/instances/custom-machine-type/extra_mem_without_helper.go
@@ -56,7 +56,7 @@ func createInstanceWithExtraMemWithoutHelper(
 				InitializeParams: &computepb.AttachedDiskInitializeParams{
 					DiskSizeGb: proto.Int64(10),
 					SourceImage: proto.String(
-						"projects/debian-cloud/global/images/family/debian-10",
+						"projects/debian-cloud/global/images/family/debian-12",
 					),
 				},
 				AutoDelete: proto.Bool(true),

--- a/compute/instances/preventing-accidental-vm-deletion/create_instance.go
+++ b/compute/instances/preventing-accidental-vm-deletion/create_instance.go
@@ -52,7 +52,7 @@ func createInstance(w io.Writer, projectID, zone, instanceName string, deletePro
 					// Describe the size and source image of the boot disk to attach to the instance.
 					InitializeParams: &computepb.AttachedDiskInitializeParams{
 						DiskSizeGb:  proto.Int64(10),
-						SourceImage: proto.String("projects/debian-cloud/global/images/family/debian-10"),
+						SourceImage: proto.String("projects/debian-cloud/global/images/family/debian-12"),
 					},
 					AutoDelete: proto.Bool(true),
 					Boot:       proto.Bool(true),

--- a/compute/start_stop_instances_test.go
+++ b/compute/start_stop_instances_test.go
@@ -45,7 +45,7 @@ func TestStartStopSnippets(t *testing.T) {
 	instanceName := "test-instance-" + fmt.Sprint(seededRand.Int())
 	instanceName2 := "test-instance-" + fmt.Sprint(seededRand.Int())
 	machineType := "n1-standard-1"
-	sourceImage := "projects/debian-cloud/global/images/family/debian-10"
+	sourceImage := "projects/debian-cloud/global/images/family/debian-12"
 	networkName := "global/networks/default"
 
 	buf := &bytes.Buffer{}


### PR DESCRIPTION
This family is no longer available, so all these compute tests are
currently broken.

## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [ ] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
