### PR TITLE
chore(endpoints): delete old region tag "swagger"

### DIFF
--- a/endpoints/getting-started/openapi-appengine.yaml
+++ b/endpoints/getting-started/openapi-appengine.yaml
@@ -13,14 +13,12 @@
 # limitations under the License.
 
 # [START endpoints_swagger_appengine_yaml_go]
-# [START swagger]
 swagger: "2.0"
 info:
   description: "A simple Google Cloud Endpoints API example."
   title: "Endpoints Example"
   version: "1.0.0"
 host: "YOUR-PROJECT-ID.appspot.com"
-# [END swagger]
 # [END endpoints_swagger_appengine_yaml_go]
 consumes:
 - "application/json"


### PR DESCRIPTION
## Description
Delete old region "swagger" as the final step for migrating a region tag

Fixes
b/393186351

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] Please **merge** this PR for me once it is approved
