### PR TITLE
chore(cloudrun): rename new region tag cloudrun_imageproc_imagemagick_dockerfile_go

### DIFF
--- a/run/image-processing/Dockerfile
+++ b/run/image-processing/Dockerfile
@@ -36,7 +36,7 @@ RUN CGO_ENABLED=0 go build -v -o server
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3
 
-# [START cloudrun_imageproc_dockerfile_imagemagick_go]
+# [START cloudrun_imageproc_imagemagick_dockerfile_go]
 # [START cloudrun_imageproc_dockerfile_imagemagick]
 
 # Install Imagemagick into the container image.
@@ -45,7 +45,7 @@ FROM alpine:3
 RUN apk add --no-cache imagemagick
 
 # [END cloudrun_imageproc_dockerfile_imagemagick]
-# [END cloudrun_imageproc_dockerfile_imagemagick_go]
+# [END cloudrun_imageproc_imagemagick_dockerfile_go]
 
 # Install certificates for secure communication with network services.
 # For production containers, a single RUN statement should install all system packages.

--- a/run/image-processing/Dockerfile
+++ b/run/image-processing/Dockerfile
@@ -36,7 +36,7 @@ RUN CGO_ENABLED=0 go build -v -o server
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3
 
-# [START cloudrun_imageproc_dockerfile_go]
+# [START cloudrun_imageproc_dockerfile_imagemagick_go]
 # [START cloudrun_imageproc_dockerfile_imagemagick]
 
 # Install Imagemagick into the container image.
@@ -45,7 +45,7 @@ FROM alpine:3
 RUN apk add --no-cache imagemagick
 
 # [END cloudrun_imageproc_dockerfile_imagemagick]
-# [END cloudrun_imageproc_dockerfile_go]
+# [END cloudrun_imageproc_dockerfile_imagemagick_go]
 
 # Install certificates for secure communication with network services.
 # For production containers, a single RUN statement should install all system packages.


### PR DESCRIPTION
## Description
Rename region tag in order to follow the pattern "product_regiontag_typeoffile_language".

Fixes b/393178651

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [X] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [X] Please **merge** this PR for me once it is approved
