### PR TITLE
fix: changes batch samples to 1000 CPU millis

### DIFF
--- a/batch/create_with_local_ssd.go
+++ b/batch/create_with_local_ssd.go
@@ -64,8 +64,8 @@ func createJobWithSSD(w io.Writer, projectID, jobName, ssdName string) error {
 
 	taskSpec := &batchpb.TaskSpec{
 		ComputeResource: &batchpb.ComputeResource{
-			// CpuMilli is milliseconds per cpu-second. This means the task requires 2 whole CPUs.
-			CpuMilli:  2000,
+			// CpuMilli is milliseconds per cpu-second. This means the task requires 1 CPU.
+			CpuMilli:  1000,
 			MemoryMib: 16,
 		},
 		MaxRunDuration: &durationpb.Duration{

--- a/batch/create_with_persistent_disk.go
+++ b/batch/create_with_persistent_disk.go
@@ -61,8 +61,8 @@ func createJobWithPD(w io.Writer, projectID, jobName, pdName string) error {
 
 	taskSpec := &batchpb.TaskSpec{
 		ComputeResource: &batchpb.ComputeResource{
-			// CpuMilli is milliseconds per cpu-second. This means the task requires 2 whole CPUs.
-			CpuMilli:  2000,
+			// CpuMilli is milliseconds per cpu-second. This means the task requires 1 CPU.
+			CpuMilli:  1000,
 			MemoryMib: 16,
 		},
 		MaxRunDuration: &durationpb.Duration{


### PR DESCRIPTION
## Description

Issues with other PRs (e.g. #4408 )

Documentation of these settings:
https://cloud.google.com/go/docs/reference/cloud.google.com/go/batch/latest/apiv1/batchpb#cloud_google_com_go_batch_apiv1_batchpb_ComputeResource

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
