### PR TITLE
fix: moved context inside functions

### DIFF
--- a/compute/reservations/reservations_test.go
+++ b/compute/reservations/reservations_test.go
@@ -29,7 +29,8 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func createTemplate(ctx context.Context, project, templateName string) error {
+func createTemplate(project, templateName string) error {
+	ctx := context.Background()
 	client, err := compute.NewInstanceTemplatesRESTClient(ctx)
 	if err != nil {
 		return err
@@ -64,7 +65,8 @@ func createTemplate(ctx context.Context, project, templateName string) error {
 	return op.Wait(ctx)
 }
 
-func getTemplate(ctx context.Context, project, templateName string) (*computepb.InstanceTemplate, error) {
+func getTemplate(project, templateName string) (*computepb.InstanceTemplate, error) {
+	ctx := context.Background()
 	client, err := compute.NewInstanceTemplatesRESTClient(ctx)
 	if err != nil {
 		return nil, err
@@ -77,7 +79,8 @@ func getTemplate(ctx context.Context, project, templateName string) (*computepb.
 	return client.Get(ctx, req)
 }
 
-func deleteTemplate(ctx context.Context, project, templateName string) error {
+func deleteTemplate(project, templateName string) error {
+	ctx := context.Background()
 	client, err := compute.NewInstanceTemplatesRESTClient(ctx)
 	if err != nil {
 		return err
@@ -104,15 +107,14 @@ func TestReservations(t *testing.T) {
 	templateName := fmt.Sprintf("test-template-%v-%v", time.Now().Format("01-02-2006"), r.Int())
 
 	var buf bytes.Buffer
-	ctx := context.Background()
 
-	err := createTemplate(ctx, tc.ProjectID, templateName)
+	err := createTemplate(tc.ProjectID, templateName)
 	if err != nil {
 		t.Errorf("createTemplate got err: %v", err)
 	}
-	defer deleteTemplate(ctx, tc.ProjectID, templateName)
+	defer deleteTemplate(tc.ProjectID, templateName)
 
-	sourceTemplate, err := getTemplate(ctx, tc.ProjectID, templateName)
+	sourceTemplate, err := getTemplate(tc.ProjectID, templateName)
 	if err != nil {
 		t.Errorf("getTemplate got err: %v", err)
 	}


### PR DESCRIPTION
## Description

Fixes context in tests for reservation snippets

## Checklist
- [ ] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [ ] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
