### PR TITLE
fix(cloudrun): remove unnecessary comment

### DIFF
--- a/run/pubsub/main.go
+++ b/run/pubsub/main.go
@@ -44,10 +44,8 @@ func main() {
 
 // [START cloudrun_pubsub_handler]
 
-// PubSubMessage is the payload of a Pub/Sub event.
-// See the documentation for more details:
-// https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage
-type PubSubMessage struct {
+// PubSubPayload is the payload of a Pub/Sub event.
+type PubSubPayload struct {
 	Message struct {
 		Data []byte `json:"data,omitempty"`
 		ID   string `json:"id"`
@@ -57,7 +55,7 @@ type PubSubMessage struct {
 
 // HelloPubSub receives and processes a Pub/Sub push message.
 func HelloPubSub(w http.ResponseWriter, r *http.Request) {
-	var m PubSubMessage
+	var m PubSubPayload
 	body, err := io.ReadAll(r.Body)
 	defer r.Body.Close()
 	if err != nil {


### PR DESCRIPTION
## Description
Remove the comment line that may confuse the expected payload from a PubSubMessage, and rename the PubSubMessage struct to PubSubPayload to better reflect its purpose.

Fixes b/327536079

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [X] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [X] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [X] Please **merge** this PR for me once it is approved
