### PR TITLE
chore(gae): delete old region "import" from ../helloworld/helloworld.go

### DIFF
--- a/appengine/go11x/helloworld/helloworld.go
+++ b/appengine/go11x/helloworld/helloworld.go
@@ -18,7 +18,6 @@
 package main
 
 // [START gae_go111_import]
-// [START import]
 import (
 	"fmt"
 	"log"
@@ -26,7 +25,6 @@ import (
 	"os"
 )
 
-// [END import]
 // [END gae_go111_import]
 
 // [START main_func]


### PR DESCRIPTION
## Description
Delete old region "import" from appengine/go11x/helloworld/helloworld.go 

Internal b/395128421

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] Please **merge** this PR for me once it is approved
