### PR TITLE
chore(secretmanager): add optional argument ttl to createSecret

### DIFF
--- a/secretmanager/create_secret.go
+++ b/secretmanager/create_secret.go
@@ -27,7 +27,7 @@ import (
 // createSecret creates a new secret with the given name. A secret is a logical
 // wrapper around a collection of secret versions. Secret versions hold the
 // actual secret material.
-func createSecret(w io.Writer, parent, id string) error {
+func createSecret(w io.Writer, parent, id string, ttl *secretmanagerpb.Secret_Ttl) (*secretmanagerpb.Secret, error) {
 	// parent := "projects/my-project"
 	// id := "my-secret"
 
@@ -35,7 +35,7 @@ func createSecret(w io.Writer, parent, id string) error {
 	ctx := context.Background()
 	client, err := secretmanager.NewClient(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to create secretmanager client: %w", err)
+		return nil, fmt.Errorf("failed to create secretmanager client: %w", err)
 	}
 	defer client.Close()
 
@@ -49,16 +49,17 @@ func createSecret(w io.Writer, parent, id string) error {
 					Automatic: &secretmanagerpb.Replication_Automatic{},
 				},
 			},
+			Expiration: ttl,
 		},
 	}
 
 	// Call the API.
 	result, err := client.CreateSecret(ctx, req)
 	if err != nil {
-		return fmt.Errorf("failed to create secret: %w", err)
+		return nil, fmt.Errorf("failed to create secret: %w", err)
 	}
 	fmt.Fprintf(w, "Created secret: %s\n", result.Name)
-	return nil
+	return result, nil
 }
 
 // [END secretmanager_create_secret]

--- a/secretmanager/create_secret_ttl.go
+++ b/secretmanager/create_secret_ttl.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/secretmanager/create_secret_ttl.go
+++ b/secretmanager/create_secret_ttl.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,22 +14,24 @@
 
 package secretmanager
 
-// [START secretmanager_create_secret]
+// [START secretmanager_create_secret_with_ttl]
 import (
 	"context"
 	"fmt"
 	"io"
+	"time"
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
-// createSecret creates a new secret with the given name. A secret is a logical
-// wrapper around a collection of secret versions. Secret versions hold the
-// actual secret material.
-func createSecret(w io.Writer, parent, id string) error {
+// createSecretWithTTL creates a new secret with the given name and ttl.
+func createSecretWithTTL(w io.Writer, parent, id string, d time.Duration) error {
 	// parent := "projects/my-project"
 	// id := "my-secret"
+
+	expiration := &secretmanagerpb.Secret_Ttl{Ttl: durationpb.New(d)}
 
 	// Create the client.
 	ctx := context.Background()
@@ -49,6 +51,7 @@ func createSecret(w io.Writer, parent, id string) error {
 					Automatic: &secretmanagerpb.Replication_Automatic{},
 				},
 			},
+			Expiration: expiration,
 		},
 	}
 
@@ -57,8 +60,8 @@ func createSecret(w io.Writer, parent, id string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create secret: %w", err)
 	}
-	fmt.Fprintf(w, "Created secret: %s\n", result.Name)
+	fmt.Fprintf(w, "Created secret with ttl: %s\n", result.Name)
 	return nil
 }
 
-// [END secretmanager_create_secret]
+// [END secretmanager_create_secret_with_ttl]

--- a/secretmanager/go.mod
+++ b/secretmanager/go.mod
@@ -9,6 +9,7 @@ require (
 	google.golang.org/api v0.195.0
 	google.golang.org/genproto v0.0.0-20240827150818-7e3bb234dfed
 	google.golang.org/grpc v1.66.0
+	google.golang.org/protobuf v1.34.2
 )
 
 require (
@@ -41,5 +42,4 @@ require (
 	golang.org/x/time v0.6.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240827150818-7e3bb234dfed // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240827150818-7e3bb234dfed // indirect
-	google.golang.org/protobuf v1.34.2 // indirect
 )

--- a/secretmanager/secretmanager_test.go
+++ b/secretmanager/secretmanager_test.go
@@ -33,7 +33,6 @@ import (
 	"google.golang.org/api/option"
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
-	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 func testLocation(tb testing.TB) string {
@@ -313,7 +312,7 @@ func TestCreateSecret(t *testing.T) {
 	parent := fmt.Sprintf("projects/%s", tc.ProjectID)
 
 	var b bytes.Buffer
-	if _, err := createSecret(&b, parent, secretID, nil); err != nil {
+	if err := createSecret(&b, parent, secretID); err != nil {
 		t.Fatal(err)
 	}
 	defer testCleanupSecret(t, fmt.Sprintf("projects/%s/secrets/%s", tc.ProjectID, secretID))
@@ -326,27 +325,21 @@ func TestCreateSecret(t *testing.T) {
 func TestCreateSecretWithTTL(t *testing.T) {
 	tc := testutil.SystemTest(t)
 
-	secretID := "createSecret"
+	secretID := "createSecretTTL"
 
 	parent := fmt.Sprintf("projects/%s", tc.ProjectID)
 
-	ttl := time.Second * 70
+	duration := time.Second * 70
 
 	var b bytes.Buffer
-	secret, err := createSecret(&b, parent, secretID, &secretmanagerpb.Secret_Ttl{Ttl: durationpb.New(ttl)})
-	if err != nil {
+	if err := createSecretWithTTL(&b, parent, secretID, duration); err != nil {
 		t.Fatal(err)
 	}
 	defer testCleanupSecret(t, fmt.Sprintf("projects/%s/secrets/%s", tc.ProjectID, secretID))
 
-	if got, want := b.String(), "Created secret:"; !strings.Contains(got, want) {
+	if got, want := b.String(), "Created secret with ttl:"; !strings.Contains(got, want) {
 		t.Errorf("createSecretWithTTL: expected %q to contain %q", got, want)
 	}
-
-	if got, want := reflect.TypeOf(secret.Expiration), reflect.TypeOf(&secretmanagerpb.Secret_ExpireTime{}); got != want {
-		t.Errorf("createSecretWithTTL: expected %q to be equal type %q", got, want)
-	}
-
 }
 
 func TestCreateSecretWithLabels(t *testing.T) {


### PR DESCRIPTION
## Description
chore(secretmanager): add optional argument ttl to createSecret and updated tests with/without ttl

Fixes #[b/384052840](http://b/384052840)

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
