### PR TITLE
chore(gae): migrate region "import" from ../helloworld/helloworld.go

### DIFF
--- a/appengine/go11x/helloworld/helloworld.go
+++ b/appengine/go11x/helloworld/helloworld.go
@@ -17,6 +17,7 @@
 // Sample helloworld is an App Engine app.
 package main
 
+// [START gae_go111_import]
 // [START import]
 import (
 	"fmt"
@@ -26,6 +27,8 @@ import (
 )
 
 // [END import]
+// [END gae_go111_import]
+
 // [START main_func]
 
 func main() {


### PR DESCRIPTION
## Description
Migrate region "import" to "gae_go111_import" from appengine/go11x/helloworld/helloworld.go 

Internal b/395128421

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] Please **merge** this PR for me once it is approved
