### PR TITLE
chore: remove flakybot configuration (long retired)

### DIFF
--- a/.github/flakybot.yaml
+++ b/.github/flakybot.yaml
@@ -1,1 +1,0 @@
-issuePriority: p2


### PR DESCRIPTION
## Description

Addresses b/434770885 (Complete flakybot deprecation) for this repo. 

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] Please **merge** this PR for me once it is approved
