### PR TITLE
chore(vision): delete unused region tag "init"

### DIFF
--- a/vision/label/label.go
+++ b/vision/label/label.go
@@ -28,7 +28,7 @@ import (
 
 // findLabels gets labels from the Vision API for an image at the given file path.
 func findLabels(file string) ([]string, error) {
-	// [START init]
+
 	ctx := context.Background()
 
 	// Create the client.
@@ -37,7 +37,6 @@ func findLabels(file string) ([]string, error) {
 		return nil, err
 	}
 	defer client.Close()
-	// [END init]
 
 	// [START request]
 	// Open the file.


### PR DESCRIPTION
## Description
Delete unused region tag "init" from vision/label/label.go

Fixes Internal b/397960375

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [X] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [X] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [X] Please **merge** this PR for me once it is approved
