### PR TITLE
fix(gae): delete old region taskqueue_host

### DIFF
--- a/docs/appengine/taskqueue/taskqueue.go
+++ b/docs/appengine/taskqueue/taskqueue.go
@@ -61,13 +61,11 @@ func example() {
 	_ = err
 
 	// [START gae_taskqueue_host]
-	// [START taskqueue_host]
 	h := http.Header{}
 	h.Add("Host", "versionHostname")
 	task := taskqueue.Task{
 		Header: h,
 	}
-	// [END taskqueue_host]
 	// [END gae_taskqueue_host]
 	_ = task
 }


### PR DESCRIPTION
## Description
Delete old region tag "taskqueue_host" at docs/appengine/taskqueue/taskqueue.go

Fixes
[b/392110136](http://b/392110136)

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
