### PR TITLE
chore: remove extraneous string

### DIFF
--- a/dlp/snippets/deid/deid_table_fpe.go
+++ b/dlp/snippets/deid/deid_table_fpe.go
@@ -32,7 +32,7 @@ func deidentifyTableFPE(w io.Writer, projectID string, kmsKeyName, wrappedAESKey
 	   + "keyRings/YOUR_KEYRING_NAME/"
 	   + "cryptoKeys/YOUR_KEY_NAME"
 	*/
-	// wrappedAESKey := "YOUR_ENCRYPTED_AES_256_KEY"git
+	// wrappedAESKey := "YOUR_ENCRYPTED_AES_256_KEY"
 
 	// define your table.
 	row1 := &dlppb.Table_Row{


### PR DESCRIPTION
It looks like there is some extraneous string in a comment; this PR removes the extraneous stuff.
