### PR TITLE
fix: wordcount.go - register DoFns with the the beam/register package

### DIFF
--- a/dataflow/flex-templates/wordcount/wordcount.go
+++ b/dataflow/flex-templates/wordcount/wordcount.go
@@ -48,6 +48,7 @@ var (
 func init() {
 	register.DoFn3x0[context.Context, string, func(string)](&extractFn{})
 	register.Emitter1[string]()
+	register.Function2x1(formatFn)
 }
 
 var (


### PR DESCRIPTION
Fixes failing [wordcount.go](https://btx.cloud.google.com/invocations/d26822fa-f42d-4e76-b4f1-6afd2854c48e/targets/cloud-devrel%2Fgo%2Fgolang-samples%2Fpresubmit%2Flatest-version;config=default/log)

```
failed to decode userfn
        	caused by:
        github.com/GoogleCloudPlatform/golang-samples/dataflow/flex-templates/wordcount.formatFn not found. Register DoFns and functions with the the beam/register package.
2024/08/05 18:32:20 ERROR ProcessBundle failed: 	invalid bundle desc: stage-004
```