### PR TITLE
feat(eventarc): improved error handling

### DIFF
--- a/functions/functionsv2/hellostorage/hello_storage.go
+++ b/functions/functionsv2/hellostorage/hello_storage.go
@@ -43,7 +43,7 @@ func helloStorage(ctx context.Context, e event.Event) error {
 
 	// Unmarshal() returns an unexported error.
 	// Parse the error string to determine whether there is an unknown field.
-	if strings.Contains(err.Error(), "unknown field") {
+	if err != nil && strings.Contains(err.Error(), "unknown field") {
 		log.Println(err.Error())
 		options := protojson.UnmarshalOptions{
 			DiscardUnknown: true,

--- a/functions/functionsv2/hellostorage/hello_storage.go
+++ b/functions/functionsv2/hellostorage/hello_storage.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 	"github.com/cloudevents/sdk-go/v2/event"
@@ -38,7 +39,18 @@ func helloStorage(ctx context.Context, e event.Event) error {
 	log.Printf("Event Type: %s", e.Type())
 
 	var data storagedata.StorageObjectData
-	if err := protojson.Unmarshal(e.Data(), &data); err != nil {
+	err := protojson.Unmarshal(e.Data(), &data)
+
+	// Unmarshal() returns an unexported error.
+	// Parse the error string to determine whether there is an unknown field.
+	if strings.Contains(err.Error(), "unknown field") {
+		log.Println(err.Error())
+		options := protojson.UnmarshalOptions{
+			DiscardUnknown: true,
+		}
+		err = options.Unmarshal(e.Data(), &data)
+	}
+	if err != nil {
 		return fmt.Errorf("protojson.Unmarshal: %w", err)
 	}
 


### PR DESCRIPTION
This PR demonstrates a potential approach towards EventArc/Cloud Event code samples that need to unmarshal JSON event data.

Note: unfortunately, the `protojson.Unmarshal()` method throws an unexported error struct. Otherwise, we could use `Errors.Is()` or `Errors.As()` to listen for an unknown field error. [This is a known issue.](https://github.com/golang/protobuf/issues/1412)