### PR TITLE
fix: update practices from deprecated ioutil to os

### DIFF
--- a/texttospeech/synthesize_file/synthesize_file.go
+++ b/texttospeech/synthesize_file/synthesize_file.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -41,7 +40,7 @@ func SynthesizeTextFile(w io.Writer, textFile, outputFile string) error {
 	}
 	defer client.Close()
 
-	text, err := ioutil.ReadFile(textFile)
+	text, err := os.ReadFile(textFile)
 	if err != nil {
 		return err
 	}
@@ -66,7 +65,7 @@ func SynthesizeTextFile(w io.Writer, textFile, outputFile string) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(outputFile, resp.AudioContent, 0644)
+	err = os.WriteFile(outputFile, resp.AudioContent, 0644)
 	if err != nil {
 		return err
 	}
@@ -95,7 +94,7 @@ func SynthesizeSSMLFile(w io.Writer, ssmlFile, outputFile string) error {
 	}
 	defer client.Close()
 
-	ssml, err := ioutil.ReadFile(ssmlFile)
+	ssml, err := os.ReadFile(ssmlFile)
 	if err != nil {
 		return err
 	}
@@ -120,7 +119,7 @@ func SynthesizeSSMLFile(w io.Writer, ssmlFile, outputFile string) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(outputFile, resp.AudioContent, 0644)
+	err = os.WriteFile(outputFile, resp.AudioContent, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

- Replaced deprecated ioutil.ReadFile with os.ReadFile
- Replaced deprecated ioutil.WriteFile with os.WriteFile
- Updated import block to remove unused io/ioutil package

Fixes [b/345846570](http://b/345846570)

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
