### PR TITLE
fix(language): delete unused region tag "language_imports"

### DIFF
--- a/language/analyze/analyze.go
+++ b/language/analyze/analyze.go
@@ -23,12 +23,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/golang/protobuf/proto"
+	"google.golang.org/protobuf/proto"
 
-	// [START language_imports]
 	language "cloud.google.com/go/language/apiv1"
 	"cloud.google.com/go/language/apiv1/languagepb"
-	// [END language_imports]
 )
 
 func main() {
@@ -148,5 +146,11 @@ func printResp(v proto.Message, err error) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	proto.MarshalText(os.Stdout, v)
+
+	out, err := proto.Marshal(v)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Fprint(os.Stdout, out)
 }

--- a/language/go.mod
+++ b/language/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 require (
 	cloud.google.com/go/language v1.14.3
 	github.com/GoogleCloudPlatform/golang-samples v0.0.0-20240724083556-7f760db013b7
-	github.com/golang/protobuf v1.5.4
+	google.golang.org/protobuf v1.36.3
 )
 
 require (
@@ -54,5 +54,4 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20250115164207-1a7da9e5054f // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f // indirect
 	google.golang.org/grpc v1.69.4 // indirect
-	google.golang.org/protobuf v1.36.3 // indirect
 )


### PR DESCRIPTION
## Description
- Delete unused region tag "language_imports" 
- Update deprecated library "github.com/golang/protobuf/proto"" to recommended "google.golang.org/protobuf/proto"

Fixes Internal b/397199209

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] Please **merge** this PR for me once it is approved
