### PR TITLE
fix(job): delete old region tag histogram_search

### DIFF
--- a/jobs/v3/howto/histogram_search_sample.go
+++ b/jobs/v3/howto/histogram_search_sample.go
@@ -24,7 +24,6 @@ import (
 )
 
 // [START job_histogram_search]
-// [START histogram_search]
 
 // histogramSearch searches for jobs with histogram facets.
 func histogramSearch(w io.Writer, projectID, companyName string) (*talent.SearchJobsResponse, error) {
@@ -84,5 +83,4 @@ func histogramSearch(w io.Writer, projectID, companyName string) (*talent.Search
 	return resp, nil
 }
 
-// [END histogram_search]
 // [END job_histogram_search]


### PR DESCRIPTION
## Description
According to the "deleting sample/region decision tree" decided to delete the region "histogram_search" because it was inner nested to the valid region "job_histogram_search"

Fixes [b/347825492](https://b.corp.google.com/issues/347825492)

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
