### PR TITLE
feat: Add MKC Code Examples

### DIFF
--- a/managedkafka/connect/clusters/connect_clusters_test.go
+++ b/managedkafka/connect/clusters/connect_clusters_test.go
@@ -1,0 +1,95 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusters
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/golang-samples/internal/managedkafka/fake"
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+)
+
+const (
+	connectClusterPrefix = "connect-cluster"
+	region               = "us-central1"
+)
+
+func TestConnectClusters(t *testing.T) {
+	tc := testutil.SystemTest(t)
+	buf := new(bytes.Buffer)
+	connectClusterID := fmt.Sprintf("%s-%d", connectClusterPrefix, time.Now().UnixNano())
+	kafkaClusterID := fmt.Sprintf("kafka-cluster-%d", time.Now().UnixNano())
+	options := fake.Options(t)
+
+	// First create a Kafka cluster that the Connect cluster will reference
+	kafkaClusterPath := fmt.Sprintf("projects/%s/locations/%s/clusters/%s", tc.ProjectID, region, kafkaClusterID)
+
+	t.Run("CreateConnectCluster", func(t *testing.T) {
+		if err := createConnectCluster(buf, tc.ProjectID, region, connectClusterID, kafkaClusterPath, options...); err != nil {
+			t.Fatalf("failed to create a connect cluster: %v", err)
+		}
+		got := buf.String()
+		want := "Created connect cluster"
+		if !strings.Contains(got, want) {
+			t.Fatalf("createConnectCluster() mismatch got: %s\nwant: %s", got, want)
+		}
+	})
+	t.Run("GetConnectCluster", func(t *testing.T) {
+		if err := getConnectCluster(buf, tc.ProjectID, region, connectClusterID, options...); err != nil {
+			t.Fatalf("failed to get connect cluster: %v", err)
+		}
+		got := buf.String()
+		want := "Got connect cluster"
+		if !strings.Contains(got, want) {
+			t.Fatalf("getConnectCluster() mismatch got: %s\nwant: %s", got, want)
+		}
+	})
+	t.Run("UpdateConnectCluster", func(t *testing.T) {
+		memoryBytes := int64(13958643712) // 13 GiB in bytes
+		labels := map[string]string{"environment": "test"}
+		if err := updateConnectCluster(buf, tc.ProjectID, region, connectClusterID, memoryBytes, labels, options...); err != nil {
+			t.Fatalf("failed to update connect cluster: %v", err)
+		}
+		got := buf.String()
+		want := "Updated connect cluster"
+		if !strings.Contains(got, want) {
+			t.Fatalf("updateConnectCluster() mismatch got: %s\nwant: %s", got, want)
+		}
+	})
+	t.Run("ListConnectClusters", func(t *testing.T) {
+		if err := listConnectClusters(buf, tc.ProjectID, region, options...); err != nil {
+			t.Fatalf("failed to list connect clusters: %v", err)
+		}
+		got := buf.String()
+		want := "Got connect cluster"
+		if !strings.Contains(got, want) {
+			t.Fatalf("listConnectClusters() mismatch got: %s\nwant: %s", got, want)
+		}
+	})
+	t.Run("DeleteConnectCluster", func(t *testing.T) {
+		if err := deleteConnectCluster(buf, tc.ProjectID, region, connectClusterID, options...); err != nil {
+			t.Fatalf("failed to delete connect cluster: %v", err)
+		}
+		got := buf.String()
+		want := "Deleted connect cluster"
+		if !strings.Contains(got, want) {
+			t.Fatalf("deleteConnectCluster() mismatch got: %s\nwant: %s", got, want)
+		}
+	})
+}

--- a/managedkafka/connect/clusters/create_connect_cluster.go
+++ b/managedkafka/connect/clusters/create_connect_cluster.go
@@ -1,0 +1,74 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusters
+
+// [START managedkafka_create_connect_cluster]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/managedkafka/apiv1/managedkafkapb"
+	"google.golang.org/api/option"
+
+	managedkafka "cloud.google.com/go/managedkafka/apiv1"
+)
+
+func createConnectCluster(w io.Writer, projectID, region, clusterID, kafkaCluster string, opts ...option.ClientOption) error {
+	// projectID := "my-project-id"
+	// region := "us-central1"
+	// clusterID := "my-connect-cluster"
+	// kafkaCluster := "projects/my-project-id/locations/us-central1/clusters/my-kafka-cluster"
+	ctx := context.Background()
+	client, err := managedkafka.NewManagedKafkaConnectClient(ctx, opts...)
+	if err != nil {
+		return fmt.Errorf("managedkafka.NewManagedKafkaConnectClient got err: %w", err)
+	}
+	defer client.Close()
+
+	locationPath := fmt.Sprintf("projects/%s/locations/%s", projectID, region)
+	clusterPath := fmt.Sprintf("%s/connectClusters/%s", locationPath, clusterID)
+
+	// Capacity configuration with 12 vCPU and 12 GiB RAM
+	capacityConfig := &managedkafkapb.CapacityConfig{
+		VcpuCount:   12,
+		MemoryBytes: 12884901888, // 12 GiB in bytes
+	}
+
+	connectCluster := &managedkafkapb.ConnectCluster{
+		Name:           clusterPath,
+		KafkaCluster:   kafkaCluster,
+		CapacityConfig: capacityConfig,
+	}
+
+	req := &managedkafkapb.CreateConnectClusterRequest{
+		Parent:           locationPath,
+		ConnectClusterId: clusterID,
+		ConnectCluster:   connectCluster,
+	}
+	op, err := client.CreateConnectCluster(ctx, req)
+	if err != nil {
+		return fmt.Errorf("client.CreateConnectCluster got err: %w", err)
+	}
+	// The duration of this operation can vary considerably, typically taking 5-15 minutes.
+	resp, err := op.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("op.Wait got err: %w", err)
+	}
+	fmt.Fprintf(w, "Created connect cluster: %s\n", resp.Name)
+	return nil
+}
+
+// [END managedkafka_create_connect_cluster]

