### PR TITLE
chore(cloudrun): delete old region tag "cloudrun_pubusub_dockerfile"

### DIFF
--- a/run/pubsub/Dockerfile
+++ b/run/pubsub/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 # [START cloudrun_pubsub_dockerfile_go]
-# [START cloudrun_pubsub_dockerfile]
 
 # Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
@@ -49,5 +48,4 @@ COPY --from=builder /app/server /server
 # Run the web service on container startup.
 CMD ["/server"]
 
-# [END cloudrun_pubsub_dockerfile]
 # [END cloudrun_pubsub_dockerfile_go]


### PR DESCRIPTION
## Description
Delete old region tag "cloudrun_pubsub_dockerfile" from run/pubsub/Dockerfile

Fixes
b/388068402

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
