### PR TITLE
chore(endpoints): remove old region "esp" at endpoints/getting-started/deployment.yaml

### DIFF
--- a/endpoints/getting-started/deployment.yaml
+++ b/endpoints/getting-started/deployment.yaml
@@ -42,7 +42,6 @@ spec:
     spec:
       containers:
       # [START endpoints_esp]
-      # [START esp]
       - name: esp
         image: gcr.io/endpoints-release/endpoints-runtime:1
         args: [
@@ -51,7 +50,6 @@ spec:
           "--service", "SERVICE_NAME",
           "--rollout_strategy", "managed",
         ]
-      # [END esp]
       # [END endpoints_esp]
         ports:
           - containerPort: 8081


### PR DESCRIPTION
## Description
Remove old region "esp". Seems like it's part of an undone migration

Fixes
[b/393614531](https://buganizer.corp.google.com/issues/393614531)

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
