### PR TITLE
chore(tts): delete old region texttospeech_audio_profile

### DIFF
--- a/texttospeech/synthesize_speech/audio_profile.go
+++ b/texttospeech/synthesize_speech/audio_profile.go
@@ -16,7 +16,6 @@
 package snippets
 
 // [START tts_synthesize_text_audio_profile]
-// [START texttospeech_audio_profile]
 
 import (
 	"fmt"
@@ -67,5 +66,4 @@ func audioProfile(w io.Writer, text string, outputFile string) error {
 	return nil
 }
 
-// [END texttospeech_audio_profile]
 // [END tts_synthesize_text_audio_profile]


### PR DESCRIPTION
## Description
- End of migration of tag "texttospeech_audio_profile" in order to create consistency between the other langauges and associate it with an official GCP product

Part of PR #5185

Fixes Internal b/399175687

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [X] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [X] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [X] Please **merge** this PR for me once it is approved