--- a/managedkafka/connect/clusters/delete_connect_cluster.go
+++ b/managedkafka/connect/clusters/delete_connect_cluster.go
@@ -1,0 +1,56 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusters
+
+// [START managedkafka_delete_connect_cluster]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/managedkafka/apiv1/managedkafkapb"
+	"google.golang.org/api/option"
+
+	managedkafka "cloud.google.com/go/managedkafka/apiv1"
+)
+
+func deleteConnectCluster(w io.Writer, projectID, region, clusterID string, opts ...option.ClientOption) error {
+	// projectID := "my-project-id"
+	// region := "us-central1"
+	// clusterID := "my-connect-cluster"
+	ctx := context.Background()
+	client, err := managedkafka.NewManagedKafkaConnectClient(ctx, opts...)
+	if err != nil {
+		return fmt.Errorf("managedkafka.NewManagedKafkaConnectClient got err: %w", err)
+	}
+	defer client.Close()
+
+	clusterPath := fmt.Sprintf("projects/%s/locations/%s/connectClusters/%s", projectID, region, clusterID)
+	req := &managedkafkapb.DeleteConnectClusterRequest{
+		Name: clusterPath,
+	}
+	op, err := client.DeleteConnectCluster(ctx, req)
+	if err != nil {
+		return fmt.Errorf("client.DeleteConnectCluster got err: %w", err)
+	}
+	err = op.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("op.Wait got err: %w", err)
+	}
+	fmt.Fprint(w, "Deleted connect cluster\n")
+	return nil
+}
+
+// [END managedkafka_delete_connect_cluster]

--- a/managedkafka/connect/clusters/get_connect_cluster.go
+++ b/managedkafka/connect/clusters/get_connect_cluster.go
@@ -1,0 +1,52 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusters
+
+// [START managedkafka_get_connect_cluster]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/managedkafka/apiv1/managedkafkapb"
+	"google.golang.org/api/option"
+
+	managedkafka "cloud.google.com/go/managedkafka/apiv1"
+)
+
+func getConnectCluster(w io.Writer, projectID, region, clusterID string, opts ...option.ClientOption) error {
+	// projectID := "my-project-id"
+	// region := "us-central1"
+	// clusterID := "my-connect-cluster"
+	ctx := context.Background()
+	client, err := managedkafka.NewManagedKafkaConnectClient(ctx, opts...)
+	if err != nil {
+		return fmt.Errorf("managedkafka.NewManagedKafkaConnectClient got err: %w", err)
+	}
+	defer client.Close()
+
+	clusterPath := fmt.Sprintf("projects/%s/locations/%s/connectClusters/%s", projectID, region, clusterID)
+	req := &managedkafkapb.GetConnectClusterRequest{
+		Name: clusterPath,
+	}
+	cluster, err := client.GetConnectCluster(ctx, req)
+	if err != nil {
+		return fmt.Errorf("client.GetConnectCluster got err: %w", err)
+	}
+	fmt.Fprintf(w, "Got connect cluster: %#v\n", cluster)
+	return nil
+}
+
+// [END managedkafka_get_connect_cluster]

--- a/managedkafka/connect/clusters/list_connect_clusters.go
+++ b/managedkafka/connect/clusters/list_connect_clusters.go
@@ -1,0 +1,58 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusters
+
+// [START managedkafka_list_connect_clusters]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/managedkafka/apiv1/managedkafkapb"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+
+	managedkafka "cloud.google.com/go/managedkafka/apiv1"
+)
+
+func listConnectClusters(w io.Writer, projectID, region string, opts ...option.ClientOption) error {
+	// projectID := "my-project-id"
+	// region := "us-central1"
+	ctx := context.Background()
+	client, err := managedkafka.NewManagedKafkaConnectClient(ctx, opts...)
+	if err != nil {
+		return fmt.Errorf("managedkafka.NewManagedKafkaConnectClient got err: %w", err)
+	}
+	defer client.Close()
+
+	locationPath := fmt.Sprintf("projects/%s/locations/%s", projectID, region)
+	req := &managedkafkapb.ListConnectClustersRequest{
+		Parent: locationPath,
+	}
+	clusterIter := client.ListConnectClusters(ctx, req)
+	for {
+		res, err := clusterIter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("clusterIter.Next() got err: %w", err)
+		}
+		fmt.Fprintf(w, "Got connect cluster: %v", res)
+	}
+	return nil
+}
+
+// [END managedkafka_list_connect_clusters]

--- a/managedkafka/connect/clusters/update_connect_cluster.go
+++ b/managedkafka/connect/clusters/update_connect_cluster.go
@@ -1,0 +1,76 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusters
+
+// [START managedkafka_update_connect_cluster]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/managedkafka/apiv1/managedkafkapb"
+	"google.golang.org/api/option"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	managedkafka "cloud.google.com/go/managedkafka/apiv1"
+)
+
+func updateConnectCluster(w io.Writer, projectID, region, clusterID string, memoryBytes int64, labels map[string]string, opts ...option.ClientOption) error {
+	// projectID := "my-project-id"
+	// region := "us-central1"
+	// clusterID := "my-connect-cluster"
+	// memoryBytes := 13958643712 // 13 GiB in bytes
+	// labels := map[string]string{"environment": "production"}
+	ctx := context.Background()
+	client, err := managedkafka.NewManagedKafkaConnectClient(ctx, opts...)
+	if err != nil {
+		return fmt.Errorf("managedkafka.NewManagedKafkaConnectClient got err: %w", err)
+	}
+	defer client.Close()
+
+	clusterPath := fmt.Sprintf("projects/%s/locations/%s/connectClusters/%s", projectID, region, clusterID)
+	
+	// Capacity configuration update
+	capacityConfig := &managedkafkapb.CapacityConfig{
+		MemoryBytes: memoryBytes,
+	}
+	
+	connectCluster := &managedkafkapb.ConnectCluster{
+		Name:           clusterPath,
+		CapacityConfig: capacityConfig,
+		Labels:         labels,
+	}
+	paths := []string{"capacity_config.memory_bytes", "labels"}
+	updateMask := &fieldmaskpb.FieldMask{
+		Paths: paths,
+	}
+
+	req := &managedkafkapb.UpdateConnectClusterRequest{
+		UpdateMask:     updateMask,
+		ConnectCluster: connectCluster,
+	}
+	op, err := client.UpdateConnectCluster(ctx, req)
+	if err != nil {
+		return fmt.Errorf("client.UpdateConnectCluster got err: %w", err)
+	}
+	resp, err := op.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("op.Wait got err: %w", err)
+	}
+	fmt.Fprintf(w, "Updated connect cluster: %#v\n", resp)
+	return nil
+}
+
+// [END managedkafka_update_connect_cluster]

