### PR TITLE
fix(eventarc): sets protojson to DiscardUnknown

### DIFF
--- a/eventarc/storage_handler/handler.go
+++ b/eventarc/storage_handler/handler.go
@@ -37,7 +37,13 @@ func HelloStorage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var so storagedata.StorageObjectData
-	err = protojson.Unmarshal(ce.Data(), &so)
+
+	// If you omit `DiscardUnknown`, then protojson.Unmarshal returns an error
+	// when encountering a new or unknown field.
+	options := protojson.UnmarshalOptions{
+		DiscardUnknown: true,
+	}
+	err = options.Unmarshal(ce.Data(), &so)
 	if err != nil {
 		log.Printf("failed to unmarshal: %v", err)
 		http.Error(w, "Bad Request: expected Cloud Storage event", http.StatusBadRequest)

--- a/eventarc/storage_handler/handler_test.go
+++ b/eventarc/storage_handler/handler_test.go
@@ -96,31 +96,3 @@ func TestHelloStorage_NotCloudEvent(t *testing.T) {
 		t.Errorf("got %q, want %q", got, wantBody)
 	}
 }
-
-func TestHelloStorage_NotStorageObjectData(t *testing.T) {
-	jsondata := []byte(`{"arbitrary": "value"}`)
-
-	ce := cloudevents.NewEvent()
-	ce.SetID("sample-id")
-	ce.SetSource("//sample/source")
-	ce.SetType("google.cloud.storage.object.v1.finalized")
-	ce.SetData(*cloudevents.StringOfApplicationJSON(), jsondata)
-
-	w := httptest.NewRecorder()
-	r, err := cloudevents.NewHTTPRequestFromEvent(context.Background(), "http://localhost", ce)
-	if err != nil {
-		t.Fatalf("cloudevents.NewHTTPRequestFromEvent: %v", err)
-	}
-	HelloStorage(w, r)
-
-	wantStatus := http.StatusBadRequest
-	if got := w.Result().StatusCode; got != wantStatus {
-		t.Errorf("got %q, want %q", got, wantStatus)
-	}
-
-	// Ensure failure on malformed storage data.
-	wantBody := "Bad Request: expected Cloud Storage event\n"
-	if got := w.Body.String(); got != wantBody {
-		t.Errorf("got %q, want %q", got, wantBody)
-	}
-}

