### PR TITLE
feat(dlp): Add code sample for using REP endpoint

### DIFF
--- a/dlp/snippets/inspect/inspect_string_rep.go
+++ b/dlp/snippets/inspect/inspect_string_rep.go
@@ -1,0 +1,77 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inspect
+
+// [START dlp_inspect_string_rep]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	dlp "cloud.google.com/go/dlp/apiv2"
+	"cloud.google.com/go/dlp/apiv2/dlppb"
+	"google.golang.org/api/option"
+)
+
+// inspectString inspects the a given string, and prints results.
+func inspectStringRep(w io.Writer, projectID, repLocation, textToInspect string) error {
+	// projectID := "my-project-id"
+	// textToInspect := "My name is Gary and my email is gary@example.com"
+	ctx := context.Background()
+
+	// Assemble the regional endpoint url using provided rep location
+	repEndpoint := fmt.Sprintf("dlp.%s.rep.googleapis.com:443", repLocation)
+
+	// Initialize client.
+	client, err := dlp.NewClient(ctx, option.WithEndpoint(repEndpoint))
+	if err != nil {
+		return err
+	}
+	defer client.Close() // Closing the client safely cleans up background resources.
+
+	// Create and send the request.
+	req := &dlppb.InspectContentRequest{
+		Parent: fmt.Sprintf("projects/%s/locations/%s", projectID, repLocation),
+		Item: &dlppb.ContentItem{
+			DataItem: &dlppb.ContentItem_Value{
+				Value: textToInspect,
+			},
+		},
+		InspectConfig: &dlppb.InspectConfig{
+			InfoTypes: []*dlppb.InfoType{
+				{Name: "PHONE_NUMBER"},
+				{Name: "EMAIL_ADDRESS"},
+				{Name: "CREDIT_CARD_NUMBER"},
+			},
+			IncludeQuote: true,
+		},
+	}
+	resp, err := client.InspectContent(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	// Process the results.
+	result := resp.Result
+	fmt.Fprintf(w, "Findings: %d\n", len(result.Findings))
+	for _, f := range result.Findings {
+		fmt.Fprintf(w, "\tQuote: %s\n", f.Quote)
+		fmt.Fprintf(w, "\tInfo type: %s\n", f.InfoType.Name)
+		fmt.Fprintf(w, "\tLikelihood: %s\n", f.Likelihood)
+	}
+	return nil
+}
+
+// [END dlp_inspect_string_rep]

--- a/dlp/snippets/inspect/inspect_string_rep_test.go
+++ b/dlp/snippets/inspect/inspect_string_rep_test.go
@@ -1,0 +1,37 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inspect
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+)
+
+func TestInspectStringRep(t *testing.T) {
+	tc := testutil.SystemTest(t)
+	buf := new(bytes.Buffer)
+
+	if err := inspectStringRep(buf, tc.ProjectID, "us-west1", "I'm Gary and my email is gary@example.com"); err != nil {
+		t.Errorf("TestInspectFile: %v", err)
+	}
+
+	got := buf.String()
+	if want := "Info type: EMAIL_ADDRESS"; !strings.Contains(got, want) {
+		t.Errorf("inspectString got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Description

Fixes: N/A

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
