### PR TITLE
Update save_data_batch_writes.go

### DIFF
--- a/firestore/save_data_batch_writes.go
+++ b/firestore/save_data_batch_writes.go
@@ -24,7 +24,7 @@ import (
 )
 
 func batchWrite(ctx context.Context, client *firestore.Client) error {
-	// Get a new write batch.
+	// Get a new write bulk.
 	batch := client.BulkWriter(ctx)
 
 	// Set the value of "NYC".
@@ -43,14 +43,10 @@ func batchWrite(ctx context.Context, client *firestore.Client) error {
 	laRef := client.Collection("cities").Doc("LA")
 	batch.Delete(laRef)
 
-	// Commit the batch.
-	_, err := batch.Commit(ctx)
-	if err != nil {
-		// Handle any errors in an appropriate way, such as returning them.
-		log.Printf("An error has occurred: %s", err)
-	}
-
-	return err
+	// Flush the bulk.
+	batch.Flush()
+	
+	return nil
 }
 
 // [END firestore_data_batch_writes]


### PR DESCRIPTION
client.Batch() is deprecated: https://pkg.go.dev/cloud.google.com/go/firestore#Client.Batch

Instead client.BulkWriter() should be documented: https://pkg.go.dev/cloud.google.com/go/firestore#Client.BulkWriter

## Description

Fixes # b/255272655

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] Please **merge** this PR for me once it is approved
