### PR TITLE
fix(cloudrun): delete old region tag run_system_package_ubuntu

### DIFF
--- a/run/system_package/Dockerfile
+++ b/run/system_package/Dockerfile
@@ -36,11 +36,9 @@ RUN go build -v -o server
 FROM ubuntu
 
 # [START cloudrun_system_package_ubuntu]
-# [START run_system_package_ubuntu]
 RUN apt-get update -y && apt-get install -y \
   graphviz \
   && apt-get clean
-# [END run_system_package_ubuntu]
 # [END cloudrun_system_package_ubuntu]
 
 # Copy the binary to the production image from the builder stage.


### PR DESCRIPTION
## Description
According to the "deleting sample/region decision tree" decided to delete the region "run_system_package_ubuntu" because it was inner nested to the valid region "cloudrun_system_package_ubuntu"

Fixes [b/347348198](https://b.corp.google.com/issues/347348198)

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
