### PR TITLE
chore(many): rename Golang to Go

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ The top level directory should be the product the sample is for (e.g.
 Sub-directories can be used to keep different groups of samples for the product
 separate.
 
-The package name should match the directory name, as is standard go practice.
+The package name should match the directory name, as is standard Go practice.
 
 Files should be named after the sample in them (e.g. `hello.go`). No need to
 include the product name or "sample" in the filename.

--- a/appengine/go11x/tasks/handle_task/Dockerfile
+++ b/appengine/go11x/tasks/handle_task/Dockerfile
@@ -1,4 +1,4 @@
-# Use the offical Golang image to create a build artifact.
+# Use the offical Go image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21 as builder

--- a/appengine_flexible/go115_and_earlier/websockets/static/index.html
+++ b/appengine_flexible/go115_and_earlier/websockets/static/index.html
@@ -16,7 +16,7 @@ limitations under the License.
 <!doctype html>
 <html>
   <head>
-    <title>Google App Engine Flexible Environment - Golang Websockets Chat</title>
+    <title>Google App Engine Flexible Environment - Go Websockets Chat</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="utf-8">
     <style>

--- a/appengine_flexible/websockets/static/index.html
+++ b/appengine_flexible/websockets/static/index.html
@@ -16,7 +16,7 @@ limitations under the License.
 <!doctype html>
 <html>
   <head>
-    <title>Google App Engine Flexible Environment - Golang Websockets Chat</title>
+    <title>Google App Engine Flexible Environment - Go Websockets Chat</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="utf-8">
     <style>

--- a/bigtable/helloworld/main.go
+++ b/bigtable/helloworld/main.go
@@ -35,7 +35,7 @@ const (
 	columnName       = "greeting"
 )
 
-var greetings = []string{"Hello World!", "Hello Cloud Bigtable!", "Hello golang!"}
+var greetings = []string{"Hello World!", "Hello Cloud Bigtable!", "Hello Go!"}
 
 // sliceContains reports whether the provided string is present in the given slice of strings.
 func sliceContains(list []string, target string) bool {

--- a/cloudsql/mysql/database-sql/Dockerfile
+++ b/cloudsql/mysql/database-sql/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the offical golang image to create a binary.
+# Use the official go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/cloudsql/mysql/database-sql/Dockerfile
+++ b/cloudsql/mysql/database-sql/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the official go image to create a binary.
+# Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/cloudsql/postgres/database-sql/Dockerfile
+++ b/cloudsql/postgres/database-sql/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the offical golang image to create a binary.
+# Use the official go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/cloudsql/postgres/database-sql/Dockerfile
+++ b/cloudsql/postgres/database-sql/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the official go image to create a binary.
+# Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/cloudsql/sqlserver/database-sql/Dockerfile
+++ b/cloudsql/sqlserver/database-sql/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the offical golang image to create a binary.
+# Use the official go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/cloudsql/sqlserver/database-sql/Dockerfile
+++ b/cloudsql/sqlserver/database-sql/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the official go image to create a binary.
+# Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/eventarc/audit_storage/Dockerfile
+++ b/eventarc/audit_storage/Dockerfile
@@ -14,7 +14,7 @@
 
 # [START eventarc_audit_storage_dockerfile]
 
-# Use the offical golang image to create a binary.
+# Use the official go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/eventarc/audit_storage/Dockerfile
+++ b/eventarc/audit_storage/Dockerfile
@@ -14,7 +14,7 @@
 
 # [START eventarc_audit_storage_dockerfile]
 
-# Use the official go image to create a binary.
+# Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/eventarc/generic/Dockerfile
+++ b/eventarc/generic/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-# Use the official go image to create a binary.
+# Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/eventarc/generic/Dockerfile
+++ b/eventarc/generic/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-# Use the offical golang image to create a binary.
+# Use the official go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/eventarc/pubsub/Dockerfile
+++ b/eventarc/pubsub/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the offical golang image to create a binary.
+# Use the official go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/eventarc/pubsub/Dockerfile
+++ b/eventarc/pubsub/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the official go image to create a binary.
+# Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/getting-started/gopher-run/Dockerfile
+++ b/getting-started/gopher-run/Dockerfile
@@ -1,4 +1,4 @@
-# Use the offical Golang image to create a build artifact.
+# Use the offical Go image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21 as builder

--- a/memorystore/redis/cloud_run_deployment/Dockerfile
+++ b/memorystore/redis/cloud_run_deployment/Dockerfile
@@ -14,7 +14,7 @@
 
 # [START memorystore_cloud_run_dockerfile]
 
-# Use the offical golang image to create a binary.
+# Use the official go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/memorystore/redis/cloud_run_deployment/Dockerfile
+++ b/memorystore/redis/cloud_run_deployment/Dockerfile
@@ -14,7 +14,7 @@
 
 # [START memorystore_cloud_run_dockerfile]
 
-# Use the official go image to create a binary.
+# Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/opentelemetry/instrumentation/app/logger.go
+++ b/opentelemetry/instrumentation/app/logger.go
@@ -36,7 +36,7 @@ type spanContextLogHandler struct {
 // Handle overrides slog.Handler's Handle method. This adds attributes from the
 // span context to the slog.Record.
 func (t *spanContextLogHandler) Handle(ctx context.Context, record slog.Record) error {
-	// Get the SpanContext from the golang Context.
+	// Get the SpanContext from the context.
 	if s := trace.SpanContextFromContext(ctx); s.IsValid() {
 		// Add trace context attributes following Cloud Logging structured log format described
 		// in https://cloud.google.com/logging/docs/structured-logging#special-payload-fields

--- a/run/grpc-ping/Dockerfile
+++ b/run/grpc-ping/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the offical golang image to create a binary.
+# Use the official go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/run/grpc-ping/Dockerfile
+++ b/run/grpc-ping/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the official go image to create a binary.
+# Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/run/grpc-ping/connection.go
+++ b/run/grpc-ping/connection.go
@@ -36,7 +36,7 @@ func NewConn(host string, insecure bool) (*grpc.ClientConn, error) {
 		opts = append(opts, grpc.WithInsecure())
 	} else {
 		// Note: On the Windows platform, use of x509.SystemCertPool() requires
-		// go version 1.18 or higher.
+		// Go version 1.18 or higher.
 		systemRoots, err := x509.SystemCertPool()
 		if err != nil {
 			return nil, err

--- a/run/grpc-server-streaming/Dockerfile
+++ b/run/grpc-server-streaming/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-# Use the official go image to create a binary.
+# Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/run/grpc-server-streaming/Dockerfile
+++ b/run/grpc-server-streaming/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-# Use the offical golang image to create a binary.
+# Use the official go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/run/hello-broken/Dockerfile
+++ b/run/hello-broken/Dockerfile
@@ -14,7 +14,7 @@
 
 # [START cloudrun_broken_dockerfile]
 
-# Use the official go image to create a binary.
+# Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/run/hello-broken/Dockerfile
+++ b/run/hello-broken/Dockerfile
@@ -14,7 +14,7 @@
 
 # [START cloudrun_broken_dockerfile]
 
-# Use the offical golang image to create a binary.
+# Use the official go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/run/helloworld/Dockerfile
+++ b/run/helloworld/Dockerfile
@@ -15,7 +15,7 @@
 # [START cloudrun_helloworld_dockerfile]
 # [START run_helloworld_dockerfile]
 
-# Use the offical golang image to create a binary.
+# Use the official go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/run/helloworld/Dockerfile
+++ b/run/helloworld/Dockerfile
@@ -15,7 +15,7 @@
 # [START cloudrun_helloworld_dockerfile]
 # [START run_helloworld_dockerfile]
 
-# Use the official go image to create a binary.
+# Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/run/image-processing/Dockerfile
+++ b/run/image-processing/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the offical golang image to create a binary.
+# Use the official go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/run/image-processing/Dockerfile
+++ b/run/image-processing/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the official go image to create a binary.
+# Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/run/logging-manual/Dockerfile
+++ b/run/logging-manual/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the offical golang image to create a binary.
+# Use the official go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/run/logging-manual/Dockerfile
+++ b/run/logging-manual/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the official go image to create a binary.
+# Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/run/markdown-preview/editor/Dockerfile
+++ b/run/markdown-preview/editor/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the offical golang image to create a binary.
+# Use the official go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/run/markdown-preview/editor/Dockerfile
+++ b/run/markdown-preview/editor/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the official go image to create a binary.
+# Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/run/markdown-preview/renderer/Dockerfile
+++ b/run/markdown-preview/renderer/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the offical golang image to create a binary.
+# Use the official go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/run/markdown-preview/renderer/Dockerfile
+++ b/run/markdown-preview/renderer/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the official go image to create a binary.
+# Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/run/pubsub/Dockerfile
+++ b/run/pubsub/Dockerfile
@@ -15,7 +15,7 @@
 # [START cloudrun_pubsub_dockerfile]
 # [START run_pubsub_dockerfile]
 
-# Use the offical golang image to create a binary.
+# Use the official go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/run/pubsub/Dockerfile
+++ b/run/pubsub/Dockerfile
@@ -15,7 +15,7 @@
 # [START cloudrun_pubsub_dockerfile]
 # [START run_pubsub_dockerfile]
 
-# Use the official go image to create a binary.
+# Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/run/sigterm-handler/Dockerfile
+++ b/run/sigterm-handler/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the offical golang image to create a binary.
+# Use the official go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/run/sigterm-handler/Dockerfile
+++ b/run/sigterm-handler/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the official go image to create a binary.
+# Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder

--- a/run/system_package/Dockerfile
+++ b/run/system_package/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the offical Golang image to create a build artifact.
+# Use the offical Go image to create a build artifact.
 # https://hub.docker.com/_/golang
 FROM golang:1.21-bookworm as builder
 

--- a/testing/docker/README.md
+++ b/testing/docker/README.md
@@ -13,7 +13,7 @@ these containers.
 
 Go language version and resulting image name are controlled by the cloud build
 substitutions `_GO_VERSION` and `_IMAGE_NAME` respectively. The command below
-will build go 1.21 and push the resulting image to
+will build Go 1.21 and push the resulting image to
 `gcr.io/golang-samples-tests/go121`
 
 ```

--- a/testing/kokoro/configure_cloudsql.bash
+++ b/testing/kokoro/configure_cloudsql.bash
@@ -32,6 +32,6 @@ mkdir /cloudsql && chmod 0777 /cloudsql
 /cloud_sql_proxy -instances="${POSTGRES_INSTANCE}"=tcp:5432,${POSTGRES_INSTANCE} -dir /cloudsql &
 /cloud_sql_proxy -instances="${SQLSERVER_INSTANCE}"=tcp:1433 &
 
-# Give proxies a second to connect before moving on. If future restructuring of Golang's Kokoro
+# Give proxies a second to connect before moving on. If future restructuring of Go's Kokoro
 # test suite ever means this isn't enough time, reordering or increasing the sleep is reasonable.
 sleep 5


### PR DESCRIPTION
## Description

The language's proper name is "Go", not "Golang".

## Checklist
- [x ] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x ] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x ] Please **merge** this PR for me once it is approved
