### PR TITLE
fix(pubsub): add locational endpoint for exactly once sample

### DIFF
--- a/pubsub/subscriptions/pull_exactly_once_delivery.go
+++ b/pubsub/subscriptions/pull_exactly_once_delivery.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/pubsub"
+	"google.golang.org/api/option"
 )
 
 // receiveMessagesWithExactlyOnceDeliveryEnabled instantiates a subscriber client.
@@ -33,7 +34,7 @@ func receiveMessagesWithExactlyOnceDeliveryEnabled(w io.Writer, projectID, subID
 	// projectID := "my-project-id"
 	// subID := "my-sub"
 	ctx := context.Background()
-	client, err := pubsub.NewClient(ctx, projectID)
+	client, err := pubsub.NewClient(ctx, projectID, option.WithEndpoint("us-central1.googleapis.com:443"))
 	if err != nil {
 		return fmt.Errorf("pubsub.NewClient: %w", err)
 	}

--- a/pubsub/subscriptions/pull_exactly_once_delivery.go
+++ b/pubsub/subscriptions/pull_exactly_once_delivery.go
@@ -34,7 +34,10 @@ func receiveMessagesWithExactlyOnceDeliveryEnabled(w io.Writer, projectID, subID
 	// projectID := "my-project-id"
 	// subID := "my-sub"
 	ctx := context.Background()
-	client, err := pubsub.NewClient(ctx, projectID, option.WithEndpoint("us-central1.googleapis.com:443"))
+
+	// Pub/Sub's exactly once delivery guarantee only applies when subscribers connect to the service in the same region.
+	// For list of locational endpoints for Pub/Sub, see https://cloud.google.com/pubsub/docs/reference/service_apis_overview#list_of_locational_endpoints
+	client, err := pubsub.NewClient(ctx, projectID, option.WithEndpoint("us-west1-pubsub.googleapis.com:443"))
 	if err != nil {
 		return fmt.Errorf("pubsub.NewClient: %w", err)
 	}

--- a/pubsub/topics/publish_ordering.go
+++ b/pubsub/topics/publish_ordering.go
@@ -31,8 +31,8 @@ func publishWithOrderingKey(w io.Writer, projectID, topicID string) {
 	// topicID := "my-topic"
 	ctx := context.Background()
 
-	// Sending messages to the same region ensures they are received in order
-	// even when multiple publishers are used.
+	// Pub/Sub's ordered delivery guarantee only applies when publishes for an ordering key are in the same region.
+	// For list of locational endpoints for Pub/Sub, see https://cloud.google.com/pubsub/docs/reference/service_apis_overview#list_of_locational_endpoints
 	client, err := pubsub.NewClient(ctx, projectID,
 		option.WithEndpoint("us-east1-pubsub.googleapis.com:443"))
 	if err != nil {

--- a/pubsub/topics/publish_resume_ordering.go
+++ b/pubsub/topics/publish_resume_ordering.go
@@ -29,8 +29,8 @@ func resumePublishWithOrderingKey(w io.Writer, projectID, topicID string) {
 	// topicID := "my-topic"
 	ctx := context.Background()
 
-	// Sending messages to the same region ensures they are received in order
-	// even when multiple publishers are used.
+	// Pub/Sub's ordered delivery guarantee only applies when publishes for an ordering key are in the same region
+	// For list of locational endpoints for Pub/Sub, see https://cloud.google.com/pubsub/docs/reference/service_apis_overview#list_of_locational_endpoints
 	client, err := pubsub.NewClient(ctx, projectID,
 		option.WithEndpoint("us-east1-pubsub.googleapis.com:443"))
 	if err != nil {


### PR DESCRIPTION
## Description

Exactly once delivery is best set with a locational endpoint. This adds the `WithEndpoint` option to the exactly once sample, and fixes the comments for ordering samples.

---

When you run your application within Google Cloud, it typically connects to the Pub/Sub endpoint in the same region by default. Therefore, running your application in a single region within Google Cloud generally ensures you are interacting with a single region.

If you are running your publisher application outside of Google Cloud or in multiple regions, you can guarantee you are connecting to a single region using a [locational endpoint](https://cloud.google.com/pubsub/docs/reference/service_apis_overview#pubsub_endpoints) when configuring your Pub/Sub client. All location endpoints for Pub/Sub point to single regions. For a list of all locational endpoints for Pub/Sub, see [List of locational endpoints](https://cloud.google.com/pubsub/docs/reference/service_apis_overview#list_of_locational_endpoints).