### PR TITLE
feat: create batch with nfs sample

### DIFF
--- a/batch/create_with_nfs.go
+++ b/batch/create_with_nfs.go
@@ -25,7 +25,7 @@ import (
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 )
 
-// Creates and runs a job with status events that mounts a Network File System (NFS).
+// createJobWithNFS creates and runs a job with status events that mounts a Network File System (NFS).
 func createJobWithNFS(w io.Writer, projectID, region, jobName, remotePath, server, mountPath string) (*batchpb.Job, error) {
 	ctx := context.Background()
 	batchClient, err := batch.NewClient(ctx)
@@ -37,6 +37,7 @@ func createJobWithNFS(w io.Writer, projectID, region, jobName, remotePath, serve
 	runn := &batchpb.Runnable{
 		Executable: &batchpb.Runnable_Script_{
 			Script: &batchpb.Runnable_Script{
+				// Example command to run executable
 				Command: &batchpb.Runnable_Script_Text{
 					Text: "echo Hello world from script 1 for task ${BATCH_TASK_INDEX}",
 				},
@@ -89,7 +90,7 @@ func createJobWithNFS(w io.Writer, projectID, region, jobName, remotePath, serve
 		}},
 	}
 
-	// We use Cloud Logging as it's an out of the box available option
+	// Use Cloud Logging as it's an out-of-the-box available option.
 	logsPolicy := &batchpb.LogsPolicy{
 		Destination: batchpb.LogsPolicy_CLOUD_LOGGING,
 	}
@@ -107,13 +108,13 @@ func createJobWithNFS(w io.Writer, projectID, region, jobName, remotePath, serve
 		Job:    job,
 	}
 
-	created_job, err := batchClient.CreateJob(ctx, request)
+	createdJob, err := batchClient.CreateJob(ctx, request)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create job: %w", err)
 	}
 
-	fmt.Fprintf(w, "Job created: %v\n", created_job)
-	return created_job, nil
+	fmt.Fprintf(w, "Job created: %v\n", createdJob)
+	return createdJob, nil
 }
 
 // [END batch_create_nfs_job]

--- a/batch/create_with_nfs.go
+++ b/batch/create_with_nfs.go
@@ -1,0 +1,119 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snippets
+
+// [START batch_create_nfs_job]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	batch "cloud.google.com/go/batch/apiv1"
+	"cloud.google.com/go/batch/apiv1/batchpb"
+	durationpb "google.golang.org/protobuf/types/known/durationpb"
+)
+
+// Creates and runs a job with status events that mounts a Network File System (NFS).
+func createJobWithNFS(w io.Writer, projectID, region, jobName, remotePath, server, mountPath string) (*batchpb.Job, error) {
+	ctx := context.Background()
+	batchClient, err := batch.NewClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("batchClient error: %w", err)
+	}
+	defer batchClient.Close()
+
+	runn := &batchpb.Runnable{
+		Executable: &batchpb.Runnable_Script_{
+			Script: &batchpb.Runnable_Script{
+				Command: &batchpb.Runnable_Script_Text{
+					Text: "echo Hello world from script 1 for task ${BATCH_TASK_INDEX}",
+				},
+			},
+		},
+	}
+
+	// Define a volume that uses NFS
+	volume := &batchpb.Volume{
+		Source: &batchpb.Volume_Nfs{
+			Nfs: &batchpb.NFS{
+				RemotePath: remotePath,
+				Server:     server,
+			},
+		},
+		MountPath: mountPath,
+	}
+
+	taskSpec := &batchpb.TaskSpec{
+		ComputeResource: &batchpb.ComputeResource{
+			// CpuMilli is milliseconds per cpu-second. This means the task requires 2 whole CPUs.
+			CpuMilli:  2000,
+			MemoryMib: 16,
+		},
+		MaxRunDuration: &durationpb.Duration{
+			Seconds: 3600,
+		},
+		MaxRetryCount: 2,
+		Runnables:     []*batchpb.Runnable{runn},
+		Volumes:       []*batchpb.Volume{volume},
+	}
+
+	taskGroups := []*batchpb.TaskGroup{
+		{
+			TaskCount: 4,
+			TaskSpec:  taskSpec,
+		},
+	}
+
+	// Policies are used to define on what kind of virtual machines the tasks will run on.
+	// In this case, we tell the system to use "e2-standard-4" machine type.
+	// Read more about machine types here: https://cloud.google.com/compute/docs/machine-types
+	allocationPolicy := &batchpb.AllocationPolicy{
+		Instances: []*batchpb.AllocationPolicy_InstancePolicyOrTemplate{{
+			PolicyTemplate: &batchpb.AllocationPolicy_InstancePolicyOrTemplate_Policy{
+				Policy: &batchpb.AllocationPolicy_InstancePolicy{
+					MachineType: "e2-standard-4",
+				},
+			},
+		}},
+	}
+
+	// We use Cloud Logging as it's an out of the box available option
+	logsPolicy := &batchpb.LogsPolicy{
+		Destination: batchpb.LogsPolicy_CLOUD_LOGGING,
+	}
+
+	job := &batchpb.Job{
+		Name:             jobName,
+		TaskGroups:       taskGroups,
+		AllocationPolicy: allocationPolicy,
+		LogsPolicy:       logsPolicy,
+	}
+
+	request := &batchpb.CreateJobRequest{
+		Parent: fmt.Sprintf("projects/%s/locations/%s", projectID, region),
+		JobId:  jobName,
+		Job:    job,
+	}
+
+	created_job, err := batchClient.CreateJob(ctx, request)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create job: %w", err)
+	}
+
+	fmt.Fprintf(w, "Job created: %v\n", created_job)
+	return created_job, nil
+}
+
+// [END batch_create_nfs_job]

