### PR TITLE
fix: update practices from deprecated ioutil to os

### DIFF
--- a/dlp/snippets/redact/redact.go
+++ b/dlp/snippets/redact/redact.go
@@ -19,7 +19,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 
 	dlp "cloud.google.com/go/dlp/apiv2"
 	"cloud.google.com/go/dlp/apiv2/dlppb"
@@ -59,9 +59,9 @@ func redactImage(w io.Writer, projectID string, infoTypeNames []string, bytesTyp
 	}
 
 	// Read the input file.
-	b, err := ioutil.ReadFile(inputPath)
+	b, err := os.ReadFile(inputPath)
 	if err != nil {
-		return fmt.Errorf("ioutil.ReadFile: %w", err)
+		return fmt.Errorf("os.ReadFile: %w", err)
 	}
 
 	// Create a configured request.
@@ -84,8 +84,8 @@ func redactImage(w io.Writer, projectID string, infoTypeNames []string, bytesTyp
 		return fmt.Errorf("RedactImage: %w", err)
 	}
 	// Write the output file.
-	if err := ioutil.WriteFile(outputPath, resp.GetRedactedImage(), 0644); err != nil {
-		return fmt.Errorf("ioutil.WriteFile: %w", err)
+	if err := os.WriteFile(outputPath, resp.GetRedactedImage(), 0644); err != nil {
+		return fmt.Errorf("os.WriteFile: %w", err)
 	}
 	fmt.Fprintf(w, "Wrote output to %s", outputPath)
 	return nil


### PR DESCRIPTION
## Description

Fixes
Internal: b/345845917

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [ ] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
