### PR TITLE
fix(cloudrun): update practices from deprecated ioutil to io

### DIFF
--- a/run/pubsub/main.go
+++ b/run/pubsub/main.go
@@ -19,7 +19,7 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -58,9 +58,10 @@ type PubSubMessage struct {
 // HelloPubSub receives and processes a Pub/Sub push message.
 func HelloPubSub(w http.ResponseWriter, r *http.Request) {
 	var m PubSubMessage
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
+	defer r.Body.Close()
 	if err != nil {
-		log.Printf("ioutil.ReadAll: %v", err)
+		log.Printf("io.ReadAll: %v", err)
 		http.Error(w, "Bad Request", http.StatusBadRequest)
 		return
 	}

--- a/run/pubsub/main_test.go
+++ b/run/pubsub/main_test.go
@@ -86,8 +86,7 @@ func TestHelloPubSub(t *testing.T) {
 			t.Errorf("HelloPubSub(%q) invalid input, status code (%q)", test.data, code)
 		}
 
-		out, err := io.ReadAll(r.Body)
-		defer r.Body.Close()
+		out, err := io.ReadAll(r)
 		if err != nil {
 			t.Fatalf("ReadAll: %v", err)
 		}

--- a/run/pubsub/main_test.go
+++ b/run/pubsub/main_test.go
@@ -17,7 +17,7 @@ package main
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -86,7 +86,8 @@ func TestHelloPubSub(t *testing.T) {
 			t.Errorf("HelloPubSub(%q) invalid input, status code (%q)", test.data, code)
 		}
 
-		out, err := ioutil.ReadAll(r)
+		out, err := io.ReadAll(r.Body)
+		defer r.Body.Close()
 		if err != nil {
 			t.Fatalf("ReadAll: %v", err)
 		}


### PR DESCRIPTION
## Description

Fixes b/368461774

* ioutil is deprecated so move to io
* while io.ReadAll closes r.Body internally, recommended practice is to explicitly do resource management and provide clarity. 

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [ ] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
