### PR TITLE
fix: update practices from deprecated ioutil to os

### DIFF
--- a/texttospeech/synthesize_text/synthesize_text.go
+++ b/texttospeech/synthesize_text/synthesize_text.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -60,7 +59,7 @@ func SynthesizeText(w io.Writer, text, outputFile string) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(outputFile, resp.AudioContent, 0644)
+	err = os.WriteFile(outputFile, resp.AudioContent, 0644)
 	if err != nil {
 		return err
 	}
@@ -108,7 +107,7 @@ func SynthesizeSSML(w io.Writer, ssml, outputFile string) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(outputFile, resp.AudioContent, 0644)
+	err = os.WriteFile(outputFile, resp.AudioContent, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

- Replaced deprecated ioutil.WriteFile with os.WriteFile
- Updated import block to remove unused io/ioutil package

Fixes [b/345846331](http://b/345846331)

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
