### PR TITLE
feat(bigtable): Add samples for deletes using streaming and batching

### DIFF
--- a/bigtable/deletes/delete_streaming_batching.go
+++ b/bigtable/deletes/delete_streaming_batching.go
@@ -1,0 +1,81 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package writes
+
+// [START bigtable_streaming_and_batching_asyncio]
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/bigtable"
+)
+
+func streamingAndBatching(w io.Writer, projectID, instanceID string, tableName string) error {
+	// projectID := "my-project-id"
+	// instanceID := "my-instance-id"
+	// tableName := "mobile-time-series"
+
+	ctx := context.Background()
+	client, err := bigtable.NewClient(ctx, projectID, instanceID)
+	if err != nil {
+		return fmt.Errorf("bigtable.NewClient: %w", err)
+	}
+	defer client.Close()
+	tbl := client.Open(tableName)
+
+	// Slices to hold the row keys and the corresponding mutations.
+	var rowKeys []string
+	var mutations []*bigtable.Mutation
+
+	// Read all rows from the table.
+	err = tbl.ReadRows(ctx, bigtable.InfiniteRange(""), func(row bigtable.Row) bool {
+		// For each row, create a mutation to delete the specified cell.
+		mut := bigtable.NewMutation()
+		mut.DeleteCellsInColumn("cell_plan", "data_plan_01gb")
+
+		// Append the row key and mutation to the slices.
+		rowKeys = append(rowKeys, row.Key())
+		mutations = append(mutations, mut)
+
+		// Continue processing rows.
+		return true
+	})
+	if err != nil {
+		return fmt.Errorf("tbl.ReadRows: %w", err)
+	}
+
+	// If there are mutations to apply, apply them in a single bulk request.
+	if len(mutations) > 0 {
+		// ApplyBulk returns a slice of errors, one for each mutation.
+		if errs, err := tbl.ApplyBulk(ctx, rowKeys, mutations); err != nil {
+			return fmt.Errorf("tbl.ApplyBulk: %w", err)
+		} else if errs != nil {
+			// Log any individual errors that occurred during the bulk operation.
+			for _, err := range errs {
+				if err != nil {
+					fmt.Fprintf(w, "Error applying mutation: %v", err)
+				}
+			}
+			return fmt.Errorf("encountered %d errors during bulk mutation", len(errs))
+		}
+	}
+
+	fmt.Fprintf(w, "Successfully deleted cells from all rows")
+	return nil
+}
+
+// [END bigtable_streaming_and_batching_asyncio]

--- a/bigtable/deletes/delete_streaming_batching_test.go
+++ b/bigtable/deletes/delete_streaming_batching_test.go
@@ -1,0 +1,118 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package writes
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/bigtable"
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestStreamingAndBatching(t *testing.T) {
+	ctx := context.Background()
+	project := os.Getenv("GOLANG_SAMPLES_BIGTABLE_PROJECT")
+	instance := os.Getenv("GOLANG_SAMPLES_BIGTABLE_INSTANCE")
+	if project == "" || instance == "" {
+		t.Skip("Skipping bigtable integration test. Set GOLANG_SAMPLES_BIGTABLE_PROJECT and GOLANG_SAMPLES_BIGTABLE_INSTANCE.")
+	}
+
+	// Create client
+	adminClient, err := bigtable.NewAdminClient(ctx, project, instance)
+	if err != nil {
+		t.Fatalf("bigtable.NewAdminClient: %v", err)
+	}
+
+	// Create table
+	tableName := "mobile-time-series-" + uuid.New().String()[:8]
+	if err := adminClient.DeleteTable(ctx, tableName); err != nil && status.Code(err) != codes.NotFound {
+		t.Fatalf("adminClient.DeleteTable(%q): %v", tableName, err)
+	}
+	testutil.Retry(t, 10, 10*time.Second, func(r *testutil.R) {
+		if err := adminClient.CreateTable(ctx, tableName); err != nil {
+			if status.Code(err) == codes.AlreadyExists {
+				adminClient.DeleteTable(ctx, tableName)
+				time.Sleep(5 * time.Second)
+			}
+			r.Errorf("Could not create table %s: %v", tableName, err)
+		}
+	})
+	if t.Failed() {
+		return
+	}
+	defer adminClient.DeleteTable(ctx, tableName)
+
+	// Create column family
+	columnFamilyName := "cell_plan"
+	if err := adminClient.CreateColumnFamily(ctx, tableName, columnFamilyName); err != nil {
+		t.Fatalf("CreateColumnFamily(%s): %v", columnFamilyName, err)
+	}
+
+	// Write test data
+	client, err := bigtable.NewClient(ctx, project, instance)
+	if err != nil {
+		t.Fatalf("bigtable.NewClient: %v", err)
+	}
+	defer client.Close()
+	tbl := client.Open(tableName)
+	rowKeys := []string{"phone#4c410523#20190501", "phone#5c10102#20190501"}
+	muts := make([]*bigtable.Mutation, len(rowKeys))
+	for i := range rowKeys {
+		mut := bigtable.NewMutation()
+		mut.Set(columnFamilyName, "data_plan_01gb", 0, []byte("true"))
+		mut.Set(columnFamilyName, "data_plan_05gb", 0, []byte("true"))
+		muts[i] = mut
+	}
+	if _, err := tbl.ApplyBulk(ctx, rowKeys, muts); err != nil {
+		t.Fatalf("tbl.ApplyBulk: %v", err)
+	}
+
+	// Run the function
+	buf := new(bytes.Buffer)
+	if err := streamingAndBatching(buf, project, instance, tableName); err != nil {
+		t.Errorf("streamingAndBatching failed: %v", err)
+	}
+
+	// Verify the output message
+	if got, want := buf.String(), "Successfully deleted cells from all rows"; !strings.Contains(got, want) {
+		t.Errorf("streamingAndBatching output got %q, want substring %q", got, want)
+	}
+
+	// Verify that the cells were deleted
+	for _, rowKey := range rowKeys {
+		row, err := tbl.ReadRow(ctx, rowKey)
+		if err != nil {
+			t.Fatalf("tbl.ReadRow(%q): %v", rowKey, err)
+		}
+		if _, ok := row[columnFamilyName]; !ok {
+			t.Errorf("row %q has no column family %q", rowKey, columnFamilyName)
+			continue
+		}
+		for _, item := range row[columnFamilyName] {
+			if item.Column == fmt.Sprintf("%s:data_plan_01gb", columnFamilyName) {
+				t.Errorf("row %q still has cell %s:data_plan_01gb", rowKey, columnFamilyName)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Description

Fixes b/417638724

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
