### PR TITLE
fix: moved attributes inside sample

### DIFF
--- a/vertexai/multimodal/multimodal.go
+++ b/vertexai/multimodal/multimodal.go
@@ -27,9 +27,7 @@ import (
 	"cloud.google.com/go/vertexai/genai"
 )
 
-// generateMultimodalContent generates a response into w, based upon the prompt
-// and image provided.
-// image is a Google Cloud Storage path starting with "gs://"
+// generateMultimodalContent generates a response into w, based upon the prompt and image.
 func generateMultimodalContent(w io.Writer, projectID, location, modelName string) error {
 	// location := "us-central1"
 	// modelName := "gemini-1.5-flash-001"

--- a/vertexai/multimodal/multimodal.go
+++ b/vertexai/multimodal/multimodal.go
@@ -30,12 +30,11 @@ import (
 // generateMultimodalContent generates a response into w, based upon the prompt
 // and image provided.
 // image is a Google Cloud Storage path starting with "gs://"
-func generateMultimodalContent(w io.Writer, prompt, image, projectID, location, modelName string) error {
-	// prompt := "describe what is in this picture"
-	// image := "gs://generativeai-downloads/images/scones.jpg"
+func generateMultimodalContent(w io.Writer, projectID, location, modelName string) error {
 	// location := "us-central1"
 	// modelName := "gemini-1.5-flash-001"
 	ctx := context.Background()
+	image := "gs://generativeai-downloads/images/scones.jpg"
 
 	client, err := genai.NewClient(ctx, projectID, location)
 	if err != nil {
@@ -52,7 +51,7 @@ func generateMultimodalContent(w io.Writer, prompt, image, projectID, location, 
 		FileURI:  image,
 	}
 
-	res, err := model.GenerateContent(ctx, img, genai.Text(prompt))
+	res, err := model.GenerateContent(ctx, img, genai.Text("describe what is in this picture"))
 	if err != nil {
 		return fmt.Errorf("unable to generate contents: %v", err)
 	}

--- a/vertexai/multimodal/multimodal_test.go
+++ b/vertexai/multimodal/multimodal_test.go
@@ -25,12 +25,10 @@ func Test_generateMultimodalContent(t *testing.T) {
 	tc := testutil.SystemTest(t)
 
 	buf := new(bytes.Buffer)
-	prompt := "describe what is in this picture"
-	image := "gs://generativeai-downloads/images/scones.jpg"
 	location := "us-central1"
 	modelName := "gemini-1.5-flash-001"
 
-	err := generateMultimodalContent(buf, prompt, image, tc.ProjectID, location, modelName)
+	err := generateMultimodalContent(buf, tc.ProjectID, location, modelName)
 	if err != nil {
 		t.Errorf("Test_generateMultimodalContent: %v", err.Error())
 	}


### PR DESCRIPTION
## Description

Moved attributes inside sample function to follow "copy-paste-runnable" principle

## Checklist
- [ ] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [ ] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
