### PR TITLE
fix: simpify sample structure

### DIFF
--- a/vertexai/multimodal-pdf/pdf.go
+++ b/vertexai/multimodal-pdf/pdf.go
@@ -25,26 +25,11 @@ import (
 	"cloud.google.com/go/vertexai/genai"
 )
 
-// pdfPrompt is a sample prompt type consisting of one PDF asset, and a text question.
-type pdfPrompt struct {
-	// pdfPath is a Google Cloud Storage path starting with "gs://"
-	pdfPath string
-	// question asked to the model
-	question string
-}
-
 // generateContentFromPDF generates a response into the provided io.Writer, based upon the PDF
-// asset and the question provided in the multimodal prompt.
-func generateContentFromPDF(w io.Writer, prompt pdfPrompt, projectID, location, modelName string) error {
-	// prompt := pdfPrompt{
-	// 	pdfPath: "gs://cloud-samples-data/generative-ai/pdf/2403.05530.pdf",
-	// 	question: `
-	// 		You are a very professional document summarization specialist.
-	// 		Please summarize the given document.
-	// 	`,
-	// }
+func generateContentFromPDF(w io.Writer, projectID, location, modelName string) error {
 	// location := "us-central1"
 	// modelName := "gemini-1.5-flash-001"
+
 	ctx := context.Background()
 
 	client, err := genai.NewClient(ctx, projectID, location)
@@ -57,10 +42,13 @@ func generateContentFromPDF(w io.Writer, prompt pdfPrompt, projectID, location, 
 
 	part := genai.FileData{
 		MIMEType: "application/pdf",
-		FileURI:  prompt.pdfPath,
+		FileURI:  "gs://cloud-samples-data/generative-ai/pdf/2403.05530.pdf",
 	}
 
-	res, err := model.GenerateContent(ctx, part, genai.Text(prompt.question))
+	res, err := model.GenerateContent(ctx, part, genai.Text(`
+			You are a very professional document summarization specialist.
+    		Please summarize the given document.
+	`))
 	if err != nil {
 		return fmt.Errorf("unable to generate contents: %w", err)
 	}

--- a/vertexai/multimodal-pdf/pdf_test.go
+++ b/vertexai/multimodal-pdf/pdf_test.go
@@ -25,11 +25,11 @@ import (
 func Test_generateContentFromPDF(t *testing.T) {
 	tc := testutil.SystemTest(t)
 
-	buf := new(bytes.Buffer)
+	var buf bytes.Buffer
 	location := "us-central1"
 	modelName := "gemini-1.5-flash-001"
 
-	err := generateContentFromPDF(buf, tc.ProjectID, location, modelName)
+	err := generateContentFromPDF(&buf, tc.ProjectID, location, modelName)
 	if err != nil {
 		t.Errorf("Test_generateContentFromPDF: %v", err.Error())
 	}

--- a/vertexai/multimodal-pdf/pdf_test.go
+++ b/vertexai/multimodal-pdf/pdf_test.go
@@ -26,17 +26,10 @@ func Test_generateContentFromPDF(t *testing.T) {
 	tc := testutil.SystemTest(t)
 
 	buf := new(bytes.Buffer)
-	prompt := pdfPrompt{
-		pdfPath: "gs://cloud-samples-data/generative-ai/pdf/2403.05530.pdf",
-		question: `
-			You are a very professional document summarization specialist.
-    		Please summarize the given document.
-		`,
-	}
 	location := "us-central1"
 	modelName := "gemini-1.5-flash-001"
 
-	err := generateContentFromPDF(buf, prompt, tc.ProjectID, location, modelName)
+	err := generateContentFromPDF(buf, tc.ProjectID, location, modelName)
 	if err != nil {
 		t.Errorf("Test_generateContentFromPDF: %v", err.Error())
 	}
@@ -50,7 +43,7 @@ func Test_generateContentFromPDF(t *testing.T) {
 		"tokens",
 	} {
 		if !strings.Contains(generatedSummaryLowercase, word) {
-			t.Errorf("expected the word %q in the description of %s", word, prompt.pdfPath)
+			t.Errorf("expected the word %q in the description of %s", word, "gs://cloud-samples-data/generative-ai/pdf/2403.05530.pdf")
 		}
 	}
 }


### PR DESCRIPTION
## Description

Removing redundant structure and put the values from the test directly to the sample

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
