### PR TITLE
feat(cloud-sql): add lazy refresh for csql: mysql, sql server and postgres

### DIFF
--- a/cloudsql/mysql/database-sql/connect_connector.go
+++ b/cloudsql/mysql/database-sql/connect_connector.go
@@ -47,9 +47,9 @@ func connectWithConnector() (*sql.DB, error) {
 		usePrivate             = os.Getenv("PRIVATE_IP")
 	)
 
-	// Setting the refresh strategy to LAZY
-	// to refresh the tokens when they are needed, rather than on a regular interval.
-	// This is recommended for serverless environments to
+	// WithLazyRefresh() Option is used to perform refresh
+	// when needed, rather than on a scheduled interval.
+	// this is recommended for serverless environments to
 	// avoid background refreshes from throttling CPU.
 	d, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithLazyRefresh())
 	if err != nil {

--- a/cloudsql/mysql/database-sql/connect_connector.go
+++ b/cloudsql/mysql/database-sql/connect_connector.go
@@ -48,7 +48,7 @@ func connectWithConnector() (*sql.DB, error) {
 	)
 
 	// WithLazyRefresh() Option is used to perform refresh
-	// When needed, rather than on a scheduled interval.
+	// when needed, rather than on a scheduled interval.
 	// This is recommended for serverless environments to
 	// avoid background refreshes from throttling CPU.
 	d, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithLazyRefresh())

--- a/cloudsql/mysql/database-sql/connect_connector.go
+++ b/cloudsql/mysql/database-sql/connect_connector.go
@@ -48,10 +48,13 @@ func connectWithConnector() (*sql.DB, error) {
 	)
 
 	// WithLazyRefresh() Option is used to perform refresh
-	// when needed, rather than on a scheduled interval.
-	// this is recommended for serverless environments to
+	// When needed, rather than on a scheduled interval.
+	// This is recommended for serverless environments to
 	// avoid background refreshes from throttling CPU.
-	d, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithLazyRefresh())
+	d, err := cloudsqlconn.NewDialer(
+		context.Background(),
+		cloudsqlconn.WithLazyRefresh()
+	)
 	if err != nil {
 		return nil, fmt.Errorf("cloudsqlconn.NewDialer: %w", err)
 	}

--- a/cloudsql/mysql/database-sql/connect_connector.go
+++ b/cloudsql/mysql/database-sql/connect_connector.go
@@ -47,6 +47,10 @@ func connectWithConnector() (*sql.DB, error) {
 		usePrivate             = os.Getenv("PRIVATE_IP")
 	)
 
+	// setting the refresh strategy to LAZY
+    // to refresh the tokens when they are needed, rather than on a regular interval
+    // this is recommended for serverless environments to 
+    // avoid background refreshes from throttling CPU.
 	d, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithLazyRefresh())
 	if err != nil {
 		return nil, fmt.Errorf("cloudsqlconn.NewDialer: %w", err)

--- a/cloudsql/mysql/database-sql/connect_connector.go
+++ b/cloudsql/mysql/database-sql/connect_connector.go
@@ -47,9 +47,9 @@ func connectWithConnector() (*sql.DB, error) {
 		usePrivate             = os.Getenv("PRIVATE_IP")
 	)
 
-	// setting the refresh strategy to LAZY
-	// to refresh the tokens when they are needed, rather than on a regular interval
-	// this is recommended for serverless environments to
+	// Setting the refresh strategy to LAZY
+	// to refresh the tokens when they are needed, rather than on a regular interval.
+	// This is recommended for serverless environments to
 	// avoid background refreshes from throttling CPU.
 	d, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithLazyRefresh())
 	if err != nil {

--- a/cloudsql/mysql/database-sql/connect_connector.go
+++ b/cloudsql/mysql/database-sql/connect_connector.go
@@ -51,10 +51,7 @@ func connectWithConnector() (*sql.DB, error) {
 	// When needed, rather than on a scheduled interval.
 	// This is recommended for serverless environments to
 	// avoid background refreshes from throttling CPU.
-	d, err := cloudsqlconn.NewDialer(
-		context.Background(),
-		cloudsqlconn.WithLazyRefresh()
-	)
+	d, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithLazyRefresh())
 	if err != nil {
 		return nil, fmt.Errorf("cloudsqlconn.NewDialer: %w", err)
 	}

--- a/cloudsql/mysql/database-sql/connect_connector.go
+++ b/cloudsql/mysql/database-sql/connect_connector.go
@@ -47,7 +47,7 @@ func connectWithConnector() (*sql.DB, error) {
 		usePrivate             = os.Getenv("PRIVATE_IP")
 	)
 
-	d, err := cloudsqlconn.NewDialer(context.Background())
+	d, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithLazyRefresh())
 	if err != nil {
 		return nil, fmt.Errorf("cloudsqlconn.NewDialer: %w", err)
 	}

