### PR TITLE
chore(gae): delete old region tags from projectionqueries.go

### DIFF
--- a/docs/appengine/datastore/projectionqueries/projectionqueries.go
+++ b/docs/appengine/datastore/projectionqueries/projectionqueries.go
@@ -29,16 +29,13 @@ type EventLog struct {
 
 func example() {
 	// [START gae_datastore_using_1]
-	// [START using_1]
 	q := datastore.NewQuery("People").Project("FirstName", "LastName")
-	// [END using_1]
 	// [END gae_datastore_using_1]
 	_ = q
 }
 
 func example2() {
 	// [START gae_datastore_using_2]
-	// [START using_2]
 	q := datastore.NewQuery("EventLog").
 		Project("Title", "ReadPath", "DateWritten").
 		Order("DateWritten")
@@ -55,18 +52,15 @@ func example2() {
 		}
 		log.Infof(ctx, "Log record: %v, %v, %v", l.Title, l.ReadPath, l.DateWritten)
 	}
-	// [END using_2]
 	// [END gae_datastore_using_2]
 }
 
 func example3() {
 	// [START gae_datastore_grouping]
-	// [START grouping]
 	q := datastore.NewQuery("Person").
 		Project("LastName", "Height").Distinct().
 		Filter("Height >", 20).
 		Order("-Height").Order("LastName")
-	// [END grouping]
 	// [END gae_datastore_grouping]
 	_ = q
 
@@ -76,18 +70,14 @@ func example3() {
 	}
 
 	// [START gae_datastore_projections_and_multiple_valued_properties_1]
-	// [START projections_and_multiple_valued_properties_1]
 	entity := Foo{A: []int{1, 1, 2, 3}, B: []string{"x", "y", "x"}}
-	// [END projections_and_multiple_valued_properties_1]
 	// [END gae_datastore_projections_and_multiple_valued_properties_1]
 	_ = entity
 }
 
 func example4() {
 	// [START gae_datastore_projections_and_multiple_valued_properties_2]
-	// [START projections_and_multiple_valued_properties_2]
 	q := datastore.NewQuery("Foo").Project("A", "B").Filter("A <", 3)
-	// [END projections_and_multiple_valued_properties_2]
 	// [END gae_datastore_projections_and_multiple_valued_properties_2]
 	_ = q
 }


### PR DESCRIPTION
## Description
Delete old region tags from docs/appengine/datastore/projectionqueries/projectionqueries.go following the PRs #5108 and #5119

Fixes
[b/392146363](http://b/392146363)
[b/392145933](http://b/392145933)
[b/392146306](http://b/392146306)
[b/391185644](http://b/391185644)
[b/391186679](http://b/391186679)

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
