### PR TITLE
fix(cloudrun): delete old region tag run_helloworld_dockerfile

### DIFF
--- a/run/helloworld/Dockerfile
+++ b/run/helloworld/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 # [START cloudrun_helloworld_dockerfile]
-# [START run_helloworld_dockerfile]
 
 # Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
@@ -49,5 +48,4 @@ COPY --from=builder /app/server /app/server
 # Run the web service on container startup.
 CMD ["/app/server"]
 
-# [END run_helloworld_dockerfile]
 # [END cloudrun_helloworld_dockerfile]


### PR DESCRIPTION
## Description
Delete old region tag 'run_helloworld_dockerfile', it seems like a started migration process didn't finish.

Fixes [b/347348196](https://b.corp.google.com/issues/347348196)

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
