### PR TITLE
Revert "chore(all): update module github.com/aws/aws-sdk-go to v1.55.7"

### DIFF
--- a/storage/go.mod
+++ b/storage/go.mod
@@ -7,7 +7,7 @@ require (
 	cloud.google.com/go/pubsub v1.47.0
 	cloud.google.com/go/storage v1.51.0
 	github.com/GoogleCloudPlatform/golang-samples v0.0.0-20240724083556-7f760db013b7
-	github.com/aws/aws-sdk-go v1.55.7
+	github.com/aws/aws-sdk-go v1.55.5
 	github.com/googleapis/gax-go/v2 v2.14.1
 	google.golang.org/api v0.224.0
 	google.golang.org/genproto v0.0.0-20250303144028-a0af3efb3deb

--- a/storagetransfer/go.mod
+++ b/storagetransfer/go.mod
@@ -10,7 +10,7 @@ require (
 	cloud.google.com/go/storagetransfer v1.12.1
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.6.1
 	github.com/GoogleCloudPlatform/golang-samples v0.0.0-20240724083556-7f760db013b7
-	github.com/aws/aws-sdk-go v1.55.7
+	github.com/aws/aws-sdk-go v1.55.5
 	google.golang.org/genproto v0.0.0-20250115164207-1a7da9e5054f
 	google.golang.org/protobuf v1.36.3
 )


### PR DESCRIPTION
Reverts GoogleCloudPlatform/golang-samples#5310

The linter doesn't like this update for some reason?