### PR TITLE
fix: update practices from deprecated ioutil to io

### DIFF
--- a/healthcare/fhir_execute_bundle.go
+++ b/healthcare/fhir_execute_bundle.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	healthcare "google.golang.org/api/healthcare/v1"
 )
@@ -68,7 +67,7 @@ func fhirExecuteBundle(w io.Writer, projectID, location, datasetID, fhirStoreID 
 	}
 	defer resp.Body.Close()
 
-	respBytes, err := ioutil.ReadAll(resp.Body)
+	respBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("could not read response: %w", err)
 	}

--- a/healthcare/fhir_execute_bundle.go
+++ b/healthcare/fhir_execute_bundle.go
@@ -63,7 +63,7 @@ func fhirExecuteBundle(w io.Writer, projectID, location, datasetID, fhirStoreID 
 	call.Header().Set("Content-Type", "application/fhir+json;charset=utf-8")
 	resp, err := call.Do()
 	if err != nil {
-		return fmt.Errorf("ExecuteBundle: %w", err)
+		return fmt.Errorf("executeBundle: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -73,7 +73,7 @@ func fhirExecuteBundle(w io.Writer, projectID, location, datasetID, fhirStoreID 
 	}
 
 	if resp.StatusCode > 299 {
-		return fmt.Errorf("Create: status %d %s: %s", resp.StatusCode, resp.Status, respBytes)
+		return fmt.Errorf("create: status %d %s: %s", resp.StatusCode, resp.Status, respBytes)
 	}
 	fmt.Fprintf(w, "%s", respBytes)
 


### PR DESCRIPTION
## Description

Fixes b/345846253

Also updated "fmt.Errorf" messages from initial capitalized word to lowercase 

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
