### PR TITLE
fix(internal): Printf with non-constant format arg

### DIFF
--- a/internal/cloudrunci/cloudrunci.go
+++ b/internal/cloudrunci/cloudrunci.go
@@ -301,7 +301,7 @@ func (s *Service) Build() error {
 	}
 
 	if out, err := gcloud(s.operationLabel(labelOperationBuild), s.buildCmd()); err != nil {
-		fmt.Printf(string(out))
+		fmt.Print(string(out))
 		return fmt.Errorf("gcloud: %s: %q", s.Image, err)
 	}
 	s.built = true


### PR DESCRIPTION
Reported by staticcheck: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
