### PR TITLE
fix(gae): delete old region tags from helloworld

### DIFF
--- a/appengine/go11x/helloworld/helloworld.go
+++ b/appengine/go11x/helloworld/helloworld.go
@@ -28,13 +28,11 @@ import (
 // [END gae_go111_import]
 
 // [START gae_go111_main_func]
-// [START main_func]
 
 func main() {
 	http.HandleFunc("/", indexHandler)
 
 	// [START gae_go111_setting_port]
-	// [START setting_port]
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"
@@ -45,15 +43,12 @@ func main() {
 	if err := http.ListenAndServe(":"+port, nil); err != nil {
 		log.Fatal(err)
 	}
-	// [END setting_port]
 	// [END gae_go111_setting_port]
 }
 
-// [END main_func]
 // [END gae_go111_main_func]
 
 // [START gae_go111_indexHandler]
-// [START indexHandler]
 
 // indexHandler responds to requests with our greeting.
 func indexHandler(w http.ResponseWriter, r *http.Request) {
@@ -64,6 +59,5 @@ func indexHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, "Hello, World!")
 }
 
-// [END indexHandler]
 // [END gae_go111_indexHandler]
 // [END gae_go111_app]


### PR DESCRIPTION
## Description
Following the PR #5161, this one deletes the old regions

Fixes Internal:
- b/397700944 
- b/397694570 
- b/397700064 

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] Please **merge** this PR for me once it is approved