--- a/managedkafka/connect/connectors/connectors_test.go
+++ b/managedkafka/connect/connectors/connectors_test.go
@@ -1,0 +1,194 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectors
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/golang-samples/internal/managedkafka/fake"
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+)
+
+const (
+	connectorPrefix  = "connector"
+	connectClusterID = "test-connect-cluster"
+	region           = "us-central1"
+)
+
+func TestConnectors(t *testing.T) {
+	tc := testutil.SystemTest(t)
+	buf := new(bytes.Buffer)
+	connectorID := fmt.Sprintf("%s-%d", connectorPrefix, time.Now().UnixNano())
+	options := fake.Options(t)
+
+	t.Run("CreateMirrorMakerConnector", func(t *testing.T) {
+		sourceDNS := "source-cluster-dns:9092"
+		targetDNS := "target-cluster-dns:9092"
+		topicName := "test-topic"
+		if err := createMirrorMakerConnector(buf, tc.ProjectID, region, connectClusterID, connectorID+"-mm2", sourceDNS, targetDNS, topicName, options...); err != nil {
+			t.Fatalf("failed to create MirrorMaker connector: %v", err)
+		}
+		got := buf.String()
+		want := "Created MirrorMaker connector"
+		if !strings.Contains(got, want) {
+			t.Fatalf("createMirrorMakerConnector() mismatch got: %s\nwant: %s", got, want)
+		}
+	})
+
+	t.Run("CreatePubSubSourceConnector", func(t *testing.T) {
+		topicName := "test-topic"
+		subscription := "test-subscription"
+		if err := createPubSubSourceConnector(buf, tc.ProjectID, region, connectClusterID, connectorID+"-pubsub-source", topicName, subscription, options...); err != nil {
+			t.Fatalf("failed to create Pub/Sub source connector: %v", err)
+		}
+		got := buf.String()
+		want := "Created Pub/Sub source connector"
+		if !strings.Contains(got, want) {
+			t.Fatalf("createPubSubSourceConnector() mismatch got: %s\nwant: %s", got, want)
+		}
+	})
+
+	t.Run("CreatePubSubSinkConnector", func(t *testing.T) {
+		topicName := "test-topic"
+		pubsubTopic := "test-pubsub-topic"
+		if err := createPubSubSinkConnector(buf, tc.ProjectID, region, connectClusterID, connectorID+"-pubsub-sink", topicName, pubsubTopic, options...); err != nil {
+			t.Fatalf("failed to create Pub/Sub sink connector: %v", err)
+		}
+		got := buf.String()
+		want := "Created Pub/Sub sink connector"
+		if !strings.Contains(got, want) {
+			t.Fatalf("createPubSubSinkConnector() mismatch got: %s\nwant: %s", got, want)
+		}
+	})
+
+	t.Run("CreateGCSSinkConnector", func(t *testing.T) {
+		topicName := "test-topic"
+		bucketName := "test-bucket"
+		if err := createGCSSinkConnector(buf, tc.ProjectID, region, connectClusterID, connectorID+"-gcs-sink", topicName, bucketName, options...); err != nil {
+			t.Fatalf("failed to create GCS sink connector: %v", err)
+		}
+		got := buf.String()
+		want := "Created Cloud Storage sink connector"
+		if !strings.Contains(got, want) {
+			t.Fatalf("createGCSSinkConnector() mismatch got: %s\nwant: %s", got, want)
+		}
+	})
+
+	t.Run("CreateBigQuerySinkConnector", func(t *testing.T) {
+		topicName := "test-topic"
+		datasetID := "test-dataset"
+		if err := createBigQuerySinkConnector(buf, tc.ProjectID, region, connectClusterID, connectorID+"-bq-sink", topicName, datasetID, options...); err != nil {
+			t.Fatalf("failed to create BigQuery sink connector: %v", err)
+		}
+		got := buf.String()
+		want := "Created BigQuery sink connector"
+		if !strings.Contains(got, want) {
+			t.Fatalf("createBigQuerySinkConnector() mismatch got: %s\nwant: %s", got, want)
+		}
+	})
+
+	t.Run("GetConnector", func(t *testing.T) {
+		if err := getConnector(buf, tc.ProjectID, region, connectClusterID, connectorID, options...); err != nil {
+			t.Fatalf("failed to get connector: %v", err)
+		}
+		got := buf.String()
+		want := "Got connector"
+		if !strings.Contains(got, want) {
+			t.Fatalf("getConnector() mismatch got: %s\nwant: %s", got, want)
+		}
+	})
+
+	t.Run("UpdateConnector", func(t *testing.T) {
+		config := map[string]string{"tasks.max": "2"}
+		if err := updateConnector(buf, tc.ProjectID, region, connectClusterID, connectorID, config, options...); err != nil {
+			t.Fatalf("failed to update connector: %v", err)
+		}
+		got := buf.String()
+		want := "Updated connector"
+		if !strings.Contains(got, want) {
+			t.Fatalf("updateConnector() mismatch got: %s\nwant: %s", got, want)
+		}
+	})
+
+	t.Run("ListConnectors", func(t *testing.T) {
+		if err := listConnectors(buf, tc.ProjectID, region, connectClusterID, options...); err != nil {
+			t.Fatalf("failed to list connectors: %v", err)
+		}
+		got := buf.String()
+		want := "Got connector"
+		if !strings.Contains(got, want) {
+			t.Fatalf("listConnectors() mismatch got: %s\nwant: %s", got, want)
+		}
+	})
+
+	t.Run("PauseConnector", func(t *testing.T) {
+		if err := pauseConnector(buf, tc.ProjectID, region, connectClusterID, connectorID, options...); err != nil {
+			t.Fatalf("failed to pause connector: %v", err)
+		}
+		got := buf.String()
+		want := "Paused connector"
+		if !strings.Contains(got, want) {
+			t.Fatalf("pauseConnector() mismatch got: %s\nwant: %s", got, want)
+		}
+	})
+
+	t.Run("ResumeConnector", func(t *testing.T) {
+		if err := resumeConnector(buf, tc.ProjectID, region, connectClusterID, connectorID, options...); err != nil {
+			t.Fatalf("failed to resume connector: %v", err)
+		}
+		got := buf.String()
+		want := "Resumed connector"
+		if !strings.Contains(got, want) {
+			t.Fatalf("resumeConnector() mismatch got: %s\nwant: %s", got, want)
+		}
+	})
+
+	t.Run("StopConnector", func(t *testing.T) {
+		if err := stopConnector(buf, tc.ProjectID, region, connectClusterID, connectorID, options...); err != nil {
+			t.Fatalf("failed to stop connector: %v", err)
+		}
+		got := buf.String()
+		want := "Stopped connector"
+		if !strings.Contains(got, want) {
+			t.Fatalf("stopConnector() mismatch got: %s\nwant: %s", got, want)
+		}
+	})
+
+	t.Run("RestartConnector", func(t *testing.T) {
+		if err := restartConnector(buf, tc.ProjectID, region, connectClusterID, connectorID, options...); err != nil {
+			t.Fatalf("failed to restart connector: %v", err)
+		}
+		got := buf.String()
+		want := "Restarted connector"
+		if !strings.Contains(got, want) {
+			t.Fatalf("restartConnector() mismatch got: %s\nwant: %s", got, want)
+		}
+	})
+
+	t.Run("DeleteConnector", func(t *testing.T) {
+		if err := deleteConnector(buf, tc.ProjectID, region, connectClusterID, connectorID, options...); err != nil {
+			t.Fatalf("failed to delete connector: %v", err)
+		}
+		got := buf.String()
+		want := "Deleted connector"
+		if !strings.Contains(got, want) {
+			t.Fatalf("deleteConnector() mismatch got: %s\nwant: %s", got, want)
+		}
+	})
+}

