### PR TITLE
fix: update practices from deprecated ioutil to io

### DIFF
--- a/run/markdown-preview/editor/render.go
+++ b/run/markdown-preview/editor/render.go
@@ -19,7 +19,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -76,7 +76,8 @@ func (s *RenderService) Render(in []byte) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("RenderService.NewRequest: %w", err)
 	}
-	req.Body = ioutil.NopCloser(bytes.NewReader(in))
+
+	req.Body = io.NopCloser(bytes.NewReader(in))
 	defer req.Body.Close()
 
 	resp, err := renderClient.Do(req)
@@ -84,7 +85,7 @@ func (s *RenderService) Render(in []byte) ([]byte, error) {
 		return nil, fmt.Errorf("http.Client.Do: %w", err)
 	}
 
-	out, err := ioutil.ReadAll(resp.Body)
+	out, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("ioutil.ReadAll: %w", err)
 	}


### PR DESCRIPTION
## Description

Fixes #b/345846153

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
