### PR TITLE
fix(slack): update practices from deprecated ioutil to io

### DIFF
--- a/pubsub/schemas/commit_avro_schema.go
+++ b/pubsub/schemas/commit_avro_schema.go
@@ -19,12 +19,12 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 
 	"cloud.google.com/go/pubsub"
 )
 
-// commitAvroSchema commits a new avro schema revision to an existing schema.
+// commitAvroSchema commits a new Avro schema revision to an existing schema.
 func commitAvroSchema(w io.Writer, projectID, schemaID, avscFile string) error {
 	// projectID := "my-project-id"
 	// schemaID := "my-schema-id"
@@ -37,7 +37,7 @@ func commitAvroSchema(w io.Writer, projectID, schemaID, avscFile string) error {
 	defer client.Close()
 
 	// Read an Avro schema file formatted in JSON as a byte slice.
-	avscSource, err := ioutil.ReadFile(avscFile)
+	avscSource, err := os.ReadFile(avscFile)
 	if err != nil {
 		return fmt.Errorf("error reading from file: %s", avscFile)
 	}


### PR DESCRIPTION
## Description

Internal: b/345845586

Also fixes check [ST1013 - Should use constants for HTTP error codes, not magic numbers](https://staticcheck.dev/docs/checks#ST1013)

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