--- a/managedkafka/connect/connectors/create_bigquery_sink_connector.go
+++ b/managedkafka/connect/connectors/create_bigquery_sink_connector.go
@@ -1,0 +1,77 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectors
+
+// [START managedkafka_create_bigquery_sink_connector]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/managedkafka/apiv1/managedkafkapb"
+	"google.golang.org/api/option"
+
+	managedkafka "cloud.google.com/go/managedkafka/apiv1"
+)
+
+func createBigQuerySinkConnector(w io.Writer, projectID, region, connectClusterID, connectorID, topicName, datasetID string, opts ...option.ClientOption) error {
+	// projectID := "my-project-id"
+	// region := "us-central1"
+	// connectClusterID := "my-connect-cluster"
+	// connectorID := "my-bigquery-sink-connector"
+	// topicName := "my-kafka-topic"
+	// datasetID := "my-bigquery-dataset"
+	ctx := context.Background()
+	client, err := managedkafka.NewManagedKafkaConnectClient(ctx, opts...)
+	if err != nil {
+		return fmt.Errorf("managedkafka.NewManagedKafkaConnectClient got err: %w", err)
+	}
+	defer client.Close()
+
+	parent := fmt.Sprintf("projects/%s/locations/%s/connectClusters/%s", projectID, region, connectClusterID)
+
+	// BigQuery Sink sample connector configuration
+	config := map[string]string{
+		"name":                           connectorID,
+		"project":                        projectID,
+		"topics":                         topicName,
+		"tasks.max":                      "3",
+		"connector.class":                "com.wepay.kafka.connect.bigquery.BigQuerySinkConnector",
+		"key.converter":                  "org.apache.kafka.connect.storage.StringConverter",
+		"value.converter":                "org.apache.kafka.connect.json.JsonConverter",
+		"value.converter.schemas.enable": "false",
+		"defaultDataset":                 datasetID,
+	}
+
+	connector := &managedkafkapb.Connector{
+		Name:    fmt.Sprintf("%s/connectors/%s", parent, connectorID),
+		Configs: config,
+	}
+
+	req := &managedkafkapb.CreateConnectorRequest{
+		Parent:      parent,
+		ConnectorId: connectorID,
+		Connector:   connector,
+	}
+
+	resp, err := client.CreateConnector(ctx, req)
+	if err != nil {
+		return fmt.Errorf("client.CreateConnector got err: %w", err)
+	}
+	fmt.Fprintf(w, "Created BigQuery sink connector: %s\n", resp.Name)
+	return nil
+}
+
+// [END managedkafka_create_bigquery_sink_connector]

