### PR TITLE
chore: upgrade GHA workflows to use stable go

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21.0'
+        go-version: 'stable'
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Build code
@@ -37,7 +37,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21.0'
+        go-version: 'stable'
     - name: Checkout code
       uses: actions/checkout@v2
     # #4374 Pin goimports at v0.22.0
@@ -65,7 +65,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21.0'
+        go-version: 'stable'
     - name: Checkout code
       uses: actions/checkout@v2
     - name: go vet
@@ -83,7 +83,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21.0'
+          go-version: 'stable'
       - name: Check code
         uses: actions/checkout@v2
       - run: go test -v

--- a/getting-started/gopher-run/cmd/main.go
+++ b/getting-started/gopher-run/cmd/main.go
@@ -114,7 +114,7 @@ unroll,0,0,0,0,0,0,0,0,0,0,0`)
 			log.Printf("ioutil.ReadAll: %v", err)
 			continue
 		}
-		data = append(data, []byte("\n")...))
+		data = append(data, []byte("\n")...)
 		data = append(data, b...)
 	}
 	newObj := bkt.Object("pldata.csv").NewWriter(ctx)

--- a/getting-started/gopher-run/cmd/main.go
+++ b/getting-started/gopher-run/cmd/main.go
@@ -114,7 +114,7 @@ unroll,0,0,0,0,0,0,0,0,0,0,0`)
 			log.Printf("ioutil.ReadAll: %v", err)
 			continue
 		}
-		data = append(append(data, []byte("\n")...))
+		data = append(data, []byte("\n")...))
 		data = append(data, b...)
 	}
 	newObj := bkt.Object("pldata.csv").NewWriter(ctx)


### PR DESCRIPTION
## Description

the `actions/setup-go` action has a ['stable'
alias](https://github.com/actions/setup-go?tab=readme-ov-file#using-stableoldstable-aliases)
that we can use for this test.

Since the goal of the workflows is fast feedback on PRs, using the most recent
stable version seems reasonable. Kokoro tests will still ensure compatability
with our minimum and maximum versions.

We can also unpin goimports, since we're using go >1.22.

Fixes #4374

