### PR TITLE
chore(endpoints): delete old region tag "endpoints_esp"

### DIFF
--- a/endpoints/getting-started/deployment.yaml
+++ b/endpoints/getting-started/deployment.yaml
@@ -42,7 +42,6 @@ spec:
     spec:
       containers:
       # [START endpoints_esp_yaml_go]
-      # [START endpoints_esp]
       - name: esp
         image: gcr.io/endpoints-release/endpoints-runtime:1
         args: [
@@ -51,7 +50,6 @@ spec:
           "--service", "SERVICE_NAME",
           "--rollout_strategy", "managed",
         ]
-      # [END endpoints_esp]
       # [END endpoints_esp_yaml_go]
         ports:
           - containerPort: 8081


### PR DESCRIPTION
## Description
Delete old region tag "endpoints_esp".

Follow-up of #5213

Fixes Internal b/393613845

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [X] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [X] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [X] Please **merge** this PR for me once it is approved
