### PR TITLE
chore(cloudrun): delete old region cloudrun_broken_dockerfile

### DIFF
--- a/run/hello-broken/Dockerfile
+++ b/run/hello-broken/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 # [START cloudrun_broken_dockerfile_go]
-# [START cloudrun_broken_dockerfile]
 
 # Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
@@ -49,5 +48,4 @@ COPY --from=builder /app/server /server
 # Run the web service on container startup.
 CMD ["/server"]
 
-# [END cloudrun_broken_dockerfile]
 # [END cloudrun_broken_dockerfile_go]


### PR DESCRIPTION
## Description
Delete old region "cloudrun_broken_dockerfile", last part of migration from PR #5215

Fixes Internal b/393125543

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [X] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [X] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [X] Please **merge** this PR for me once it is approved