--- a/cloudsql/mysql/database-sql/connect_connector.go
+++ b/cloudsql/mysql/database-sql/connect_connector.go
@@ -48,9 +48,9 @@ func connectWithConnector() (*sql.DB, error) {
 	)
 
 	// setting the refresh strategy to LAZY
-    // to refresh the tokens when they are needed, rather than on a regular interval
-    // this is recommended for serverless environments to 
-    // avoid background refreshes from throttling CPU.
+	// to refresh the tokens when they are needed, rather than on a regular interval
+	// this is recommended for serverless environments to
+	// avoid background refreshes from throttling CPU.
 	d, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithLazyRefresh())
 	if err != nil {
 		return nil, fmt.Errorf("cloudsqlconn.NewDialer: %w", err)

--- a/cloudsql/mysql/database-sql/connect_connector_iam_authn.go
+++ b/cloudsql/mysql/database-sql/connect_connector_iam_authn.go
@@ -48,9 +48,9 @@ func connectWithConnectorIAMAuthN() (*sql.DB, error) {
 	)
 
 	// setting the refresh strategy to LAZY
-    // to refresh the tokens when they are needed, rather than on a regular interval
-    // this is recommended for serverless environments to 
-    // avoid background refreshes from throttling CPU.
+	// to refresh the tokens when they are needed, rather than on a regular interval
+	// this is recommended for serverless environments to
+	// avoid background refreshes from throttling CPU.
 	d, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithIAMAuthN(), cloudsqlconn.WithLazyRefresh())
 	if err != nil {
 		return nil, fmt.Errorf("cloudsqlconn.NewDialer: %w", err)

--- a/cloudsql/mysql/database-sql/connect_connector_iam_authn.go
+++ b/cloudsql/mysql/database-sql/connect_connector_iam_authn.go
@@ -47,9 +47,9 @@ func connectWithConnectorIAMAuthN() (*sql.DB, error) {
 		usePrivate             = os.Getenv("PRIVATE_IP")
 	)
 
-	// Setting the refresh strategy to LAZY
-	// to refresh the tokens when they are needed, rather than on a regular interval.
-	// This is recommended for serverless environments to
+	// WithLazyRefresh() Option is used to perform refresh
+	// when needed, rather than on a scheduled interval.
+	// this is recommended for serverless environments to
 	// avoid background refreshes from throttling CPU.
 	d, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithIAMAuthN(), cloudsqlconn.WithLazyRefresh())
 	if err != nil {

--- a/cloudsql/mysql/database-sql/connect_connector_iam_authn.go
+++ b/cloudsql/mysql/database-sql/connect_connector_iam_authn.go
@@ -48,10 +48,14 @@ func connectWithConnectorIAMAuthN() (*sql.DB, error) {
 	)
 
 	// WithLazyRefresh() Option is used to perform refresh
-	// when needed, rather than on a scheduled interval.
-	// this is recommended for serverless environments to
+	// When needed, rather than on a scheduled interval.
+	// This is recommended for serverless environments to
 	// avoid background refreshes from throttling CPU.
-	d, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithIAMAuthN(), cloudsqlconn.WithLazyRefresh())
+	d, err := cloudsqlconn.NewDialer(
+		context.Background(),
+		cloudsqlconn.WithIAMAuthN(),
+		cloudsqlconn.WithLazyRefresh()
+	)
 	if err != nil {
 		return nil, fmt.Errorf("cloudsqlconn.NewDialer: %w", err)
 	}

