### PR TITLE
fix(spanner): add Edition to created databases.

### DIFF
--- a/spanner/spanner_snippets/spanner/integration_test.go
+++ b/spanner/spanner_snippets/spanner/integration_test.go
@@ -1419,6 +1419,7 @@ func createTestInstance(t *testing.T, projectID string, instanceConfigName strin
 					"cloud_spanner_samples_test": "true",
 					"create_time":                fmt.Sprintf("%v", time.Now().Unix()),
 				},
+				Edition: instancepb.Instance_ENTERPRISE_PLUS,
 			},
 		})
 		if err != nil {

--- a/spanner/spanner_snippets/spanner/spanner_create_instance_with_autoscaling_config.go
+++ b/spanner/spanner_snippets/spanner/spanner_create_instance_with_autoscaling_config.go
@@ -61,7 +61,8 @@ func createInstanceWithAutoscalingConfig(w io.Writer, projectID, instanceID stri
 					StorageUtilizationPercent:         95,
 				},
 			},
-			Labels: map[string]string{"cloud_spanner_samples": "true"},
+			Labels:  map[string]string{"cloud_spanner_samples": "true"},
+			Edition: instancepb.Instance_ENTERPRISE_PLUS,
 		},
 	})
 	if err != nil {

--- a/spanner/spanner_snippets/spanner/spanner_create_instance_with_processing_units.go
+++ b/spanner/spanner_snippets/spanner/spanner_create_instance_with_processing_units.go
@@ -46,6 +46,7 @@ func createInstanceWithProcessingUnits(w io.Writer, projectID, instanceID string
 			DisplayName:     "This is a display name.",
 			ProcessingUnits: 500,
 			Labels:          map[string]string{"cloud_spanner_samples": "true"},
+			Edition:         instancepb.Instance_ENTERPRISE_PLUS,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
## Description

Fix spanner tests by introducing suitable Edition parameters in instance
creation.

Editions are a product change that caused test breakage.

## Checklist
- [ ] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [ ] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