--- a/functions/functionsv2/firebase/hellofirestore/hellofirestore.go
+++ b/functions/functionsv2/firebase/hellofirestore/hellofirestore.go
@@ -24,7 +24,7 @@ import (
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/googleapis/google-cloudevents-go/cloud/firestoredata"
-	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 func init() {
@@ -34,7 +34,15 @@ func init() {
 // HelloFirestore is triggered by a change to a Firestore document.
 func HelloFirestore(ctx context.Context, event event.Event) error {
 	var data firestoredata.DocumentEventData
-	if err := proto.Unmarshal(event.Data(), &data); err != nil {
+
+	// If you omit `DiscardUnknown`, protojson.Unmarshal returns an error
+	// when encountering a new or unknown field.
+	options := protojson.UnmarshalOptions{
+		DiscardUnknown: true,
+	}
+	err := options.Unmarshal(event.Data(), &data)
+
+	if err != nil {
 		return fmt.Errorf("proto.Unmarshal: %w", err)
 	}
 

--- a/functions/functionsv2/firebase/hellofirestore/hellofirestore.go
+++ b/functions/functionsv2/firebase/hellofirestore/hellofirestore.go
@@ -24,7 +24,7 @@ import (
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/googleapis/google-cloudevents-go/cloud/firestoredata"
-	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 func init() {
@@ -37,7 +37,7 @@ func HelloFirestore(ctx context.Context, event event.Event) error {
 
 	// If you omit `DiscardUnknown`, protojson.Unmarshal returns an error
 	// when encountering a new or unknown field.
-	options := protojson.UnmarshalOptions{
+	options := proto.UnmarshalOptions{
 		DiscardUnknown: true,
 	}
 	err := options.Unmarshal(event.Data(), &data)

--- a/functions/functionsv2/firebase/upper/upper.go
+++ b/functions/functionsv2/firebase/upper/upper.go
@@ -101,7 +101,7 @@ func MakeUpperCase(ctx context.Context, e event.Event) error {
 	log.Printf("Replacing value: %q -> %q", originalStringValue, newValue)
 
 	newDocumentEntry := map[string]string{"original": newValue}
-	_, err := client.Collection(collection).Doc(doc).Set(ctx, newDocumentEntry)
+	_, err = client.Collection(collection).Doc(doc).Set(ctx, newDocumentEntry)
 	if err != nil {
 		return fmt.Errorf("Set: %w", err)
 	}

--- a/functions/functionsv2/firebase/upper/upper.go
+++ b/functions/functionsv2/firebase/upper/upper.go
@@ -30,7 +30,7 @@ import (
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/googleapis/google-cloudevents-go/cloud/firestoredata"
-	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 // set the GOOGLE_CLOUD_PROJECT environment variable when deploying.
@@ -68,7 +68,7 @@ func MakeUpperCase(ctx context.Context, e event.Event) error {
 
 	// If you omit `DiscardUnknown`, protojson.Unmarshal returns an error
 	// when encountering a new or unknown field.
-	options := protojson.UnmarshalOptions{
+	options := proto.UnmarshalOptions{
 		DiscardUnknown: true,
 	}
 	err := options.Unmarshal(e.Data(), &data)

--- a/functions/functionsv2/firebase/upper/upper.go
+++ b/functions/functionsv2/firebase/upper/upper.go
@@ -30,7 +30,7 @@ import (
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
 	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/googleapis/google-cloudevents-go/cloud/firestoredata"
-	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // set the GOOGLE_CLOUD_PROJECT environment variable when deploying.
@@ -65,7 +65,15 @@ func init() {
 // the `original` value of the document to upper case.
 func MakeUpperCase(ctx context.Context, e event.Event) error {
 	var data firestoredata.DocumentEventData
-	if err := proto.Unmarshal(e.Data(), &data); err != nil {
+
+	// If you omit `DiscardUnknown`, protojson.Unmarshal returns an error
+	// when encountering a new or unknown field.
+	options := protojson.UnmarshalOptions{
+		DiscardUnknown: true,
+	}
+	err := options.Unmarshal(e.Data(), &data)
+
+	if err != nil {
 		return fmt.Errorf("proto.Unmarshal: %w", err)
 	}
 

--- a/functions/functionsv2/imagemagick/imagemagick.go
+++ b/functions/functionsv2/imagemagick/imagemagick.go
@@ -70,7 +70,15 @@ func blurOffensiveImages(ctx context.Context, e cloudevents.Event) error {
 	}
 
 	var gcsEvent storagedata.StorageObjectData
-	if err := protojson.Unmarshal(e.Data(), &gcsEvent); err != nil {
+
+	// If you omit `DiscardUnknown`, protojson.Unmarshal returns an error
+	// when encountering a new or unknown field.
+	options := protojson.UnmarshalOptions{
+		DiscardUnknown: true,
+	}
+
+	err := options.Unmarshal(e.Data(), &gcsEvent)
+	if err != nil {
 		return fmt.Errorf("protojson.Unmarshal: failed to decode event data: %w", err)
 	}
 	img := vision.NewImageFromURI(fmt.Sprintf("gs://%s/%s", gcsEvent.GetBucket(), gcsEvent.GetName()))

--- a/functions/functionsv2/ocr/app/process.go
+++ b/functions/functionsv2/ocr/app/process.go
@@ -39,7 +39,15 @@ func ProcessImage(ctx context.Context, cloudevent event.Event) error {
 	}
 
 	var data storagedata.StorageObjectData
-	if err := protojson.Unmarshal(cloudevent.Data(), &data); err != nil {
+
+	// If you omit `DiscardUnknown`, then protojson.Unmarshal returns an error
+	// when encountering a new or unknown field.
+	options := protojson.UnmarshalOptions{
+		DiscardUnknown: true,
+	}
+
+	err := options.Unmarshal(cloudevent.Data(), &data)
+	if err != nil {
 		return fmt.Errorf("protojson.Unmarshal: Failed to parse CloudEvent data: %w", err)
 	}
 	if data.GetBucket() == "" {


### PR DESCRIPTION
## Description

This PR sets all of the calls to `protojson.Unmarshal()` to `DiscardUnknown` fields. This will reduce the likelihood of customers encountering errors in their deployed functions. This PR also adds a comment explaining the usage of the `DiscardUnknown` field.