--- a/managedkafka/connect/connectors/create_gcs_sink_connector.go
+++ b/managedkafka/connect/connectors/create_gcs_sink_connector.go
@@ -1,0 +1,78 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectors
+
+// [START managedkafka_create_gcs_sink_connector]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/managedkafka/apiv1/managedkafkapb"
+	"google.golang.org/api/option"
+
+	managedkafka "cloud.google.com/go/managedkafka/apiv1"
+)
+
+func createGCSSinkConnector(w io.Writer, projectID, region, connectClusterID, connectorID, topicName, bucketName string, opts ...option.ClientOption) error {
+	// projectID := "my-project-id"
+	// region := "us-central1"
+	// connectClusterID := "my-connect-cluster"
+	// connectorID := "my-gcs-sink-connector"
+	// topicName := "my-kafka-topic"
+	// bucketName := "my-gcs-bucket"
+	ctx := context.Background()
+	client, err := managedkafka.NewManagedKafkaConnectClient(ctx, opts...)
+	if err != nil {
+		return fmt.Errorf("managedkafka.NewManagedKafkaConnectClient got err: %w", err)
+	}
+	defer client.Close()
+
+	parent := fmt.Sprintf("projects/%s/locations/%s/connectClusters/%s", projectID, region, connectClusterID)
+
+	// Cloud Storage Sink sample connector configuration
+	config := map[string]string{
+		"connector.class":                "io.aiven.kafka.connect.gcs.GcsSinkConnector",
+		"tasks.max":                      "1",
+		"topics":                         topicName,
+		"gcs.bucket.name":                bucketName,
+		"gcs.credentials.default":        "true",
+		"format.output.type":             "json",
+		"name":                           connectorID,
+		"value.converter":                "org.apache.kafka.connect.json.JsonConverter",
+		"value.converter.schemas.enable": "false",
+		"key.converter":                  "org.apache.kafka.connect.storage.StringConverter",
+	}
+
+	connector := &managedkafkapb.Connector{
+		Name:    fmt.Sprintf("%s/connectors/%s", parent, connectorID),
+		Configs: config,
+	}
+
+	req := &managedkafkapb.CreateConnectorRequest{
+		Parent:      parent,
+		ConnectorId: connectorID,
+		Connector:   connector,
+	}
+
+	resp, err := client.CreateConnector(ctx, req)
+	if err != nil {
+		return fmt.Errorf("client.CreateConnector got err: %w", err)
+	}
+	fmt.Fprintf(w, "Created Cloud Storage sink connector: %s\n", resp.Name)
+	return nil
+}
+
+// [END managedkafka_create_gcs_sink_connector]

--- a/managedkafka/connect/connectors/create_pubsub_sink_connector.go
+++ b/managedkafka/connect/connectors/create_pubsub_sink_connector.go
@@ -1,0 +1,76 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectors
+
+// [START managedkafka_create_pubsub_sink_connector]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/managedkafka/apiv1/managedkafkapb"
+	"google.golang.org/api/option"
+
+	managedkafka "cloud.google.com/go/managedkafka/apiv1"
+)
+
+func createPubSubSinkConnector(w io.Writer, projectID, region, connectClusterID, connectorID, topicName, pubsubTopic string, opts ...option.ClientOption) error {
+	// projectID := "my-project-id"
+	// region := "us-central1"
+	// connectClusterID := "my-connect-cluster"
+	// connectorID := "my-pubsub-sink-connector"
+	// topicName := "my-kafka-topic"
+	// pubsubTopic := "my-pubsub-topic"
+	ctx := context.Background()
+	client, err := managedkafka.NewManagedKafkaConnectClient(ctx, opts...)
+	if err != nil {
+		return fmt.Errorf("managedkafka.NewManagedKafkaConnectClient got err: %w", err)
+	}
+	defer client.Close()
+
+	parent := fmt.Sprintf("projects/%s/locations/%s/connectClusters/%s", projectID, region, connectClusterID)
+
+	// Pub/Sub Sink sample connector configuration
+	config := map[string]string{
+		"connector.class": "com.google.pubsub.kafka.sink.CloudPubSubSinkConnector",
+		"name":            connectorID,
+		"tasks.max":       "1",
+		"topics":          topicName,
+		"value.converter": "org.apache.kafka.connect.storage.StringConverter",
+		"key.converter":   "org.apache.kafka.connect.storage.StringConverter",
+		"cps.topic":       pubsubTopic,
+		"cps.project":     projectID,
+	}
+
+	connector := &managedkafkapb.Connector{
+		Name:    fmt.Sprintf("%s/connectors/%s", parent, connectorID),
+		Configs: config,
+	}
+
+	req := &managedkafkapb.CreateConnectorRequest{
+		Parent:      parent,
+		ConnectorId: connectorID,
+		Connector:   connector,
+	}
+
+	resp, err := client.CreateConnector(ctx, req)
+	if err != nil {
+		return fmt.Errorf("client.CreateConnector got err: %w", err)
+	}
+	fmt.Fprintf(w, "Created Pub/Sub sink connector: %s\n", resp.Name)
+	return nil
+}
+
+// [END managedkafka_create_pubsub_sink_connector]

--- a/managedkafka/connect/connectors/create_pubsub_source_connector.go
+++ b/managedkafka/connect/connectors/create_pubsub_source_connector.go
@@ -1,0 +1,76 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectors
+
+// [START managedkafka_create_pubsub_source_connector]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/managedkafka/apiv1/managedkafkapb"
+	"google.golang.org/api/option"
+
+	managedkafka "cloud.google.com/go/managedkafka/apiv1"
+)
+
+func createPubSubSourceConnector(w io.Writer, projectID, region, connectClusterID, connectorID, topicName, subscription string, opts ...option.ClientOption) error {
+	// projectID := "my-project-id"
+	// region := "us-central1"
+	// connectClusterID := "my-connect-cluster"
+	// connectorID := "my-pubsub-source-connector"
+	// topicName := "my-kafka-topic"
+	// subscription := "my-pubsub-subscription"
+	ctx := context.Background()
+	client, err := managedkafka.NewManagedKafkaConnectClient(ctx, opts...)
+	if err != nil {
+		return fmt.Errorf("managedkafka.NewManagedKafkaConnectClient got err: %w", err)
+	}
+	defer client.Close()
+
+	parent := fmt.Sprintf("projects/%s/locations/%s/connectClusters/%s", projectID, region, connectClusterID)
+
+	// Pub/Sub Source sample connector configuration
+	config := map[string]string{
+		"connector.class":  "com.google.pubsub.kafka.source.CloudPubSubSourceConnector",
+		"name":             connectorID,
+		"tasks.max":        "1",
+		"kafka.topic":      topicName,
+		"cps.subscription": subscription,
+		"cps.project":      projectID,
+		"value.converter":  "org.apache.kafka.connect.converters.ByteArrayConverter",
+		"key.converter":    "org.apache.kafka.connect.storage.StringConverter",
+	}
+
+	connector := &managedkafkapb.Connector{
+		Name:    fmt.Sprintf("%s/connectors/%s", parent, connectorID),
+		Configs: config,
+	}
+
+	req := &managedkafkapb.CreateConnectorRequest{
+		Parent:      parent,
+		ConnectorId: connectorID,
+		Connector:   connector,
+	}
+
+	resp, err := client.CreateConnector(ctx, req)
+	if err != nil {
+		return fmt.Errorf("client.CreateConnector got err: %w", err)
+	}
+	fmt.Fprintf(w, "Created Pub/Sub source connector: %s\n", resp.Name)
+	return nil
+}
+
+// [END managedkafka_create_pubsub_source_connector]

