### PR TITLE
fix(cloudrun): remove old region cloudrun_imageproc_dockerfile_imagemagick

### DIFF
--- a/run/image-processing/Dockerfile
+++ b/run/image-processing/Dockerfile
@@ -37,14 +37,12 @@ RUN CGO_ENABLED=0 go build -v -o server
 FROM alpine:3
 
 # [START cloudrun_imageproc_imagemagick_dockerfile_go]
-# [START cloudrun_imageproc_dockerfile_imagemagick]
 
 # Install Imagemagick into the container image.
 # For more on system packages review the system packages tutorial.
 # https://cloud.google.com/run/docs/tutorials/system-packages#dockerfile
 RUN apk add --no-cache imagemagick
 
-# [END cloudrun_imageproc_dockerfile_imagemagick]
 # [END cloudrun_imageproc_imagemagick_dockerfile_go]
 
 # Install certificates for secure communication with network services.


### PR DESCRIPTION
## Description
Remove old region "cloudrun_imageproc_dockerfile_imagemagick".

Fixes b/393178651

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [X] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [X] Please **merge** this PR for me once it is approved
