### PR TITLE
fix(gae): add "gae_datastore" prefix

### DIFF
--- a/docs/appengine/datastore/entities/entities.go
+++ b/docs/appengine/datastore/entities/entities.go
@@ -30,6 +30,7 @@ type T struct{}
 type Address struct{}
 
 func example() {
+	// [START gae_datastore_batch]
 	// [START batch]
 	// A batch put.
 	_, err = datastore.PutMulti(ctx, []*datastore.Key{k1, k2, k3}, []interface{}{e1, e2, e3})
@@ -41,36 +42,44 @@ func example() {
 	// A batch delete.
 	err = datastore.DeleteMulti(ctx, []*datastore.Key{k1, k2, k3})
 	// [END batch]
+	// [END gae_datastore_batch]
 	_ = err
 }
 
 func example2() {
+	// [START gae_datastore_delete]
 	// [START delete]
 	key := datastore.NewKey(ctx, "Employee", "asalieri", 0, nil)
 	err = datastore.Delete(ctx, key)
 	// [END delete]
+	// [END gae_datastore_delete]
 }
 
 func example3() {
+	// [START gae_datastore_get_key]
 	// [START get_key]
 	employeeKey := datastore.NewKey(ctx, "Employee", "asalieri", 0, nil)
 	addressKey := datastore.NewKey(ctx, "Address", "", 1, employeeKey)
 	var addr Address
 	err = datastore.Get(ctx, addressKey, &addr)
 	// [END get_key]
+	// [END gae_datastore_get_key]
 }
 
 func example4() {
+	// [START gae_datastore_key_id]
 	// [START key_id]
 	// Create a key such as Employee:8261.
 	key := datastore.NewKey(ctx, "Employee", "", 0, nil)
 	// This is equivalent:
 	key = datastore.NewIncompleteKey(ctx, "Employee", nil)
 	// [END key_id]
+	// [END gae_datastore_key_id]
 	_ = key
 }
 
 func example5() {
+	// [START gae_datastore_key_name]
 	// [START key_name]
 	// Create a key with a key name "asalieri".
 	key := datastore.NewKey(
@@ -81,10 +90,12 @@ func example5() {
 		nil,        // Parent Key; nil means no parent
 	)
 	// [END key_name]
+	// [END gae_datastore_key_name]
 	_ = key
 }
 
 func example6() {
+	// [START gae_datastore_parent]
 	// [START parent]
 	// Create Employee entity
 	employee := &Employee{ /* ... */ }
@@ -96,10 +107,12 @@ func example6() {
 	addressKey := datastore.NewIncompleteKey(ctx, "Address", employeeKey)
 	_, err = datastore.Put(ctx, addressKey, address)
 	// [END parent]
+	// [END gae_datastore_parent]
 	_ = err
 }
 
 func example7() {
+	// [START gae_datastore_put_with_keyname]
 	// [START put_with_keyname]
 	employee := &Employee{
 		FirstName: "Antonio",
@@ -110,9 +123,11 @@ func example7() {
 	key := datastore.NewKey(ctx, "Employee", "asalieri", 0, nil)
 	_, err = datastore.Put(ctx, key, employee)
 	// [END put_with_keyname]
+	// [END gae_datastore_put_with_keyname]
 }
 
 func example8() {
+	// [START gae_datastore_put_without_keyname]
 	// [START put_without_keyname]
 	employee := &Employee{
 		FirstName: "Antonio",
@@ -123,4 +138,5 @@ func example8() {
 	key := datastore.NewIncompleteKey(ctx, "Employee", nil)
 	_, err = datastore.Put(ctx, key, employee)
 	// [END put_without_keyname]
+	// [END gae_datastore_put_without_keyname]
 }


### PR DESCRIPTION
## Description
Migrate region tags by adding "gae_datastore" prefix in order to associate them with an official GCP product

Fixes
[b/391176362](http://b/391176362)
[b/389106593](http://b/389106593)
[b/391176883](http://b/391176883)
[b/391175192](http://b/391175192)
[b/391176374](http://b/391176374)
[b/391176575](http://b/391176575)
[b/391175195](http://b/391175195)
[b/391176890](http://b/391176890)

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