--- a/managedkafka/connect/connectors/delete_connector.go
+++ b/managedkafka/connect/connectors/delete_connector.go
@@ -1,0 +1,53 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectors
+
+// [START managedkafka_delete_connector]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/managedkafka/apiv1/managedkafkapb"
+	"google.golang.org/api/option"
+
+	managedkafka "cloud.google.com/go/managedkafka/apiv1"
+)
+
+func deleteConnector(w io.Writer, projectID, region, connectClusterID, connectorID string, opts ...option.ClientOption) error {
+	// projectID := "my-project-id"
+	// region := "us-central1"
+	// connectClusterID := "my-connect-cluster"
+	// connectorID := "my-connector"
+	ctx := context.Background()
+	client, err := managedkafka.NewManagedKafkaConnectClient(ctx, opts...)
+	if err != nil {
+		return fmt.Errorf("managedkafka.NewManagedKafkaConnectClient got err: %w", err)
+	}
+	defer client.Close()
+
+	connectorPath := fmt.Sprintf("projects/%s/locations/%s/connectClusters/%s/connectors/%s", projectID, region, connectClusterID, connectorID)
+	req := &managedkafkapb.DeleteConnectorRequest{
+		Name: connectorPath,
+	}
+	err = client.DeleteConnector(ctx, req)
+	if err != nil {
+		return fmt.Errorf("client.DeleteConnector got err: %w", err)
+	}
+	fmt.Fprint(w, "Deleted connector\n")
+	return nil
+}
+
+// [END managedkafka_delete_connector]

--- a/managedkafka/connect/connectors/get_connector.go
+++ b/managedkafka/connect/connectors/get_connector.go
@@ -1,0 +1,53 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectors
+
+// [START managedkafka_get_connector]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/managedkafka/apiv1/managedkafkapb"
+	"google.golang.org/api/option"
+
+	managedkafka "cloud.google.com/go/managedkafka/apiv1"
+)
+
+func getConnector(w io.Writer, projectID, region, connectClusterID, connectorID string, opts ...option.ClientOption) error {
+	// projectID := "my-project-id"
+	// region := "us-central1"
+	// connectClusterID := "my-connect-cluster"
+	// connectorID := "my-connector"
+	ctx := context.Background()
+	client, err := managedkafka.NewManagedKafkaConnectClient(ctx, opts...)
+	if err != nil {
+		return fmt.Errorf("managedkafka.NewManagedKafkaConnectClient got err: %w", err)
+	}
+	defer client.Close()
+
+	connectorPath := fmt.Sprintf("projects/%s/locations/%s/connectClusters/%s/connectors/%s", projectID, region, connectClusterID, connectorID)
+	req := &managedkafkapb.GetConnectorRequest{
+		Name: connectorPath,
+	}
+	connector, err := client.GetConnector(ctx, req)
+	if err != nil {
+		return fmt.Errorf("client.GetConnector got err: %w", err)
+	}
+	fmt.Fprintf(w, "Got connector: %#v\n", connector)
+	return nil
+}
+
+// [END managedkafka_get_connector]

--- a/managedkafka/connect/connectors/list_connectors.go
+++ b/managedkafka/connect/connectors/list_connectors.go
@@ -1,0 +1,59 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectors
+
+// [START managedkafka_list_connectors]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/managedkafka/apiv1/managedkafkapb"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+
+	managedkafka "cloud.google.com/go/managedkafka/apiv1"
+)
+
+func listConnectors(w io.Writer, projectID, region, connectClusterID string, opts ...option.ClientOption) error {
+	// projectID := "my-project-id"
+	// region := "us-central1"
+	// connectClusterID := "my-connect-cluster"
+	ctx := context.Background()
+	client, err := managedkafka.NewManagedKafkaConnectClient(ctx, opts...)
+	if err != nil {
+		return fmt.Errorf("managedkafka.NewManagedKafkaConnectClient got err: %w", err)
+	}
+	defer client.Close()
+
+	parent := fmt.Sprintf("projects/%s/locations/%s/connectClusters/%s", projectID, region, connectClusterID)
+	req := &managedkafkapb.ListConnectorsRequest{
+		Parent: parent,
+	}
+	connectorIter := client.ListConnectors(ctx, req)
+	for {
+		connector, err := connectorIter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("connectorIter.Next() got err: %w", err)
+		}
+		fmt.Fprintf(w, "Got connector: %v", connector)
+	}
+	return nil
+}
+
+// [END managedkafka_list_connectors]

--- a/managedkafka/connect/connectors/pause_connector.go
+++ b/managedkafka/connect/connectors/pause_connector.go
@@ -1,0 +1,53 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectors
+
+// [START managedkafka_pause_connector]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/managedkafka/apiv1/managedkafkapb"
+	"google.golang.org/api/option"
+
+	managedkafka "cloud.google.com/go/managedkafka/apiv1"
+)
+
+func pauseConnector(w io.Writer, projectID, region, connectClusterID, connectorID string, opts ...option.ClientOption) error {
+	// projectID := "my-project-id"
+	// region := "us-central1"
+	// connectClusterID := "my-connect-cluster"
+	// connectorID := "my-connector"
+	ctx := context.Background()
+	client, err := managedkafka.NewManagedKafkaConnectClient(ctx, opts...)
+	if err != nil {
+		return fmt.Errorf("managedkafka.NewManagedKafkaConnectClient got err: %w", err)
+	}
+	defer client.Close()
+
+	connectorPath := fmt.Sprintf("projects/%s/locations/%s/connectClusters/%s/connectors/%s", projectID, region, connectClusterID, connectorID)
+	req := &managedkafkapb.PauseConnectorRequest{
+		Name: connectorPath,
+	}
+	resp, err := client.PauseConnector(ctx, req)
+	if err != nil {
+		return fmt.Errorf("client.PauseConnector got err: %w", err)
+	}
+	fmt.Fprintf(w, "Paused connector: %#v\n", resp)
+	return nil
+}
+
+// [END managedkafka_pause_connector]