--- a/batch/create_with_nfs_test.go
+++ b/batch/create_with_nfs_test.go
@@ -26,8 +26,7 @@ import (
 )
 
 func TestCreateJobWithNFS(t *testing.T) {
-	var r *rand.Rand = rand.New(
-		rand.NewSource(time.Now().UnixNano()))
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	tc := testutil.SystemTest(t)
 	jobName := fmt.Sprintf("test-job-go-%v-%v", time.Now().Format("2006-01-02"), r.Int())
 	region := "us-central1"
@@ -40,7 +39,7 @@ func TestCreateJobWithNFS(t *testing.T) {
 	job, err := createJobWithNFS(buf, tc.ProjectID, region, jobName, nfsPath, nfsIpAddress, mountPath)
 
 	if err != nil {
-		t.Errorf("createJobWithNFS got err: %v", err)
+		t.Fatalf("createJobWithNFS got err: %v", err)
 	}
 	if got := buf.String(); !strings.Contains(got, "Job created") {
 		t.Errorf("createJobWithNFS got %q, expected %q", got, "Job created")

--- a/batch/create_with_nfs_test.go
+++ b/batch/create_with_nfs_test.go
@@ -1,0 +1,57 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snippets
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+)
+
+func TestCreateJobWithNFS(t *testing.T) {
+	var r *rand.Rand = rand.New(
+		rand.NewSource(time.Now().UnixNano()))
+	tc := testutil.SystemTest(t)
+	jobName := fmt.Sprintf("test-job-go-%v-%v", time.Now().Format("2006-01-02"), r.Int())
+	region := "us-central1"
+	nfsPath := "/mnt/nfs"
+	nfsIpAddress := "0.0.0.0"
+	mountPath := "/vol1"
+
+	buf := &bytes.Buffer{}
+
+	job, err := createJobWithNFS(buf, tc.ProjectID, region, jobName, nfsPath, nfsIpAddress, mountPath)
+
+	if err != nil {
+		t.Errorf("createJobWithNFS got err: %v", err)
+	}
+	if got := buf.String(); !strings.Contains(got, "Job created") {
+		t.Errorf("createJobWithNFS got %q, expected %q", got, "Job created")
+	}
+
+	volume := job.GetTaskGroups()[0].GetTaskSpec().GetVolumes()[0]
+	if volume.GetNfs().GetRemotePath() != nfsIpAddress || volume.GetNfs().GetServer() != nfsIpAddress || volume.GetMountPath() != mountPath {
+		t.Errorf("volume wasn't set")
+	}
+
+	if err := deleteJob(buf, tc.ProjectID, region, jobName); err != nil {
+		t.Errorf("deleteJob got err: %v", err)
+	}
+}

--- a/batch/create_with_nfs_test.go
+++ b/batch/create_with_nfs_test.go
@@ -47,7 +47,7 @@ func TestCreateJobWithNFS(t *testing.T) {
 	}
 
 	volume := job.GetTaskGroups()[0].GetTaskSpec().GetVolumes()[0]
-	if volume.GetNfs().GetRemotePath() != nfsIpAddress || volume.GetNfs().GetServer() != nfsIpAddress || volume.GetMountPath() != mountPath {
+	if volume.GetNfs().GetRemotePath() != nfsPath || volume.GetNfs().GetServer() != nfsIpAddress || volume.GetMountPath() != mountPath {
 		t.Errorf("volume wasn't set")
 	}
 


### PR DESCRIPTION
## Description

Samples, which demonstrates how to create batch with custom network and subnetwork. Documentation reference [here](https://cloud.google.com/batch/docs/create-run-job-storage#use-nfs)

## Checklist
- [ ] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [ ] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
