### PR TITLE
feat(pubsub): add v2 subscription samples

### DIFF
--- a/pubsub/subscriptions/add_users.go
+++ b/pubsub/subscriptions/add_users.go
@@ -18,13 +18,13 @@ package subscriptions
 import (
 	"context"
 	"fmt"
+	"io"
 
-	"cloud.google.com/go/iam"
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/iam/apiv1/iampb"
+	"cloud.google.com/go/pubsub/v2"
 )
 
-// addUsers adds all IAM users to a subscription.
-func addUsers(projectID, subID string) error {
+func addUsersToSubscription(w io.Writer, projectID, subID string) error {
 	// projectID := "my-project-id"
 	// subID := "my-sub"
 	ctx := context.Background()
@@ -34,21 +34,31 @@ func addUsers(projectID, subID string) error {
 	}
 	defer client.Close()
 
-	sub := client.Subscription(subID)
-	policy, err := sub.IAM().Policy(ctx)
+	subName := fmt.Sprintf("projects/%s/subscriptions/%s", projectID, subID)
+	req := &iampb.GetIamPolicyRequest{
+		Resource: subName,
+	}
+	policy, err := client.SubscriptionAdminClient.GetIamPolicy(ctx, req)
 	if err != nil {
-		return fmt.Errorf("err getting IAM Policy: %w", err)
+		return fmt.Errorf("error calling GetIamPolicy: %w", err)
 	}
-	// Other valid prefixes are "serviceAccount:", "user:"
-	// See the documentation for more values.
-	policy.Add(iam.AllUsers, iam.Viewer)
-	policy.Add("group:cloud-logs@google.com", iam.Editor)
-	if err := sub.IAM().SetPolicy(ctx, policy); err != nil {
-		return fmt.Errorf("SetPolicy: %w", err)
+	b := &iampb.Binding{
+		Role: "roles/editor",
+		// Other valid prefixes are "serviceAccount:", "user:"
+		// See the documentation for more values.
+		Members: []string{"group:cloud-logs@google.com"},
 	}
-	// NOTE: It may be necessary to retry this operation if IAM policies are
-	// being modified concurrently. SetPolicy will return an error if the policy
-	// was modified since it was retrieved.
+	policy.Bindings = append(policy.Bindings, b)
+
+	setRequest := &iampb.SetIamPolicyRequest{
+		Resource: subName,
+		Policy:   policy,
+	}
+	_, err = client.SubscriptionAdminClient.SetIamPolicy(ctx, setRequest)
+	if err != nil {
+		return fmt.Errorf("error calling SetIamPolicy: %w", err)
+	}
+	fmt.Fprintln(w, "Added roles to subscription.")
 	return nil
 }
 

--- a/pubsub/subscriptions/async_pull.go
+++ b/pubsub/subscriptions/async_pull.go
@@ -23,7 +23,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
 )
 
 func pullMsgs(w io.Writer, projectID, subID string) error {
@@ -36,7 +36,7 @@ func pullMsgs(w io.Writer, projectID, subID string) error {
 	}
 	defer client.Close()
 
-	sub := client.Subscription(subID)
+	sub := client.Subscriber(subID)
 
 	// Receive messages for 10 seconds, which simplifies testing.
 	// Comment this out in production, since `Receive` should

--- a/pubsub/subscriptions/async_pull_custom_attributes.go
+++ b/pubsub/subscriptions/async_pull_custom_attributes.go
@@ -21,7 +21,7 @@ import (
 	"io"
 	"time"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
 )
 
 func pullMsgsCustomAttributes(w io.Writer, projectID, subID string) error {
@@ -34,7 +34,7 @@ func pullMsgsCustomAttributes(w io.Writer, projectID, subID string) error {
 	}
 	defer client.Close()
 
-	sub := client.Subscription(subID)
+	sub := client.Subscriber(subID)
 
 	// Receive messages for 10 seconds, which simplifies testing.
 	// Comment this out in production, since `Receive` should

--- a/pubsub/subscriptions/create.go
+++ b/pubsub/subscriptions/create.go
@@ -19,15 +19,15 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"time"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
+	"cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
 )
 
-func create(w io.Writer, projectID, subID string, topic *pubsub.Topic) error {
+func create(w io.Writer, projectID, topic, subscription string) error {
 	// projectID := "my-project-id"
-	// subID := "my-sub"
-	// topic of type https://godoc.org/cloud.google.com/go/pubsub#Topic
+	// topic := "projects/my-project-id/topics/my-topic"
+	// subscription := "projects/my-project/subscriptions/my-sub"
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)
 	if err != nil {
@@ -35,9 +35,9 @@ func create(w io.Writer, projectID, subID string, topic *pubsub.Topic) error {
 	}
 	defer client.Close()
 
-	sub, err := client.CreateSubscription(ctx, subID, pubsub.SubscriptionConfig{
-		Topic:       topic,
-		AckDeadline: 20 * time.Second,
+	sub, err := client.SubscriptionAdminClient.CreateSubscription(ctx, &pubsubpb.Subscription{
+		Name:  subscription,
+		Topic: topic,
 	})
 	if err != nil {
 		return fmt.Errorf("CreateSubscription: %w", err)

--- a/pubsub/subscriptions/create_bigquery_subscription.go
+++ b/pubsub/subscriptions/create_bigquery_subscription.go
@@ -20,14 +20,15 @@ import (
 	"fmt"
 	"io"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
+	"cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
 )
 
 // createBigQuerySubscription creates a Pub/Sub subscription that exports messages to BigQuery.
-func createBigQuerySubscription(w io.Writer, projectID, subID string, topic *pubsub.Topic, table string) error {
-	// projectID := "my-project-id"
-	// subID := "my-sub"
-	// topic of type https://godoc.org/cloud.google.com/go/pubsub#Topic
+func createBigQuerySubscription(w io.Writer, projectID, topic, subscription, table string) error {
+	// projectID := "my-project"
+	// topic := "projects/my-project-id/topics/my-topic"
+	// subscription := "projects/my-project/subscriptions/my-sub"
 	// table := "my-project-id.dataset_id.table_id"
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)
@@ -36,15 +37,16 @@ func createBigQuerySubscription(w io.Writer, projectID, subID string, topic *pub
 	}
 	defer client.Close()
 
-	sub, err := client.CreateSubscription(ctx, subID, pubsub.SubscriptionConfig{
+	sub, err := client.SubscriptionAdminClient.CreateSubscription(ctx, &pubsubpb.Subscription{
+		Name:  subscription,
 		Topic: topic,
-		BigQueryConfig: pubsub.BigQueryConfig{
+		BigqueryConfig: &pubsubpb.BigQueryConfig{
 			Table:         table,
 			WriteMetadata: true,
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("client.CreateSubscription: %w", err)
+		return fmt.Errorf("failed to create subscription: %w", err)
 	}
 	fmt.Fprintf(w, "Created BigQuery subscription: %v\n", sub)
 

--- a/pubsub/subscriptions/create_exactly_once_delivery.go
+++ b/pubsub/subscriptions/create_exactly_once_delivery.go
@@ -20,13 +20,14 @@ import (
 	"fmt"
 	"io"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
+	"cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
 )
 
-func createSubscriptionWithExactlyOnceDelivery(w io.Writer, projectID, subID string, topic *pubsub.Topic) error {
+func createSubscriptionWithExactlyOnceDelivery(w io.Writer, projectID, topic, subscription string) error {
 	// projectID := "my-project-id"
-	// subID := "my-sub"
-	// topic of type https://godoc.org/cloud.google.com/go/pubsub#Topic
+	// topic := "projects/my-project-id/topics/my-topic"
+	// subscription := "projects/my-project/subscriptions/my-sub"
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)
 	if err != nil {
@@ -34,12 +35,12 @@ func createSubscriptionWithExactlyOnceDelivery(w io.Writer, projectID, subID str
 	}
 	defer client.Close()
 
-	sub, err := client.CreateSubscription(ctx, subID, pubsub.SubscriptionConfig{
-		Topic:                     topic,
-		EnableExactlyOnceDelivery: true,
+	sub, err := client.SubscriptionAdminClient.CreateSubscription(ctx, &pubsubpb.Subscription{
+		Name:  subscription,
+		Topic: topic, EnableExactlyOnceDelivery: true,
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create exactly once sub: %w", err)
 	}
 	fmt.Fprintf(w, "Created a subscription with exactly once delivery enabled: %v\n", sub)
 	return nil

--- a/pubsub/subscriptions/create_filter.go
+++ b/pubsub/subscriptions/create_filter.go
@@ -20,15 +20,16 @@ import (
 	"fmt"
 	"io"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
+	"cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
 )
 
-func createWithFilter(w io.Writer, projectID, subID, filter string, topic *pubsub.Topic) error {
+func createWithFilter(w io.Writer, projectID, topic, subscription, filter string) error {
 	// Receive messages with attribute key "author" and value "unknown".
 	// projectID := "my-project-id"
-	// subID := "my-sub"
+	// topic := "projects/my-project-id/topics/my-topic"
+	// subscription := "projects/my-project/subscriptions/my-sub"
 	// filter := "attributes.author=\"unknown\""
-	// topic of type https://godoc.org/cloud.google.com/go/pubsub#Topic
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)
 	if err != nil {
@@ -36,7 +37,8 @@ func createWithFilter(w io.Writer, projectID, subID, filter string, topic *pubsu
 	}
 	defer client.Close()
 
-	sub, err := client.CreateSubscription(ctx, subID, pubsub.SubscriptionConfig{
+	sub, err := client.SubscriptionAdminClient.CreateSubscription(ctx, &pubsubpb.Subscription{
+		Name:   subscription,
 		Topic:  topic,
 		Filter: filter,
 	})

--- a/pubsub/subscriptions/create_ordering.go
+++ b/pubsub/subscriptions/create_ordering.go
@@ -19,15 +19,15 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"time"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
+	"cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
 )
 
-func createWithOrdering(w io.Writer, projectID, subID string, topic *pubsub.Topic) error {
+func createWithOrdering(w io.Writer, projectID, topic, subscription string) error {
 	// projectID := "my-project-id"
-	// subID := "my-sub"
-	// topic of type https://godoc.org/cloud.google.com/go/pubsub#Topic
+	// topic := "projects/my-project-id/topics/my-topic"
+	// subscription := "projects/my-project/subscriptions/my-sub"
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)
 	if err != nil {
@@ -36,9 +36,9 @@ func createWithOrdering(w io.Writer, projectID, subID string, topic *pubsub.Topi
 	defer client.Close()
 
 	// Message ordering can only be set when creating a subscription.
-	sub, err := client.CreateSubscription(ctx, subID, pubsub.SubscriptionConfig{
+	sub, err := client.SubscriptionAdminClient.CreateSubscription(ctx, &pubsubpb.Subscription{
+		Name:                  subscription,
 		Topic:                 topic,
-		AckDeadline:           20 * time.Second,
 		EnableMessageOrdering: true,
 	})
 	if err != nil {

--- a/pubsub/subscriptions/dead_letter_create.go
+++ b/pubsub/subscriptions/dead_letter_create.go
@@ -19,17 +19,17 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"time"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
+	"cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
 )
 
 // createSubWithDeadLetter creates a subscription with a dead letter policy.
-func createSubWithDeadLetter(w io.Writer, projectID, subID string, topicID string, fullyQualifiedDeadLetterTopic string) error {
+func createSubWithDeadLetter(w io.Writer, projectID, topic, subscription, fullyQualifiedDeadLetterTopic string) error {
 	// projectID := "my-project-id"
-	// subID := "my-sub"
-	// topicID := "my-topic"
-	// fullyQualifiedDeadLetterTopic := "projects/my-project/topics/my-dead-letter-topic"
+	// topic := "projects/my-project-id/topics/my-topic"
+	// subscription := "projects/my-project-id/subscriptions/my-sub"
+	// fullyQualifiedDeadLetterTopic := "projects/my-project-id/topics/my-dead-letter-topic"
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)
 	if err != nil {
@@ -37,22 +37,18 @@ func createSubWithDeadLetter(w io.Writer, projectID, subID string, topicID strin
 	}
 	defer client.Close()
 
-	topic := client.Topic(topicID)
-
-	subConfig := pubsub.SubscriptionConfig{
-		Topic:       topic,
-		AckDeadline: 20 * time.Second,
-		DeadLetterPolicy: &pubsub.DeadLetterPolicy{
+	_, err = client.SubscriptionAdminClient.CreateSubscription(ctx, &pubsubpb.Subscription{
+		Name:  subscription,
+		Topic: topic,
+		DeadLetterPolicy: &pubsubpb.DeadLetterPolicy{
 			DeadLetterTopic:     fullyQualifiedDeadLetterTopic,
 			MaxDeliveryAttempts: 10,
 		},
-	}
-
-	sub, err := client.CreateSubscription(ctx, subID, subConfig)
+	})
 	if err != nil {
 		return fmt.Errorf("CreateSubscription: %w", err)
 	}
-	fmt.Fprintf(w, "Created subscription (%s) with dead letter topic (%s)\n", sub.String(), fullyQualifiedDeadLetterTopic)
+	fmt.Fprintf(w, "Created subscription with dead letter topic: (%s)\n", fullyQualifiedDeadLetterTopic)
 	fmt.Fprintln(w, "To process dead letter messages, remember to add a subscription to your dead letter topic.")
 	return nil
 }

--- a/pubsub/subscriptions/dead_letter_delivery_attempt.go
+++ b/pubsub/subscriptions/dead_letter_delivery_attempt.go
@@ -21,7 +21,7 @@ import (
 	"io"
 	"time"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
 )
 
 func pullMsgsDeadLetterDeliveryAttempt(w io.Writer, projectID, subID string) error {
@@ -40,7 +40,7 @@ func pullMsgsDeadLetterDeliveryAttempt(w io.Writer, projectID, subID string) err
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	sub := client.Subscription(subID)
+	sub := client.Subscriber(subID)
 	err = sub.Receive(ctx, func(_ context.Context, msg *pubsub.Message) {
 		// When dead lettering is enabled, the delivery attempt field is a pointer to the
 		// the number of times the service has attempted to delivery a message.

--- a/pubsub/subscriptions/dead_letter_remove.go
+++ b/pubsub/subscriptions/dead_letter_remove.go
@@ -20,13 +20,15 @@ import (
 	"fmt"
 	"io"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
+	"cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 // removeDeadLetterTopic removes the dead letter policy from a subscription.
-func removeDeadLetterTopic(w io.Writer, projectID, subID string) error {
+func removeDeadLetterTopic(w io.Writer, projectID, subscriptionName string) error {
 	// projectID := "my-project-id"
-	// subID := "my-sub"
+	// subscription := "projects/my-project/subscriptions/my-sub"
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)
 	if err != nil {
@@ -34,13 +36,19 @@ func removeDeadLetterTopic(w io.Writer, projectID, subID string) error {
 	}
 	defer client.Close()
 
-	subConfig, err := client.Subscription(subID).Update(ctx, pubsub.SubscriptionConfigToUpdate{
-		DeadLetterPolicy: &pubsub.DeadLetterPolicy{},
+	sub, err := client.SubscriptionAdminClient.UpdateSubscription(ctx, &pubsubpb.UpdateSubscriptionRequest{
+		Subscription: &pubsubpb.Subscription{
+			Name:             subscriptionName,
+			DeadLetterPolicy: nil, // alternatively, you can omit this line entirely.
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{
+			Paths: []string{"dead_letter_policy"},
+		},
 	})
 	if err != nil {
-		return fmt.Errorf("Update: %w", err)
+		return fmt.Errorf("UpdateSubscription: %w", err)
 	}
-	fmt.Fprintf(w, "Updated subscription config: %+v\n", subConfig)
+	fmt.Fprintf(w, "Updated subscription: %+v\n", sub)
 	return nil
 }
 

--- a/pubsub/subscriptions/dead_letter_update.go
+++ b/pubsub/subscriptions/dead_letter_update.go
@@ -20,14 +20,16 @@ import (
 	"fmt"
 	"io"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
+	"cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 // updateDeadLetter updates an existing subscription with a dead letter policy.
-func updateDeadLetter(w io.Writer, projectID, subID string, fullyQualifiedDeadLetterTopic string) error {
+func updateDeadLetter(w io.Writer, projectID, subscription, deadLetterTopic string) error {
 	// projectID := "my-project-id"
-	// subID := "my-sub"
-	// fullyQualifiedDeadLetterTopic := "projects/my-project/topics/my-dead-letter-topic"
+	// subID := "projects/my-project-id/subscriptions/my-sub"
+	// deadLetterTopic := "projects/my-project-id/topics/my-dead-letter-topic"
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)
 	if err != nil {
@@ -35,18 +37,22 @@ func updateDeadLetter(w io.Writer, projectID, subID string, fullyQualifiedDeadLe
 	}
 	defer client.Close()
 
-	updateConfig := pubsub.SubscriptionConfigToUpdate{
-		DeadLetterPolicy: &pubsub.DeadLetterPolicy{
-			DeadLetterTopic:     fullyQualifiedDeadLetterTopic,
-			MaxDeliveryAttempts: 20,
+	sub, err := client.SubscriptionAdminClient.UpdateSubscription(ctx, &pubsubpb.UpdateSubscriptionRequest{
+		Subscription: &pubsubpb.Subscription{
+			Name: subscription,
+			DeadLetterPolicy: &pubsubpb.DeadLetterPolicy{
+				MaxDeliveryAttempts: 20,
+				DeadLetterTopic:     deadLetterTopic,
+			},
 		},
-	}
-
-	subConfig, err := client.Subscription(subID).Update(ctx, updateConfig)
+		UpdateMask: &fieldmaskpb.FieldMask{
+			Paths: []string{"dead_letter_policy"},
+		},
+	})
 	if err != nil {
 		return fmt.Errorf("Update: %w", err)
 	}
-	fmt.Fprintf(w, "Updated subscription config: %+v\n", subConfig)
+	fmt.Fprintf(w, "Updated subscription: %+v\n", sub)
 	return nil
 }
 

--- a/pubsub/subscriptions/delete.go
+++ b/pubsub/subscriptions/delete.go
@@ -20,7 +20,8 @@ import (
 	"fmt"
 	"io"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
+	"cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
 )
 
 func delete(w io.Writer, projectID, subID string) error {
@@ -33,8 +34,10 @@ func delete(w io.Writer, projectID, subID string) error {
 	}
 	defer client.Close()
 
-	sub := client.Subscription(subID)
-	if err := sub.Delete(ctx); err != nil {
+	req := &pubsubpb.DeleteSubscriptionRequest{
+		Subscription: fmt.Sprintf("projects/%s/subscriptions/%s", projectID, subID),
+	}
+	if err := client.SubscriptionAdminClient.DeleteSubscription(ctx, req); err != nil {
 		return fmt.Errorf("Delete: %w", err)
 	}
 	fmt.Fprintf(w, "Subscription %q deleted.", subID)

--- a/pubsub/subscriptions/detach_subscription.go
+++ b/pubsub/subscriptions/detach_subscription.go
@@ -20,7 +20,8 @@ import (
 	"fmt"
 	"io"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
+	"cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
 )
 
 func detachSubscription(w io.Writer, projectID, subName string) error {
@@ -38,8 +39,12 @@ func detachSubscription(w io.Writer, projectID, subName string) error {
 
 	// Call DetachSubscription, which detaches a subscription from
 	// a topic. This can only be done if you have the
-	// `pubsub.topics.detachSubscription` role on the topic.
-	_, err = client.DetachSubscription(ctx, subName)
+	// `pubsub.topics.detachSubscription` role on the topic the
+	// subscription is attached to.
+	req := &pubsubpb.DetachSubscriptionRequest{
+		Subscription: subName,
+	}
+	_, err = client.TopicAdminClient.DetachSubscription(ctx, req)
 	if err != nil {
 		return fmt.Errorf("detach subscription failed: %w", err)
 	}

--- a/pubsub/subscriptions/list.go
+++ b/pubsub/subscriptions/list.go
@@ -19,11 +19,12 @@ import (
 	"context"
 	"fmt"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
+	"cloud.google.com/go/pubsub/v2/apiv1/pubsubpb"
 	"google.golang.org/api/iterator"
 )
 
-func list(projectID string) ([]*pubsub.Subscription, error) {
+func list(projectID string) ([]*pubsubpb.Subscription, error) {
 	// projectID := "my-project-id"
 	ctx := context.Background()
 	client, err := pubsub.NewClient(ctx, projectID)
@@ -32,8 +33,11 @@ func list(projectID string) ([]*pubsub.Subscription, error) {
 	}
 	defer client.Close()
 
-	var subs []*pubsub.Subscription
-	it := client.Subscriptions(ctx)
+	var subs []*pubsubpb.Subscription
+	req := &pubsubpb.ListSubscriptionsRequest{
+		Project: fmt.Sprintf("projects/%s", projectID),
+	}
+	it := client.SubscriptionAdminClient.ListSubscriptions(ctx, req)
 	for {
 		s, err := it.Next()
 		if err == iterator.Done {

--- a/pubsub/subscriptions/pull_concurrency.go
+++ b/pubsub/subscriptions/pull_concurrency.go
@@ -22,7 +22,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
 )
 
 func pullMsgsConcurrencyControl(w io.Writer, projectID, subID string) error {
@@ -35,17 +35,14 @@ func pullMsgsConcurrencyControl(w io.Writer, projectID, subID string) error {
 	}
 	defer client.Close()
 
-	sub := client.Subscription(subID)
-	// Must set ReceiveSettings.Synchronous to false (or leave as default) to enable
-	// concurrency pulling of messages. Otherwise, NumGoroutines will be set to 1.
-	sub.ReceiveSettings.Synchronous = false
-	// NumGoroutines determines the number of goroutines sub.Receive will spawn to pull
-	// messages.
-	sub.ReceiveSettings.NumGoroutines = 16
+	sub := client.Subscriber(subID)
+	// NumGoroutines determines the number of streams sub.Receive will spawn to pull
+	// messages. It is recommended to set this to 1, unless your throughput
+	// is greater than 10 MB/s, as even having 1 stream can still result in
+	// messages being handled asynchronously.
+	sub.ReceiveSettings.NumGoroutines = 1
 	// MaxOutstandingMessages limits the number of concurrent handlers of messages.
 	// In this case, up to 8 unacked messages can be handled concurrently.
-	// Note, even in synchronous mode, messages pulled in a batch can still be handled
-	// concurrently.
 	sub.ReceiveSettings.MaxOutstandingMessages = 8
 
 	// Receive messages for 10 seconds, which simplifies testing.

--- a/pubsub/subscriptions/pull_error.go
+++ b/pubsub/subscriptions/pull_error.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"io"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
 )
 
 func pullMsgsError(w io.Writer, projectID, subID string) error {
@@ -35,7 +35,8 @@ func pullMsgsError(w io.Writer, projectID, subID string) error {
 
 	// If the service returns a non-retryable error, Receive returns that error after
 	// all of the outstanding calls to the handler have returned.
-	err = client.Subscription(subID).Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
+	sub := client.Subscriber(subID)
+	err = sub.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
 		fmt.Fprintf(w, "Got message: %q\n", string(msg.Data))
 		msg.Ack()
 	})

--- a/pubsub/subscriptions/pull_exactly_once_delivery.go
+++ b/pubsub/subscriptions/pull_exactly_once_delivery.go
@@ -21,7 +21,7 @@ import (
 	"io"
 	"time"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
 	"google.golang.org/api/option"
 )
 
@@ -43,11 +43,11 @@ func receiveMessagesWithExactlyOnceDeliveryEnabled(w io.Writer, projectID, subID
 	}
 	defer client.Close()
 
-	sub := client.Subscription(subID)
-	// Set MinExtensionPeriod high to avoid any unintentional
+	sub := client.Subscriber(subID)
+	// Set MinDurationPerAckExtension high to avoid any unintentional
 	// acknowledgment expirations (e.g. due to network events).
 	// This can lead to high tail latency in case of client crashes.
-	sub.ReceiveSettings.MinExtensionPeriod = 600 * time.Second
+	sub.ReceiveSettings.MinDurationPerAckExtension = 600 * time.Second
 
 	// Receive messages for 10 seconds, which simplifies testing.
 	// Comment this out in production, since `Receive` should

--- a/pubsub/subscriptions/pull_otel_tracing.go
+++ b/pubsub/subscriptions/pull_otel_tracing.go
@@ -22,7 +22,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
 	texporter "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -73,7 +73,7 @@ func subscribeOpenTelemetryTracing(w io.Writer, projectID, subID string, sampleR
 	}
 	defer client.Close()
 
-	sub := client.Subscription(subID)
+	sub := client.Subscriber(subID)
 
 	// Receive messages for 10 seconds, which simplifies testing.
 	// Comment this out in production, since `Receive` should

--- a/pubsub/subscriptions/pull_settings.go
+++ b/pubsub/subscriptions/pull_settings.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"io"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/pubsub/v2"
 )
 
 func pullMsgsFlowControlSettings(w io.Writer, projectID, subID string) error {
@@ -33,7 +33,7 @@ func pullMsgsFlowControlSettings(w io.Writer, projectID, subID string) error {
 	}
 	defer client.Close()
 
-	sub := client.Subscription(subID)
+	sub := client.Subscriber(subID)
 	// MaxOutstandingMessages is the maximum number of unprocessed messages the
 	// subscriber client will pull from the server before pausing. This also configures
 	// the maximum number of concurrent handlers for received messages.

--- a/pubsub/subscriptions/test_permissions.go
+++ b/pubsub/subscriptions/test_permissions.go
@@ -20,7 +20,8 @@ import (
 	"fmt"
 	"io"
 
-	"cloud.google.com/go/pubsub"
+	"cloud.google.com/go/iam/apiv1/iampb"
+	"cloud.google.com/go/pubsub/v2"
 )
 
 func testPermissions(w io.Writer, projectID, subID string) ([]string, error) {
@@ -32,17 +33,19 @@ func testPermissions(w io.Writer, projectID, subID string) ([]string, error) {
 		return nil, fmt.Errorf("pubsub.NewClient: %w", err)
 	}
 
-	sub := client.Subscription(subID)
-	perms, err := sub.IAM().TestPermissions(ctx, []string{
-		"pubsub.subscriptions.consume",
-		"pubsub.subscriptions.update",
-	})
-	if err != nil {
-		return nil, fmt.Errorf("TestPermissions: %w", err)
+	req := &iampb.TestIamPermissionsRequest{
+		Resource: fmt.Sprintf("projects/%s/subscriptions/%s", projectID, subID),
+		Permissions: []string{
+			"pubsub.subscriptions.consume",
+			"pubsub.subscriptions.update",
+		},
 	}
-	for _, perm := range perms {
+	resp, err := client.SubscriptionAdminClient.TestIamPermissions(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("error calling TestIamPermissions: %w", err)
+	}
+	for _, perm := range resp.Permissions {
 		fmt.Fprintf(w, "Allowed: %v\n", perm)
 	}
-	// [END pubsub_test_subscription_permissions]
-	return perms, nil
+	return resp.Permissions, nil
 }


### PR DESCRIPTION
This is part 2 of 3 PRs that will be updating our existing Go Pub/Sub samples to use the new v2 library. This PR focuses on updating subscription and receive samples and the tests associated with them.

We are merging these PRs into pubsub-v2-samples-trunk since the v2 library isn't fully released yet.
