### PR TITLE
fix: update practices from deprecated ioutil to os

### DIFF
--- a/dlp/snippets/redact/redact_image_all_text.go
+++ b/dlp/snippets/redact/redact_image_all_text.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 
 	dlp "cloud.google.com/go/dlp/apiv2"
 	"cloud.google.com/go/dlp/apiv2/dlppb"
@@ -43,7 +43,7 @@ func redactImageFileAllText(w io.Writer, projectID, inputPath, outputPath string
 	defer client.Close()
 
 	// read the image file
-	fileBytes, err := ioutil.ReadFile(inputPath)
+	fileBytes, err := os.ReadFile(inputPath)
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func redactImageFileAllText(w io.Writer, projectID, inputPath, outputPath string
 	}
 
 	// Write the output file.
-	if err := ioutil.WriteFile(outputPath, resp.GetRedactedImage(), 0644); err != nil {
+	if err := os.WriteFile(outputPath, resp.GetRedactedImage(), 0644); err != nil {
 		return err
 	}
 	fmt.Fprintf(w, "Wrote output to %s", outputPath)


### PR DESCRIPTION
## Description

Fixes 
Internal: b/345845803

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
