### PR TITLE
fix: update practices from deprecated ioutil to os #4620

### DIFF
--- a/functions/helloworld/hello_http_system_test.go
+++ b/functions/helloworld/hello_http_system_test.go
@@ -23,7 +23,7 @@ package helloworld
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -114,16 +114,17 @@ func TestHelloHTTPSystem(t *testing.T) {
 	for _, test := range tests {
 		req := &http.Request{
 			Method: http.MethodPost,
-			Body:   ioutil.NopCloser(strings.NewReader(test.body)),
+			Body:   io.NopCloser(strings.NewReader(test.body)),
 			URL:    testURL,
 		}
 		resp, err := client.Do(req)
 		if err != nil {
 			t.Fatalf("HelloHTTP http.Get: %v", err)
 		}
-		body, err := ioutil.ReadAll(resp.Body)
+
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			t.Fatalf("HelloHTTP ioutil.ReadAll: %v", err)
+			t.Fatalf("HelloHTTP io.ReadAll: %v", err)
 		}
 		if got := string(body); got != test.want {
 			t.Errorf("HelloHTTP(%q) = %q, want %q", test.body, got, test.want)


### PR DESCRIPTION
## Description

Fixes #b/345846233

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [ ] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
