### PR TITLE
fix: update practices from deprecated ioutil to io

### DIFF
--- a/cloudsql/mysql/database-sql/connect_tcp.go
+++ b/cloudsql/mysql/database-sql/connect_tcp.go
@@ -23,7 +23,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -66,7 +65,7 @@ func connectTCPSocket() (*sql.DB, error) {
 			dbKey  = mustGetenv("DB_KEY")  // e.g. '/path/to/my/client-key.pem'
 		)
 		pool := x509.NewCertPool()
-		pem, err := ioutil.ReadFile(dbRootCert)
+		pem, err := os.ReadFile(dbRootCert)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Description

Fixes #<ISSUE-NUMBER>
b/345845660
Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