--- a/managedkafka/connect/connectors/restart_connector.go
+++ b/managedkafka/connect/connectors/restart_connector.go
@@ -1,0 +1,53 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectors
+
+// [START managedkafka_restart_connector]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/managedkafka/apiv1/managedkafkapb"
+	"google.golang.org/api/option"
+
+	managedkafka "cloud.google.com/go/managedkafka/apiv1"
+)
+
+func restartConnector(w io.Writer, projectID, region, connectClusterID, connectorID string, opts ...option.ClientOption) error {
+	// projectID := "my-project-id"
+	// region := "us-central1"
+	// connectClusterID := "my-connect-cluster"
+	// connectorID := "my-connector"
+	ctx := context.Background()
+	client, err := managedkafka.NewManagedKafkaConnectClient(ctx, opts...)
+	if err != nil {
+		return fmt.Errorf("managedkafka.NewManagedKafkaConnectClient got err: %w", err)
+	}
+	defer client.Close()
+
+	connectorPath := fmt.Sprintf("projects/%s/locations/%s/connectClusters/%s/connectors/%s", projectID, region, connectClusterID, connectorID)
+	req := &managedkafkapb.RestartConnectorRequest{
+		Name: connectorPath,
+	}
+	resp, err := client.RestartConnector(ctx, req)
+	if err != nil {
+		return fmt.Errorf("client.RestartConnector got err: %w", err)
+	}
+	fmt.Fprintf(w, "Restarted connector: %#v\n", resp)
+	return nil
+}
+
+// [END managedkafka_restart_connector]

--- a/managedkafka/connect/connectors/resume_connector.go
+++ b/managedkafka/connect/connectors/resume_connector.go
@@ -1,0 +1,53 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectors
+
+// [START managedkafka_resume_connector]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/managedkafka/apiv1/managedkafkapb"
+	"google.golang.org/api/option"
+
+	managedkafka "cloud.google.com/go/managedkafka/apiv1"
+)
+
+func resumeConnector(w io.Writer, projectID, region, connectClusterID, connectorID string, opts ...option.ClientOption) error {
+	// projectID := "my-project-id"
+	// region := "us-central1"
+	// connectClusterID := "my-connect-cluster"
+	// connectorID := "my-connector"
+	ctx := context.Background()
+	client, err := managedkafka.NewManagedKafkaConnectClient(ctx, opts...)
+	if err != nil {
+		return fmt.Errorf("managedkafka.NewManagedKafkaConnectClient got err: %w", err)
+	}
+	defer client.Close()
+
+	connectorPath := fmt.Sprintf("projects/%s/locations/%s/connectClusters/%s/connectors/%s", projectID, region, connectClusterID, connectorID)
+	req := &managedkafkapb.ResumeConnectorRequest{
+		Name: connectorPath,
+	}
+	resp, err := client.ResumeConnector(ctx, req)
+	if err != nil {
+		return fmt.Errorf("client.ResumeConnector got err: %w", err)
+	}
+	fmt.Fprintf(w, "Resumed connector: %#v\n", resp)
+	return nil
+}
+
+// [END managedkafka_resume_connector]

--- a/managedkafka/connect/connectors/stop_connector.go
+++ b/managedkafka/connect/connectors/stop_connector.go
@@ -1,0 +1,53 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectors
+
+// [START managedkafka_stop_connector]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/managedkafka/apiv1/managedkafkapb"
+	"google.golang.org/api/option"
+
+	managedkafka "cloud.google.com/go/managedkafka/apiv1"
+)
+
+func stopConnector(w io.Writer, projectID, region, connectClusterID, connectorID string, opts ...option.ClientOption) error {
+	// projectID := "my-project-id"
+	// region := "us-central1"
+	// connectClusterID := "my-connect-cluster"
+	// connectorID := "my-connector"
+	ctx := context.Background()
+	client, err := managedkafka.NewManagedKafkaConnectClient(ctx, opts...)
+	if err != nil {
+		return fmt.Errorf("managedkafka.NewManagedKafkaConnectClient got err: %w", err)
+	}
+	defer client.Close()
+
+	connectorPath := fmt.Sprintf("projects/%s/locations/%s/connectClusters/%s/connectors/%s", projectID, region, connectClusterID, connectorID)
+	req := &managedkafkapb.StopConnectorRequest{
+		Name: connectorPath,
+	}
+	resp, err := client.StopConnector(ctx, req)
+	if err != nil {
+		return fmt.Errorf("client.StopConnector got err: %w", err)
+	}
+	fmt.Fprintf(w, "Stopped connector: %#v\n", resp)
+	return nil
+}
+
+// [END managedkafka_stop_connector]

