### PR TITLE
feat(security-command-center): simplify "create client with endpoint" sample

### DIFF
--- a/securitycenter/clientv2/create_client_with_endpoint.go
+++ b/securitycenter/clientv2/create_client_with_endpoint.go
@@ -24,17 +24,8 @@ import (
 )
 
 // createClientWithEndpoint creates a Security Command Center client for a
-// regional endpoint, along with another client for the default endpoint.
+// regional endpoint.
 func createClientWithEndpoint(repLocation string) error {
-	// Instantiate client for default endpoint. Use this client to access resources that
-	// aren't subject to data residency controls.
-	ctx := context.Background()
-	client, err := securitycenter.NewClient(ctx)
-	if err != nil {
-		return err
-	}
-	defer client.Close()
-
 	// Assemble the regional endpoint URL using provided location.
 	repEndpoint := fmt.Sprintf("securitycenter.%s.rep.googleapis.com:443", repLocation)
 	// Instantiate client for regional endpoint. Use this client to access resources that


### PR DESCRIPTION
## Description

I added this sample in #4419. See that PR for the rationale for creating both regional and global clients. However, when I sent a PR for the Java equivalent of this sample, the Java reviewer wouldn't accept a sample that created both regional and non-regional clients.

I still think it would be useful to show the creation of both clients, but I think it's more important to make the samples do approximately the same thing in each language.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
