### PR TITLE
chore(cloudrun): migrate region tag "cloudrun_imageproc_dockerfile_imagemagick"

### DIFF
--- a/run/image-processing/Dockerfile
+++ b/run/image-processing/Dockerfile
@@ -36,6 +36,7 @@ RUN CGO_ENABLED=0 go build -v -o server
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3
 
+# [START cloudrun_imageproc_dockerfile_go]
 # [START cloudrun_imageproc_dockerfile_imagemagick]
 
 # Install Imagemagick into the container image.
@@ -44,6 +45,7 @@ FROM alpine:3
 RUN apk add --no-cache imagemagick
 
 # [END cloudrun_imageproc_dockerfile_imagemagick]
+# [END cloudrun_imageproc_dockerfile_go]
 
 # Install certificates for secure communication with network services.
 # For production containers, a single RUN statement should install all system packages.


### PR DESCRIPTION
## Description
Start migrating region tag "cloudrun_imageproc_dockerfile_imagemagick" to "cloudrun_imageproc_dockerfile_go" in order to align with pattern "product_regiontag_typeoffile_language" when dealing with file whom type is different from the language's context.

Fixes Internal b/393178651

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [X] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [X] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [X] Please **merge** this PR for me once it is approved
