### PR TITLE
feat(securitycenter): add v2 API version of set_mute_undefined_finding.go

### DIFF
--- a/securitycenter/muteconfigv2/mute_config_test.go
+++ b/securitycenter/muteconfigv2/mute_config_test.go
@@ -253,7 +253,6 @@ func TestSetMuteFinding(t *testing.T) {
 }
 
 func TestSetUnmuteFinding(t *testing.T) {
-	t.Skip("see https://github.com/GoogleCloudPlatform/golang-samples/issues/3793")
 	testutil.SystemTest(t)
 
 	var buf bytes.Buffer
@@ -269,6 +268,19 @@ func TestSetUnmuteFinding(t *testing.T) {
 	}
 	if got := buf.String(); !strings.Contains(got, fmt.Sprintf("Mute value for the finding: %s is %s", fixture.finding1Name, "UNMUTE")) {
 		t.Errorf("setUnmute got %q, expected %q", got, fmt.Sprintf("Mute value for the finding: %s is %s", fixture.finding1Name, "UNMUTE"))
+	}
+}
+
+func TestSetMuteUndefinedFinding(t *testing.T) {
+	testutil.SystemTest(t)
+
+	var buf bytes.Buffer
+	// Reset an individual finding mute state to UNDEFINED.
+	if err := setMuteUndefined(&buf, fixture.finding1Name); err != nil {
+		t.Errorf("setMuteUndefined had error: %v", err)
+	}
+	if got := buf.String(); !strings.Contains(got, fmt.Sprintf("Mute value for the finding: %s is %s", fixture.finding1Name, "UNDEFINED")) {
+		t.Errorf("setMuteUndefined got %q, expected %q", got, fmt.Sprintf("Mute value for the finding: %s is %s", fixture.finding1Name, "UNDEFINED"))
 	}
 }
 

--- a/securitycenter/muteconfigv2/set_mute_undefined_finding.go
+++ b/securitycenter/muteconfigv2/set_mute_undefined_finding.go
@@ -1,0 +1,57 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package muteconfigv2
+
+// [START securitycenter_set_mute_undefined_v2]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	securitycenter "cloud.google.com/go/securitycenter/apiv2"
+	"cloud.google.com/go/securitycenter/apiv2/securitycenterpb"
+)
+
+// setMute mutes an individual finding, can also unmute or reset the mute state of a finding.
+// If a finding is already muted, muting it again has no effect.
+// Various mute states are: UNDEFINED/MUTE/UNMUTE.
+func setMuteUndefined(w io.Writer, findingPath string) error {
+	// findingPath: The relative resource name of the finding. See:
+	// https://cloud.google.com/apis/design/resource_names#relative_resource_name
+	// Use any one of the following formats:
+	//  - organizations/{organization_id}/sources/{source_id}/locations/{location_id}/finding/{finding_id}
+	//  - folders/{folder_id}/sources/{source_id}/locations/{location_id}/finding/{finding_id}
+	//  - projects/{project_id}/sources/{source_id}/locations/{location_id}/finding/{finding_id}
+	// findingPath := fmt.Sprintf("projects/%s/sources/%s/locations/%s/finding/%s", "your-google-cloud-project-id", "source", "global", "finding-id")
+	ctx := context.Background()
+	client, err := securitycenter.NewClient(ctx)
+	if err != nil {
+		return fmt.Errorf("securitycenter.NewClient: %w", err)
+	}
+	defer client.Close()
+
+	req := &securitycenterpb.SetMuteRequest{
+		Name: findingPath,
+		Mute: securitycenterpb.Finding_UNDEFINED}
+
+	finding, err := client.SetMute(ctx, req)
+	if err != nil {
+		return fmt.Errorf("failed to set the specified mute value: %w", err)
+	}
+	fmt.Fprintf(w, "Mute value for the finding: %s is %s", finding.Name, finding.Mute)
+	return nil
+}
+
+// [END securitycenter_set_mute_undefined_v2]


### PR DESCRIPTION
## Description

Adds a v2 API equivalent of [`securitycenter/muteconfig/set_mute_undefined_finding.go`](https://github.com/GoogleCloudPlatform/golang-samples/blob/4806377f298263add9ece7569940fd6b8cfde488/securitycenter/muteconfig/set_mute_undefined_finding.go).

Also removes an unnecessary `t.Skip()` from an existing test.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
