### PR TITLE
Missing variable in the OR query example

### DIFF
--- a/firestore/query_filter_or.go
+++ b/firestore/query_filter_or.go
@@ -51,7 +51,7 @@ func queryFilterOr(w io.Writer, projectId string) error {
 	}
 
 	orQuery := client.Collection("users").WhereEntity(orFilter)
-	it := orQuery.Documents(ctx)
+	it, err := orQuery.Documents(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
While reading the documentation on how to perform [OR queries](https://cloud.google.com/firestore/docs/query-data/queries#or_queries) in Firestore using GO, I noticed that the code was checking for the success of an invocation, while not actually gathering its error (if one present)

## Description

Fixes #4433 

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
