### PR TITLE
chore(profiler): delete unused region tag "hotmid"

### DIFF
--- a/profiler/hotmid/main.go
+++ b/profiler/hotmid/main.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START hotmid]
-
 // Sample hotmid is an application that simulates multiple calls to a library
 // function made via different call paths. Each of these calls is not
 // particularly expensive (and so does not stand out on the flame graph). But
@@ -125,5 +123,3 @@ func main() {
 
 	run()
 }
-
-// [END hotmid]


### PR DESCRIPTION
## Description
Delete unused region tag "hotapp" at profiler/hotapp/main.go

Internal:
b/347348734

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD]
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] Please **merge** this PR for me once it is approved
