### PR TITLE
feat: AR migration for kokoro, pt 1

### DIFF
--- a/testing/docker/cloudbuild.yaml
+++ b/testing/docker/cloudbuild.yaml
@@ -14,9 +14,9 @@
 
 steps:
   - name: 'gcr.io/cloud-builders/docker'
-    args: [ 'build', '--build-arg', 'BASE_IMAGE=golang:${_GO_VERSION}', '-t', 'gcr.io/$PROJECT_ID/${_IMAGE_NAME}', '.' ]
+    args: [ 'build', '--build-arg', 'BASE_IMAGE=golang:${_GO_VERSION}', '-t', 'us-docker.pkg.dev/$PROJECT_ID/kokoro-images/${_IMAGE_NAME}', '.' ]
     waitFor: ['-']
 substitutions:
-  _GO_VERSION: "1.20"
-  _IMAGE_NAME: "go120"
-images: ['gcr.io/$PROJECT_ID/${_IMAGE_NAME}']
+  _GO_VERSION: "1.23"
+  _IMAGE_NAME: "go123"
+images: ['us-docker.pkg.dev/$PROJECT_ID/kokoro-images/${_IMAGE_NAME}']

--- a/testing/kokoro/latest-version.cfg
+++ b/testing/kokoro/latest-version.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/golang-samples-tests/go122"
+    value: "us-docker.pkg.dev/golang-samples-tests/kokoro-images/go123"
 }
 
 # Check `go vet` and `gofmt`.

--- a/testing/kokoro/trampoline.sh
+++ b/testing/kokoro/trampoline.sh
@@ -40,4 +40,5 @@ function cleanup() {
 trap cleanup EXIT
 
 $(dirname $0)/populate-secrets.sh # Secret Manager secrets.
+gcloud auth configure-docker us-docker.pkg.dev #set up docker to use gcloud for this url.
 python3 "${KOKORO_GFILE_DIR}/trampoline_v1.py"


### PR DESCRIPTION
## Description

Update kokoro image builds, and the latest-version kokoro build to use Artifact
Registry.

The container images exist for go 1.21 and 1.23 already.

Part of #4228


## Checklist
- [ ] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [ ] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
