### PR TITLE
fix: added defer client.Close() to Vertex samples

### DIFF
--- a/vertexai/batch-predict/batch_code_predict.go
+++ b/vertexai/batch-predict/batch_code_predict.go
@@ -51,6 +51,7 @@ func batchCodePredict(w io.Writer, projectID, location, name, outputURI string, 
 	if err != nil {
 		return err
 	}
+	defer client.Close()
 
 	req := &aiplatformpb.CreateBatchPredictionJobRequest{
 		Parent: fmt.Sprintf("projects/%s/locations/%s", projectID, location),

--- a/vertexai/batch-predict/batch_text_predict.go
+++ b/vertexai/batch-predict/batch_text_predict.go
@@ -54,6 +54,7 @@ func batchTextPredict(w io.Writer, projectID, location, name, outputURI string, 
 	if err != nil {
 		return err
 	}
+	defer client.Close()
 
 	req := &aiplatformpb.CreateBatchPredictionJobRequest{
 		Parent: fmt.Sprintf("projects/%s/locations/%s", projectID, location),

--- a/vertexai/snippets/gemini_translate.go
+++ b/vertexai/snippets/gemini_translate.go
@@ -36,6 +36,8 @@ func geminiTranslate(w io.Writer, project, location string) error {
 	if err != nil {
 		return fmt.Errorf("error creating client: %w", err)
 	}
+	defer client.Close()
+
 	model := client.GenerativeModel(modelName)
 
 	model.GenerationConfig = genai.GenerationConfig{


### PR DESCRIPTION
Two recent PRs -- #4417 and #4413 -- were merged without the `defer client.Close()` line of code. This PR adds those lines to the samples.