--- a/managedkafka/connect/connectors/update_connector.go
+++ b/managedkafka/connect/connectors/update_connector.go
@@ -1,0 +1,65 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connectors
+
+// [START managedkafka_update_connector]
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/managedkafka/apiv1/managedkafkapb"
+	"google.golang.org/api/option"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	managedkafka "cloud.google.com/go/managedkafka/apiv1"
+)
+
+func updateConnector(w io.Writer, projectID, region, connectClusterID, connectorID string, config map[string]string, opts ...option.ClientOption) error {
+	// projectID := "my-project-id"
+	// region := "us-central1"
+	// connectClusterID := "my-connect-cluster"
+	// connectorID := "my-connector"
+	// config := map[string]string{"tasks.max": "2"}
+	ctx := context.Background()
+	client, err := managedkafka.NewManagedKafkaConnectClient(ctx, opts...)
+	if err != nil {
+		return fmt.Errorf("managedkafka.NewManagedKafkaConnectClient got err: %w", err)
+	}
+	defer client.Close()
+
+	connectorPath := fmt.Sprintf("projects/%s/locations/%s/connectClusters/%s/connectors/%s", projectID, region, connectClusterID, connectorID)
+	connector := &managedkafkapb.Connector{
+		Name:    connectorPath,
+		Configs: config,
+	}
+	paths := []string{"configs"}
+	updateMask := &fieldmaskpb.FieldMask{
+		Paths: paths,
+	}
+
+	req := &managedkafkapb.UpdateConnectorRequest{
+		UpdateMask: updateMask,
+		Connector:  connector,
+	}
+	resp, err := client.UpdateConnector(ctx, req)
+	if err != nil {
+		return fmt.Errorf("client.UpdateConnector got err: %w", err)
+	}
+	fmt.Fprintf(w, "Updated connector: %#v\n", resp)
+	return nil
+}
+
+// [END managedkafka_update_connector]

--- a/managedkafka/go.mod
+++ b/managedkafka/go.mod
@@ -3,59 +3,61 @@ module github.com/GoogleCloudPlatform/golang-samples/managedkafka
 go 1.23.0
 
 require (
-	cloud.google.com/go/managedkafka v0.1.3
+	cloud.google.com/go/managedkafka v0.7.0
 	github.com/GoogleCloudPlatform/golang-samples v0.0.0-20240724083556-7f760db013b7
 	github.com/GoogleCloudPlatform/golang-samples/internal/managedkafka v0.0.0-00010101000000-000000000000
-	google.golang.org/api v0.217.0
-	google.golang.org/protobuf v1.36.3
+	google.golang.org/api v0.239.0
+	google.golang.org/protobuf v1.36.6
 )
 
 require (
-	cel.dev/expr v0.19.1 // indirect
-	cloud.google.com/go v0.118.0 // indirect
-	cloud.google.com/go/auth v0.14.0 // indirect
-	cloud.google.com/go/auth/oauth2adapt v0.2.7 // indirect
-	cloud.google.com/go/compute/metadata v0.6.0 // indirect
-	cloud.google.com/go/iam v1.3.1 // indirect
-	cloud.google.com/go/longrunning v0.6.4 // indirect
-	cloud.google.com/go/monitoring v1.23.0 // indirect
+	cel.dev/expr v0.23.0 // indirect
+	cloud.google.com/go v0.120.0 // indirect
+	cloud.google.com/go/auth v0.16.2 // indirect
+	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
+	cloud.google.com/go/compute/metadata v0.7.0 // indirect
+	cloud.google.com/go/iam v1.5.2 // indirect
+	cloud.google.com/go/longrunning v0.6.7 // indirect
+	cloud.google.com/go/monitoring v1.24.2 // indirect
 	cloud.google.com/go/storage v1.50.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.25.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.49.0 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.49.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.27.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.50.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.50.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/cncf/xds/go v0.0.0-20250121191232-2f005788dc42 // indirect
-	github.com/envoyproxy/go-control-plane/envoy v1.32.3 // indirect
-	github.com/envoyproxy/protoc-gen-validate v1.1.0 // indirect
+	github.com/cncf/xds/go v0.0.0-20250326154945-ae57f3c0d45f // indirect
+	github.com/envoyproxy/go-control-plane/envoy v1.32.4 // indirect
+	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
-	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
+	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
+	github.com/googleapis/gax-go/v2 v2.14.2 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect
+	github.com/zeebo/errs v1.4.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/contrib/detectors/gcp v1.34.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.59.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.59.0 // indirect
-	go.opentelemetry.io/otel v1.34.0 // indirect
-	go.opentelemetry.io/otel/metric v1.34.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.34.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.34.0 // indirect
-	go.opentelemetry.io/otel/trace v1.34.0 // indirect
-	golang.org/x/crypto v0.32.0 // indirect
-	golang.org/x/net v0.34.0 // indirect
-	golang.org/x/oauth2 v0.25.0 // indirect
-	golang.org/x/sync v0.10.0 // indirect
-	golang.org/x/sys v0.29.0 // indirect
-	golang.org/x/text v0.21.0 // indirect
-	golang.org/x/time v0.9.0 // indirect
-	google.golang.org/genproto v0.0.0-20250115164207-1a7da9e5054f // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20250115164207-1a7da9e5054f // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f // indirect
-	google.golang.org/grpc v1.69.4 // indirect
+	go.opentelemetry.io/contrib/detectors/gcp v1.35.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
+	go.opentelemetry.io/otel v1.36.0 // indirect
+	go.opentelemetry.io/otel/metric v1.36.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.36.0 // indirect
+	go.opentelemetry.io/otel/sdk/metric v1.36.0 // indirect
+	go.opentelemetry.io/otel/trace v1.36.0 // indirect
+	golang.org/x/crypto v0.39.0 // indirect
+	golang.org/x/net v0.41.0 // indirect
+	golang.org/x/oauth2 v0.30.0 // indirect
+	golang.org/x/sync v0.15.0 // indirect
+	golang.org/x/sys v0.33.0 // indirect
+	golang.org/x/text v0.26.0 // indirect
+	golang.org/x/time v0.12.0 // indirect
+	google.golang.org/genproto v0.0.0-20250505200425-f936aa4a68b2 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20250603155806-513f23925822 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250603155806-513f23925822 // indirect
+	google.golang.org/grpc v1.73.0 // indirect
 )
 
 replace github.com/GoogleCloudPlatform/golang-samples/internal/managedkafka => ../internal/managedkafka/


### PR DESCRIPTION
Adds code examples for Managed Kafka Connect (MKC) clusters and connectors

* Managed Kafka Connect Go Code Samples
* Adds fake client for testing Connect clusters

## Description

Fixes https://buganizer.corp.google.com/issues/430087669

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [X] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [X] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [X] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [X] Please **merge** this PR for me once it is approved
