### PR TITLE
chore(gae): delete old region tags from indexes.go

### DIFF
--- a/docs/appengine/datastore/indexes/indexes.go
+++ b/docs/appengine/datastore/indexes/indexes.go
@@ -22,17 +22,14 @@ import (
 )
 
 // [START gae_datastore_unindexed_properties]
-// [START unindexed_properties]
 type Person struct {
 	Name string
 	Age  int `datastore:",noindex"`
 }
 
-// [END unindexed_properties]
 // [END gae_datastore_unindexed_properties]
 
 // [START gae_datastore_exploding_index_example_3]
-// [START exploding_index_example_3]
 type Widget struct {
 	X    []int
 	Y    []string
@@ -52,5 +49,4 @@ func f(ctx context.Context) {
 	}
 }
 
-// [END exploding_index_example_3]
 // [END gae_datastore_exploding_index_example_3]


### PR DESCRIPTION
## Description
Delete old region tags
- exploding_index_example_3
- unindexed_properties

Fixes
[b/392128463](http://b/392128463)
[b/389106598](http://b/389106598)

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