--- a/cloudsql/mysql/database-sql/connect_connector_iam_authn.go
+++ b/cloudsql/mysql/database-sql/connect_connector_iam_authn.go
@@ -47,9 +47,9 @@ func connectWithConnectorIAMAuthN() (*sql.DB, error) {
 		usePrivate             = os.Getenv("PRIVATE_IP")
 	)
 
-	// setting the refresh strategy to LAZY
-	// to refresh the tokens when they are needed, rather than on a regular interval
-	// this is recommended for serverless environments to
+	// Setting the refresh strategy to LAZY
+	// to refresh the tokens when they are needed, rather than on a regular interval.
+	// This is recommended for serverless environments to
 	// avoid background refreshes from throttling CPU.
 	d, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithIAMAuthN(), cloudsqlconn.WithLazyRefresh())
 	if err != nil {

--- a/cloudsql/mysql/database-sql/connect_connector_iam_authn.go
+++ b/cloudsql/mysql/database-sql/connect_connector_iam_authn.go
@@ -47,6 +47,10 @@ func connectWithConnectorIAMAuthN() (*sql.DB, error) {
 		usePrivate             = os.Getenv("PRIVATE_IP")
 	)
 
+	// setting the refresh strategy to LAZY
+    // to refresh the tokens when they are needed, rather than on a regular interval
+    // this is recommended for serverless environments to 
+    // avoid background refreshes from throttling CPU.
 	d, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithIAMAuthN(), cloudsqlconn.WithLazyRefresh())
 	if err != nil {
 		return nil, fmt.Errorf("cloudsqlconn.NewDialer: %w", err)

--- a/cloudsql/mysql/database-sql/connect_connector_iam_authn.go
+++ b/cloudsql/mysql/database-sql/connect_connector_iam_authn.go
@@ -54,7 +54,7 @@ func connectWithConnectorIAMAuthN() (*sql.DB, error) {
 	d, err := cloudsqlconn.NewDialer(
 		context.Background(),
 		cloudsqlconn.WithIAMAuthN(),
-		cloudsqlconn.WithLazyRefresh()
+		cloudsqlconn.WithLazyRefresh(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("cloudsqlconn.NewDialer: %w", err)

--- a/cloudsql/mysql/database-sql/connect_connector_iam_authn.go
+++ b/cloudsql/mysql/database-sql/connect_connector_iam_authn.go
@@ -48,7 +48,7 @@ func connectWithConnectorIAMAuthN() (*sql.DB, error) {
 	)
 
 	// WithLazyRefresh() Option is used to perform refresh
-	// When needed, rather than on a scheduled interval.
+	// when needed, rather than on a scheduled interval.
 	// This is recommended for serverless environments to
 	// avoid background refreshes from throttling CPU.
 	d, err := cloudsqlconn.NewDialer(

--- a/cloudsql/mysql/database-sql/connect_connector_iam_authn.go
+++ b/cloudsql/mysql/database-sql/connect_connector_iam_authn.go
@@ -47,7 +47,7 @@ func connectWithConnectorIAMAuthN() (*sql.DB, error) {
 		usePrivate             = os.Getenv("PRIVATE_IP")
 	)
 
-	d, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithIAMAuthN())
+	d, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithIAMAuthN(), cloudsqlconn.WithLazyRefresh())
 	if err != nil {
 		return nil, fmt.Errorf("cloudsqlconn.NewDialer: %w", err)
 	}

--- a/cloudsql/postgres/database-sql/connect_connector.go
+++ b/cloudsql/postgres/database-sql/connect_connector.go
@@ -57,6 +57,7 @@ func connectWithConnector() (*sql.DB, error) {
 	if usePrivate != "" {
 		opts = append(opts, cloudsqlconn.WithDefaultDialOptions(cloudsqlconn.WithPrivateIP()))
 	}
+	opts = append(opts, cloudsqlconn.WithLazyRefresh())
 	d, err := cloudsqlconn.NewDialer(context.Background(), opts...)
 	if err != nil {
 		return nil, err

--- a/cloudsql/postgres/database-sql/connect_connector.go
+++ b/cloudsql/postgres/database-sql/connect_connector.go
@@ -58,9 +58,9 @@ func connectWithConnector() (*sql.DB, error) {
 		opts = append(opts, cloudsqlconn.WithDefaultDialOptions(cloudsqlconn.WithPrivateIP()))
 	}
 	// setting the refresh strategy to LAZY
-    // to refresh the tokens when they are needed, rather than on a regular interval
-    // this is recommended for serverless environments to 
-    // avoid background refreshes from throttling CPU.
+	// to refresh the tokens when they are needed, rather than on a regular interval
+	// this is recommended for serverless environments to
+	// avoid background refreshes from throttling CPU.
 	opts = append(opts, cloudsqlconn.WithLazyRefresh())
 	d, err := cloudsqlconn.NewDialer(context.Background(), opts...)
 	if err != nil {

--- a/cloudsql/postgres/database-sql/connect_connector.go
+++ b/cloudsql/postgres/database-sql/connect_connector.go
@@ -57,6 +57,10 @@ func connectWithConnector() (*sql.DB, error) {
 	if usePrivate != "" {
 		opts = append(opts, cloudsqlconn.WithDefaultDialOptions(cloudsqlconn.WithPrivateIP()))
 	}
+	// setting the refresh strategy to LAZY
+    // to refresh the tokens when they are needed, rather than on a regular interval
+    // this is recommended for serverless environments to 
+    // avoid background refreshes from throttling CPU.
 	opts = append(opts, cloudsqlconn.WithLazyRefresh())
 	d, err := cloudsqlconn.NewDialer(context.Background(), opts...)
 	if err != nil {

--- a/cloudsql/postgres/database-sql/connect_connector.go
+++ b/cloudsql/postgres/database-sql/connect_connector.go
@@ -58,8 +58,8 @@ func connectWithConnector() (*sql.DB, error) {
 		opts = append(opts, cloudsqlconn.WithDefaultDialOptions(cloudsqlconn.WithPrivateIP()))
 	}
 	// WithLazyRefresh() Option is used to perform refresh
-	// when needed, rather than on a scheduled interval.
-	// this is recommended for serverless environments to
+	// When needed, rather than on a scheduled interval.
+	// This is recommended for serverless environments to
 	// avoid background refreshes from throttling CPU.
 	opts = append(opts, cloudsqlconn.WithLazyRefresh())
 	d, err := cloudsqlconn.NewDialer(context.Background(), opts...)

--- a/cloudsql/postgres/database-sql/connect_connector.go
+++ b/cloudsql/postgres/database-sql/connect_connector.go
@@ -58,7 +58,7 @@ func connectWithConnector() (*sql.DB, error) {
 		opts = append(opts, cloudsqlconn.WithDefaultDialOptions(cloudsqlconn.WithPrivateIP()))
 	}
 	// WithLazyRefresh() Option is used to perform refresh
-	// When needed, rather than on a scheduled interval.
+	// when needed, rather than on a scheduled interval.
 	// This is recommended for serverless environments to
 	// avoid background refreshes from throttling CPU.
 	opts = append(opts, cloudsqlconn.WithLazyRefresh())

--- a/cloudsql/postgres/database-sql/connect_connector.go
+++ b/cloudsql/postgres/database-sql/connect_connector.go
@@ -57,9 +57,9 @@ func connectWithConnector() (*sql.DB, error) {
 	if usePrivate != "" {
 		opts = append(opts, cloudsqlconn.WithDefaultDialOptions(cloudsqlconn.WithPrivateIP()))
 	}
-	// Setting the refresh strategy to LAZY
-	// to refresh the tokens when they are needed, rather than on a regular interval.
-	// This is recommended for serverless environments to
+	// WithLazyRefresh() Option is used to perform refresh
+	// when needed, rather than on a scheduled interval.
+	// this is recommended for serverless environments to
 	// avoid background refreshes from throttling CPU.
 	opts = append(opts, cloudsqlconn.WithLazyRefresh())
 	d, err := cloudsqlconn.NewDialer(context.Background(), opts...)

--- a/cloudsql/postgres/database-sql/connect_connector.go
+++ b/cloudsql/postgres/database-sql/connect_connector.go
@@ -57,9 +57,9 @@ func connectWithConnector() (*sql.DB, error) {
 	if usePrivate != "" {
 		opts = append(opts, cloudsqlconn.WithDefaultDialOptions(cloudsqlconn.WithPrivateIP()))
 	}
-	// setting the refresh strategy to LAZY
-	// to refresh the tokens when they are needed, rather than on a regular interval
-	// this is recommended for serverless environments to
+	// Setting the refresh strategy to LAZY
+	// to refresh the tokens when they are needed, rather than on a regular interval.
+	// This is recommended for serverless environments to
 	// avoid background refreshes from throttling CPU.
 	opts = append(opts, cloudsqlconn.WithLazyRefresh())
 	d, err := cloudsqlconn.NewDialer(context.Background(), opts...)

--- a/cloudsql/postgres/database-sql/connect_connector_iam_authn.go
+++ b/cloudsql/postgres/database-sql/connect_connector_iam_authn.go
@@ -48,9 +48,9 @@ func connectWithConnectorIAMAuthN() (*sql.DB, error) {
 	)
 
 	// setting the refresh strategy to LAZY
-    // to refresh the tokens when they are needed, rather than on a regular interval
-    // this is recommended for serverless environments to 
-    // avoid background refreshes from throttling CPU.
+	// to refresh the tokens when they are needed, rather than on a regular interval
+	// this is recommended for serverless environments to
+	// avoid background refreshes from throttling CPU.
 	d, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithIAMAuthN(), cloudsqlconn.WithLazyRefresh())
 	if err != nil {
 		return nil, fmt.Errorf("cloudsqlconn.NewDialer: %w", err)

--- a/cloudsql/postgres/database-sql/connect_connector_iam_authn.go
+++ b/cloudsql/postgres/database-sql/connect_connector_iam_authn.go
@@ -47,9 +47,9 @@ func connectWithConnectorIAMAuthN() (*sql.DB, error) {
 		usePrivate             = os.Getenv("PRIVATE_IP")
 	)
 
-	// Setting the refresh strategy to LAZY
-	// to refresh the tokens when they are needed, rather than on a regular interval.
-	// This is recommended for serverless environments to
+	// WithLazyRefresh() Option is used to perform refresh
+	// when needed, rather than on a scheduled interval.
+	// this is recommended for serverless environments to
 	// avoid background refreshes from throttling CPU.
 	d, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithIAMAuthN(), cloudsqlconn.WithLazyRefresh())
 	if err != nil {

--- a/cloudsql/postgres/database-sql/connect_connector_iam_authn.go
+++ b/cloudsql/postgres/database-sql/connect_connector_iam_authn.go
@@ -48,10 +48,14 @@ func connectWithConnectorIAMAuthN() (*sql.DB, error) {
 	)
 
 	// WithLazyRefresh() Option is used to perform refresh
-	// when needed, rather than on a scheduled interval.
-	// this is recommended for serverless environments to
+	// When needed, rather than on a scheduled interval.
+	// This is recommended for serverless environments to
 	// avoid background refreshes from throttling CPU.
-	d, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithIAMAuthN(), cloudsqlconn.WithLazyRefresh())
+	d, err := cloudsqlconn.NewDialer(
+		context.Background(),
+		cloudsqlconn.WithIAMAuthN(),
+		cloudsqlconn.WithLazyRefresh()
+	)
 	if err != nil {
 		return nil, fmt.Errorf("cloudsqlconn.NewDialer: %w", err)
 	}

--- a/cloudsql/postgres/database-sql/connect_connector_iam_authn.go
+++ b/cloudsql/postgres/database-sql/connect_connector_iam_authn.go
@@ -47,9 +47,9 @@ func connectWithConnectorIAMAuthN() (*sql.DB, error) {
 		usePrivate             = os.Getenv("PRIVATE_IP")
 	)
 
-	// setting the refresh strategy to LAZY
-	// to refresh the tokens when they are needed, rather than on a regular interval
-	// this is recommended for serverless environments to
+	// Setting the refresh strategy to LAZY
+	// to refresh the tokens when they are needed, rather than on a regular interval.
+	// This is recommended for serverless environments to
 	// avoid background refreshes from throttling CPU.
 	d, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithIAMAuthN(), cloudsqlconn.WithLazyRefresh())
 	if err != nil {

--- a/cloudsql/postgres/database-sql/connect_connector_iam_authn.go
+++ b/cloudsql/postgres/database-sql/connect_connector_iam_authn.go
@@ -47,6 +47,10 @@ func connectWithConnectorIAMAuthN() (*sql.DB, error) {
 		usePrivate             = os.Getenv("PRIVATE_IP")
 	)
 
+	// setting the refresh strategy to LAZY
+    // to refresh the tokens when they are needed, rather than on a regular interval
+    // this is recommended for serverless environments to 
+    // avoid background refreshes from throttling CPU.
 	d, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithIAMAuthN(), cloudsqlconn.WithLazyRefresh())
 	if err != nil {
 		return nil, fmt.Errorf("cloudsqlconn.NewDialer: %w", err)

--- a/cloudsql/postgres/database-sql/connect_connector_iam_authn.go
+++ b/cloudsql/postgres/database-sql/connect_connector_iam_authn.go
@@ -54,7 +54,7 @@ func connectWithConnectorIAMAuthN() (*sql.DB, error) {
 	d, err := cloudsqlconn.NewDialer(
 		context.Background(),
 		cloudsqlconn.WithIAMAuthN(),
-		cloudsqlconn.WithLazyRefresh()
+		cloudsqlconn.WithLazyRefresh(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("cloudsqlconn.NewDialer: %w", err)

--- a/cloudsql/postgres/database-sql/connect_connector_iam_authn.go
+++ b/cloudsql/postgres/database-sql/connect_connector_iam_authn.go
@@ -48,7 +48,7 @@ func connectWithConnectorIAMAuthN() (*sql.DB, error) {
 	)
 
 	// WithLazyRefresh() Option is used to perform refresh
-	// When needed, rather than on a scheduled interval.
+	// when needed, rather than on a scheduled interval.
 	// This is recommended for serverless environments to
 	// avoid background refreshes from throttling CPU.
 	d, err := cloudsqlconn.NewDialer(

--- a/cloudsql/postgres/database-sql/connect_connector_iam_authn.go
+++ b/cloudsql/postgres/database-sql/connect_connector_iam_authn.go
@@ -47,7 +47,7 @@ func connectWithConnectorIAMAuthN() (*sql.DB, error) {
 		usePrivate             = os.Getenv("PRIVATE_IP")
 	)
 
-	d, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithIAMAuthN())
+	d, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithIAMAuthN(), cloudsqlconn.WithLazyRefresh())
 	if err != nil {
 		return nil, fmt.Errorf("cloudsqlconn.NewDialer: %w", err)
 	}

--- a/cloudsql/sqlserver/database-sql/connect_connector.go
+++ b/cloudsql/sqlserver/database-sql/connect_connector.go
@@ -71,10 +71,7 @@ func connectWithConnector() (*sql.DB, error) {
 	// When needed, rather than on a scheduled interval.
 	// This is recommended for serverless environments to
 	// avoid background refreshes from throttling CPU.
-	dialer, err := cloudsqlconn.NewDialer(
-		context.Background(),
-		cloudsqlconn.WithLazyRefresh()
-	)
+	dialer, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithLazyRefresh())
 	if err != nil {
 		return nil, fmt.Errorf("cloudsqlconn.NewDailer: %w", err)
 	}

--- a/cloudsql/sqlserver/database-sql/connect_connector.go
+++ b/cloudsql/sqlserver/database-sql/connect_connector.go
@@ -68,7 +68,7 @@ func connectWithConnector() (*sql.DB, error) {
 		return nil, fmt.Errorf("mssql.NewConnector: %w", err)
 	}
 	// WithLazyRefresh() Option is used to perform refresh
-	// When needed, rather than on a scheduled interval.
+	// when needed, rather than on a scheduled interval.
 	// This is recommended for serverless environments to
 	// avoid background refreshes from throttling CPU.
 	dialer, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithLazyRefresh())

--- a/cloudsql/sqlserver/database-sql/connect_connector.go
+++ b/cloudsql/sqlserver/database-sql/connect_connector.go
@@ -67,7 +67,7 @@ func connectWithConnector() (*sql.DB, error) {
 	if err != nil {
 		return nil, fmt.Errorf("mssql.NewConnector: %w", err)
 	}
-	dialer, err := cloudsqlconn.NewDialer(context.Background())
+	dialer, err := cloudsqlconn.NewDialer(context.Background(),cloudsqlconn.WithLazyRefresh())
 	if err != nil {
 		return nil, fmt.Errorf("cloudsqlconn.NewDailer: %w", err)
 	}

--- a/cloudsql/sqlserver/database-sql/connect_connector.go
+++ b/cloudsql/sqlserver/database-sql/connect_connector.go
@@ -67,6 +67,10 @@ func connectWithConnector() (*sql.DB, error) {
 	if err != nil {
 		return nil, fmt.Errorf("mssql.NewConnector: %w", err)
 	}
+	// WithLazyRefresh() Option is used to perform refresh
+	// when needed, rather than on a scheduled interval.
+	// this is recommended for serverless environments to
+	// avoid background refreshes from throttling CPU.
 	dialer, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithLazyRefresh())
 	if err != nil {
 		return nil, fmt.Errorf("cloudsqlconn.NewDailer: %w", err)

--- a/cloudsql/sqlserver/database-sql/connect_connector.go
+++ b/cloudsql/sqlserver/database-sql/connect_connector.go
@@ -68,10 +68,13 @@ func connectWithConnector() (*sql.DB, error) {
 		return nil, fmt.Errorf("mssql.NewConnector: %w", err)
 	}
 	// WithLazyRefresh() Option is used to perform refresh
-	// when needed, rather than on a scheduled interval.
-	// this is recommended for serverless environments to
+	// When needed, rather than on a scheduled interval.
+	// This is recommended for serverless environments to
 	// avoid background refreshes from throttling CPU.
-	dialer, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithLazyRefresh())
+	dialer, err := cloudsqlconn.NewDialer(
+		context.Background(),
+		cloudsqlconn.WithLazyRefresh()
+	)
 	if err != nil {
 		return nil, fmt.Errorf("cloudsqlconn.NewDailer: %w", err)
 	}

--- a/cloudsql/sqlserver/database-sql/connect_connector.go
+++ b/cloudsql/sqlserver/database-sql/connect_connector.go
@@ -67,7 +67,7 @@ func connectWithConnector() (*sql.DB, error) {
 	if err != nil {
 		return nil, fmt.Errorf("mssql.NewConnector: %w", err)
 	}
-	dialer, err := cloudsqlconn.NewDialer(context.Background(),cloudsqlconn.WithLazyRefresh())
+	dialer, err := cloudsqlconn.NewDialer(context.Background(), cloudsqlconn.WithLazyRefresh())
 	if err != nil {
 		return nil, fmt.Errorf("cloudsqlconn.NewDailer: %w", err)
 	}


### PR DESCRIPTION
Enabled lazy refresh for the Go Cloud SQL connector (Postgres, MySQL, and SQL Server).
