### PR TITLE
chore: allow .jj repos in badfiles check

### DIFF
--- a/badfiles_test.go
+++ b/badfiles_test.go
@@ -57,6 +57,9 @@ var allowList = []string{
 	".gitignore",
 	"**/.gitkeep",
 
+	// Jujutsu repo files (for local https://jj-vcs.github.io/ users)
+	".jj/**",
+
 	// Primarily ML APIs.
 	"**/testdata/**/*.jpg",
 	"**/testdata/**/*.wav",


### PR DESCRIPTION
## Description

Needed to allow local test runs when using [Jujutsu VCS](https://jj-vcs.github.io/).

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] Please **merge** this PR for me once it is approved
