### PR TITLE
chore(gae): migrate region tags from docs/appengine/datastore/indexes/index.yaml

### DIFF
--- a/docs/appengine/datastore/indexes/index.yaml
+++ b/docs/appengine/datastore/indexes/index.yaml
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-// [START gae_datastore_exploding_index_2_yaml_go]
 // [START exploding_index_example_2]
 indexes:
 - kind: Widget
@@ -21,9 +20,7 @@ indexes:
   - name: Y
   - name: Date
 // [END exploding_index_example_2]
-// [END gae_datastore_exploding_index_2_yaml_go]
 
-// [START gae_datastore_exploding_index_4_yaml_go]
 // [START exploding_index_example_4]
 indexes:
 - kind: Widget
@@ -35,4 +32,3 @@ indexes:
   - name: Y
   - name: Date
 // [END exploding_index_example_4]
-// [END gae_datastore_exploding_index_4_yaml_go]

--- a/docs/appengine/datastore/indexes/index.yaml
+++ b/docs/appengine/datastore/indexes/index.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+// [START gae_datastore_exploding_index_2_yaml_go]
 // [START exploding_index_example_2]
 indexes:
 - kind: Widget
@@ -20,8 +21,9 @@ indexes:
   - name: Y
   - name: Date
 // [END exploding_index_example_2]
+// [END gae_datastore_exploding_index_2_yaml_go]
 
-
+// [START gae_datastore_exploding_index_4_yaml_go]
 // [START exploding_index_example_4]
 indexes:
 - kind: Widget
@@ -33,4 +35,4 @@ indexes:
   - name: Y
   - name: Date
 // [END exploding_index_example_4]
-
+// [END gae_datastore_exploding_index_4_yaml_go]

--- a/docs/appengine/datastore/indexes/index.yaml
+++ b/docs/appengine/datastore/indexes/index.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+// [START gae_datastore_exploding_index_2_yaml_go]
 // [START exploding_index_example_2]
 indexes:
 - kind: Widget
@@ -20,7 +21,9 @@ indexes:
   - name: Y
   - name: Date
 // [END exploding_index_example_2]
+// [END gae_datastore_exploding_index_2_yaml_go]
 
+// [START gae_datastore_exploding_index_4_yaml_go]
 // [START exploding_index_example_4]
 indexes:
 - kind: Widget
@@ -32,3 +35,4 @@ indexes:
   - name: Y
   - name: Date
 // [END exploding_index_example_4]
+// [END gae_datastore_exploding_index_4_yaml_go]

--- a/docs/appengine/datastore/projectionqueries/projectionqueries.go
+++ b/docs/appengine/datastore/projectionqueries/projectionqueries.go
@@ -29,16 +29,13 @@ type EventLog struct {
 
 func example() {
 	// [START gae_datastore_using_1]
-	// [START using_1]
 	q := datastore.NewQuery("People").Project("FirstName", "LastName")
-	// [END using_1]
 	// [END gae_datastore_using_1]
 	_ = q
 }
 
 func example2() {
 	// [START gae_datastore_using_2]
-	// [START using_2]
 	q := datastore.NewQuery("EventLog").
 		Project("Title", "ReadPath", "DateWritten").
 		Order("DateWritten")
@@ -55,18 +52,15 @@ func example2() {
 		}
 		log.Infof(ctx, "Log record: %v, %v, %v", l.Title, l.ReadPath, l.DateWritten)
 	}
-	// [END using_2]
 	// [END gae_datastore_using_2]
 }
 
 func example3() {
 	// [START gae_datastore_grouping]
-	// [START grouping]
 	q := datastore.NewQuery("Person").
 		Project("LastName", "Height").Distinct().
 		Filter("Height >", 20).
 		Order("-Height").Order("LastName")
-	// [END grouping]
 	// [END gae_datastore_grouping]
 	_ = q
 
@@ -76,18 +70,14 @@ func example3() {
 	}
 
 	// [START gae_datastore_projections_and_multiple_valued_properties_1]
-	// [START projections_and_multiple_valued_properties_1]
 	entity := Foo{A: []int{1, 1, 2, 3}, B: []string{"x", "y", "x"}}
-	// [END projections_and_multiple_valued_properties_1]
 	// [END gae_datastore_projections_and_multiple_valued_properties_1]
 	_ = entity
 }
 
 func example4() {
 	// [START gae_datastore_projections_and_multiple_valued_properties_2]
-	// [START projections_and_multiple_valued_properties_2]
 	q := datastore.NewQuery("Foo").Project("A", "B").Filter("A <", 3)
-	// [END projections_and_multiple_valued_properties_2]
 	// [END gae_datastore_projections_and_multiple_valued_properties_2]
 	_ = q
 }


### PR DESCRIPTION
## Description
Migrate region tags from docs/appengine/datastore/indexes/index.yaml in order to align to pattern "product_regiontag_typeoffile_language"

Fixes
b/394594341
b/394594345

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
