### PR TITLE
chore(cloudrun): delete old region tag "cloudrun_system_package_ubuntu"

### DIFF
--- a/run/system_package/Dockerfile
+++ b/run/system_package/Dockerfile
@@ -36,11 +36,9 @@ RUN go build -v -o server
 FROM ubuntu
 
 # [START cloudrun_system_package_ubuntu_dockerfile_go]
-# [START cloudrun_system_package_ubuntu]
 RUN apt-get update -y && apt-get install -y \
   graphviz \
   && apt-get clean
-# [END cloudrun_system_package_ubuntu]
 # [END cloudrun_system_package_ubuntu_dockerfile_go]
 
 # Copy the binary to the production image from the builder stage.


### PR DESCRIPTION
## Description
Last step of migrating the region tag "cloudrun_system_package_ubuntu" to "cloudrun_system_package_ubuntu_dockerfile_go" to align with the pattern "product_region_typeoffile_language" for files with different types than the language context.

Following PR #5214 

Fixes Internal b/393126836

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [X] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [X] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [X] Please **merge** this PR for me once it is approved
