### PR TITLE
chore: try heterogenous Go versions

### DIFF
--- a/go.work
+++ b/go.work
@@ -94,6 +94,7 @@ use (
 	./healthcare
 	./iam
 	./iap
+	./internal/canary
 	./internal/cloudrunci/testingapp
 	./internal/gomodversiontest
 	./internal/managedkafka

--- a/internal/canary/canary.go
+++ b/internal/canary/canary.go
@@ -1,0 +1,29 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package canary
+
+import (
+	"fmt"
+	"io"
+	"slices"
+)
+
+func doCanaryTesting(w io.Writer) {
+	fruits := []string{"apple", "banana", "cherry"}
+
+	// slices.All() uses an iterator, which is a Go 1.23 feature.
+	for i, v := range slices.All(fruits) {
+		fmt.Fprintln(w, i, ":", v)
+	}
+}

--- a/internal/canary/canary_test.go
+++ b/internal/canary/canary_test.go
@@ -1,0 +1,31 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package canary
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestCanary(t *testing.T) {
+
+	var buf bytes.Buffer
+	doCanaryTesting(&buf)
+
+	got := buf.String()
+	want := "0 : apple\n1 : banana\n2 : cherry\n"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/internal/canary/go.mod
+++ b/internal/canary/go.mod
@@ -1,0 +1,5 @@
+module github.com/GoogleCloudPlatform/golang-samples/internal/canary
+
+toolchain go1.23.4
+
+go 1.23.4

--- a/internal/cloudrunci/testingapp/Dockerfile
+++ b/internal/cloudrunci/testingapp/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21 as builder
+FROM golang:1.22 as builder
 WORKDIR /app
 COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o server


### PR DESCRIPTION
This PR attempts to demonstrate how to support different sub packages in the repo that have different minimum supported versions.

The "canary" package has a minimum support version of 1.23, due to its use of iterators (introduced in 1.23). It also declares its toolchain, which might allow for some flexibility when building on Go 1.22.x. We shall see if this approach is sufficient for our CI/CD.