### PR TITLE
feat: migrate earliest-version off of Container Registry

### DIFF
--- a/testing/kokoro/earliest-version.cfg
+++ b/testing/kokoro/earliest-version.cfg
@@ -3,5 +3,5 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/golang-samples-tests/go121"
+    value: "us-docker.pkg.dev/golang-samples-tests/kokoro-images/go121"
 }


### PR DESCRIPTION
## Description

Switch kokoro's 'earliest-version' builds to use the 1.21 image from Artifact
Registry instead of container registry, which is in turndown.

Part of #4228
