### PR TITLE
chore: bump supported Go versions from (1.23, 1.24) to (1.24, 1.25)

### DIFF
--- a/aiplatform/go.mod
+++ b/aiplatform/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/aiplatform
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/aiplatform v1.70.0

--- a/appengine/go.mod
+++ b/appengine/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/appengine
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/cloudtasks v1.13.3

--- a/appengine/go11x/cloudsql/go.mod
+++ b/appengine/go11x/cloudsql/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/appengine/go11x/cloudsql
 
-go 1.23.0
+go 1.24.0
 
 require github.com/go-sql-driver/mysql v1.8.1
 

--- a/appengine/go11x/helloworld/app.yaml
+++ b/appengine/go11x/helloworld/app.yaml
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: go123
+runtime: go124

--- a/appengine/go11x/helloworld/go.mod
+++ b/appengine/go11x/helloworld/go.mod
@@ -1,3 +1,3 @@
 module github.com/GoogleCloudPlatform/appengine/go11x/helloworld
 
-go 1.23.0
+go 1.24.0

--- a/appengine/go11x/tasks/handle_task/Dockerfile
+++ b/appengine/go11x/tasks/handle_task/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/appengine/go11x/tasks/handle_task/Dockerfile
+++ b/appengine/go11x/tasks/handle_task/Dockerfile
@@ -1,7 +1,21 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Use the offical Go image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.23 as builder
+FROM golang:1.24 as builder
 
 # Copy local code to the container image.
 RUN mkdir /app

--- a/appengine/go11x/tasks/handle_task/go.mod
+++ b/appengine/go11x/tasks/handle_task/go.mod
@@ -1,3 +1,3 @@
 module github.com/GoogleCloudPlatform/appengine/go11x/tasks/handle_task
 
-go 1.23.0
+go 1.24.0

--- a/appengine/go11x/warmup/go.mod
+++ b/appengine/go11x/warmup/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/appengine/go11x/warmup
 
-go 1.23.0
+go 1.24.0
 
 require cloud.google.com/go/storage v1.50.0
 

--- a/appengine_flexible/analytics/go.mod
+++ b/appengine_flexible/analytics/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/appengine_flexible/analytics
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/gofrs/uuid v4.4.0+incompatible

--- a/appengine_flexible/datastore/go.mod
+++ b/appengine_flexible/datastore/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/appengine_flexible/datastore
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/datastore v1.20.0

--- a/appengine_flexible/go115_and_earlier/go.mod
+++ b/appengine_flexible/go115_and_earlier/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/appengine_flexible/go115_and_earlier
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/datastore v1.20.0

--- a/appengine_flexible/helloworld/app.yaml
+++ b/appengine_flexible/helloworld/app.yaml
@@ -17,7 +17,7 @@ env: flex
 
 runtime_config:
   operating_system: 'ubuntu22'
-  runtime_version: 1.23
+  runtime_version: 1.24
 # This sample incurs costs to run on the App Engine flexible environment. 
 # The settings below are to reduce costs during testing and are not appropriate
 # for production use. For more information, see:

--- a/appengine_flexible/helloworld/go.mod
+++ b/appengine_flexible/helloworld/go.mod
@@ -1,3 +1,3 @@
 module github.com/GoogleCloudPlatform/appengine_flexible/helloworld
 
-go 1.23.0
+go 1.24.0

--- a/appengine_flexible/pubsub/go.mod
+++ b/appengine_flexible/pubsub/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/appengine_flexible/pubsub
 
-go 1.23.0
+go 1.24.0
 
 require cloud.google.com/go/pubsub v1.45.3
 

--- a/appengine_flexible/redis/go.mod
+++ b/appengine_flexible/redis/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/appengine_flexible/redis
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/gomodule/redigo v2.0.0+incompatible

--- a/appengine_flexible/static_files/go.mod
+++ b/appengine_flexible/static_files/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/appengine_flexible/staticfiles
 
-go 1.23.0
+go 1.24.0
 
 require google.golang.org/appengine v1.6.8
 

--- a/appengine_flexible/storage/go.mod
+++ b/appengine_flexible/storage/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/appengine_flexible/storage
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/storage v1.50.0

--- a/appengine_flexible/websockets/go.mod
+++ b/appengine_flexible/websockets/go.mod
@@ -1,5 +1,5 @@
 module github.com/GoogleCloudPlatform/golang-samples/appengine_flexible/websockets
 
-go 1.23.0
+go 1.24.0
 
 require github.com/gorilla/websocket v1.5.3

--- a/asset/go.mod
+++ b/asset/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/asset
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/asset v1.20.4

--- a/auth/go.mod
+++ b/auth/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/auth
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/pubsub v1.45.3

--- a/automl/go.mod
+++ b/automl/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/automl
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/automl v1.14.4

--- a/batch/go.mod
+++ b/batch/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/batch
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/batch v1.12.2

--- a/bigquery/go.mod
+++ b/bigquery/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/bigquery
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go v0.121.3

--- a/bigtable/go.mod
+++ b/bigtable/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/bigtable
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/bigtable v1.34.0

--- a/cdn/go.mod
+++ b/cdn/go.mod
@@ -1,3 +1,3 @@
 module github.com/GoogleCloudPlatform/golang-samples/cdn
 
-go 1.23.0
+go 1.24.0

--- a/cloudsql/mysql/database-sql/Dockerfile
+++ b/cloudsql/mysql/database-sql/Dockerfile
@@ -15,7 +15,7 @@
 # Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.23-bookworm as builder
+FROM golang:1.24-bookworm as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/cloudsql/mysql/database-sql/go.mod
+++ b/cloudsql/mysql/database-sql/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/cloudsql/mysql/database-sql
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.14.1

--- a/cloudsql/postgres/database-sql/Dockerfile
+++ b/cloudsql/postgres/database-sql/Dockerfile
@@ -15,7 +15,7 @@
 # Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.23-bookworm as builder
+FROM golang:1.24-bookworm as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/cloudsql/postgres/database-sql/go.mod
+++ b/cloudsql/postgres/database-sql/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/cloudsql/postgres/database-sql
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.14.1

--- a/cloudsql/sqlserver/database-sql/Dockerfile
+++ b/cloudsql/sqlserver/database-sql/Dockerfile
@@ -15,7 +15,7 @@
 # Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.23-bookworm as builder
+FROM golang:1.24-bookworm as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/cloudsql/sqlserver/database-sql/go.mod
+++ b/cloudsql/sqlserver/database-sql/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/cloudsql/sqlserver/database-sql
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/cloudsqlconn v1.14.1

--- a/compute/firewall/firewall_test.go
+++ b/compute/firewall/firewall_test.go
@@ -66,7 +66,7 @@ func TestFirewallSnippets(t *testing.T) {
 	}
 
 	if firewallBefore.GetPriority() != 1000 {
-		t.Errorf(fmt.Sprintf("Got: %q; want %q", firewallBefore.GetPriority(), 1000))
+		t.Errorf("Got: %q; want %q", firewallBefore.GetPriority(), 1000)
 	}
 
 	var newFirewallPriority int32 = 500
@@ -85,7 +85,7 @@ func TestFirewallSnippets(t *testing.T) {
 	}
 
 	if firewallAfter.GetPriority() != newFirewallPriority {
-		t.Errorf(fmt.Sprintf("Got: %q; want %q", firewallAfter.GetPriority(), newFirewallPriority))
+		t.Errorf("Got: %q; want %q", firewallAfter.GetPriority(), newFirewallPriority)
 	}
 
 	buf.Reset()

--- a/compute/go.mod
+++ b/compute/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/compute
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/compute v1.31.1

--- a/compute/quickstart/go.mod
+++ b/compute/quickstart/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/compute/quickstart/exec
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/compute/usage_export_test.go
+++ b/compute/usage_export_test.go
@@ -102,10 +102,10 @@ func TestUsageExportSnippets(t *testing.T) {
 	usageExportLocation := project.GetUsageExportLocation()
 
 	if usageExportLocation.GetBucketName() != bucketName {
-		t.Errorf(fmt.Sprintf("Got: %s; want %s", *usageExportLocation.BucketName, bucketName))
+		t.Errorf("Got: %s; want %s", *usageExportLocation.BucketName, bucketName)
 	}
 	if usageExportLocation.GetReportNamePrefix() != "" {
-		t.Errorf(fmt.Sprintf("Got: %s; want %q", *usageExportLocation.BucketName, ""))
+		t.Errorf("Got: %s; want %q", *usageExportLocation.BucketName, "")
 	}
 
 	buf.Reset()

--- a/connectgateway/go.mod
+++ b/connectgateway/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/connectgateway
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/gkeconnect v0.12.4

--- a/container_registry/go.mod
+++ b/container_registry/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/container_registry
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/containeranalysis v0.13.3

--- a/datacatalog/go.mod
+++ b/datacatalog/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/datacatalog
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/bigquery v1.69.0

--- a/dataflow/go.mod
+++ b/dataflow/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/dataflow
 
-go 1.23.0
+go 1.24.0
 
 require github.com/apache/beam/sdks/v2 v2.57.0
 

--- a/dataproc/go.mod
+++ b/dataproc/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/dataproc
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/dataproc v1.12.0

--- a/dataproc/quickstart/quickstart_test.go
+++ b/dataproc/quickstart/quickstart_test.go
@@ -64,7 +64,7 @@ func setup(t *testing.T, projectID string) {
 
 	w := obj.NewWriter(ctx)
 
-	if _, err := fmt.Fprintf(w, code); err != nil {
+	if _, err := fmt.Fprint(w, code); err != nil {
 		if err2 := w.Close(); err != nil {
 			t.Errorf("Error writing to file and closing it: %v", err2)
 		}

--- a/datastore/go.mod
+++ b/datastore/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/datastore
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/datastore v1.20.0

--- a/dialogflow/go.mod
+++ b/dialogflow/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/dialogflow
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/dialogflow v1.65.0

--- a/dlp/go.mod
+++ b/dlp/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/dlp
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/bigquery v1.65.0

--- a/dlp/snippets/inspect/inspect_with_stored_infotype_test.go
+++ b/dlp/snippets/inspect/inspect_with_stored_infotype_test.go
@@ -37,7 +37,7 @@ func TestInspectWithStoredInfotype(t *testing.T) {
 	}
 	defer client.Close()
 	outputBucketPathForStoredInfotype := testutil.CreateTestBucket(ctx, t, client, tc.ProjectID, testPrefix)
-	outputPath := fmt.Sprintf("gs://" + outputBucketPathForStoredInfotype + "/")
+	outputPath := fmt.Sprintf("gs://%s/", outputBucketPathForStoredInfotype)
 
 	infoTypeId, err := createStoredInfoTypeForTesting(t, tc.ProjectID, outputPath)
 	if err != nil {

--- a/dlp/snippets/metadata/create_stored_infotype_test.go
+++ b/dlp/snippets/metadata/create_stored_infotype_test.go
@@ -34,7 +34,7 @@ func TestCreateStoredInfoType(t *testing.T) {
 	defer client.Close()
 
 	bucketName := testutil.CreateTestBucket(ctx, t, client, tc.ProjectID, bucket_prefix)
-	outputPath := fmt.Sprintf("gs://" + bucketName + "/")
+	outputPath := fmt.Sprintf("gs://%s/", bucketName)
 	var buf bytes.Buffer
 
 	if err := createStoredInfoType(&buf, tc.ProjectID, outputPath); err != nil {

--- a/dlp/snippets/metadata/update_stored_infotype_test.go
+++ b/dlp/snippets/metadata/update_stored_infotype_test.go
@@ -37,7 +37,7 @@ func TestUpdateStoredInfoType(t *testing.T) {
 	defer client.Close()
 	outputBucket := testutil.CreateTestBucket(ctx, t, client, tc.ProjectID, bucket_prefix)
 
-	outputPath := fmt.Sprintf("gs://" + outputBucket + "/")
+	outputPath := fmt.Sprintf("gs://%s/", outputBucket)
 
 	bucketName := testutil.CreateTestBucket(ctx, t, client, tc.ProjectID, bucket_prefix)
 

--- a/dlp/snippets/template/create_test.go
+++ b/dlp/snippets/template/create_test.go
@@ -38,6 +38,6 @@ func TestCreateTemplate(t *testing.T) {
 	if got, want := buf.String(), "Successfully created inspect template"; !strings.Contains(got, want) {
 		t.Errorf("createInspectTemplate got\n----\n%v\n----\nWant to contain:\n----\n%v\n----", got, want)
 	}
-	fullID := fmt.Sprintf("projects/" + tc.ProjectID + "/locations/global/inspectTemplates/" + templateID)
+	fullID := fmt.Sprintf("projects/%s/locations/global/inspectTemplates/%s", tc.ProjectID, templateID)
 	defer cleeanUpTemplates(t, tc.ProjectID, fullID)
 }

--- a/dlp/snippets/template/delete_test.go
+++ b/dlp/snippets/template/delete_test.go
@@ -36,7 +36,7 @@ func TestDeleteTemplate(t *testing.T) {
 		t.Fatalf("createInspectTemplate: %v", err)
 	}
 
-	fullID := fmt.Sprintf("projects/" + tc.ProjectID + "/locations/global/inspectTemplates/" + templateID)
+	fullID := fmt.Sprintf("projects/%s/locations/global/inspectTemplates/%s", tc.ProjectID, templateID)
 
 	if err := deleteInspectTemplate(&buf, fullID); err != nil {
 		t.Fatalf("deleteInspectTemplate: %v", err)

--- a/dlp/snippets/template/list_test.go
+++ b/dlp/snippets/template/list_test.go
@@ -42,6 +42,6 @@ func TestListTemplate(t *testing.T) {
 	if got := buf.String(); !strings.Contains(got, templateID) {
 		t.Errorf("listInspectTemplates got\n----\n%v\n----\nWant to contain:\n----\n%v\n----", got, templateID)
 	}
-	fullID := fmt.Sprintf("projects/" + tc.ProjectID + "/locations/global/inspectTemplates/" + templateID)
+	fullID := fmt.Sprintf("projects/%s/locations/global/inspectTemplates/%s", tc.ProjectID, templateID)
 	defer cleeanUpTemplates(t, tc.ProjectID, fullID)
 }

--- a/dlp/snippets/trigger/create_test.go
+++ b/dlp/snippets/trigger/create_test.go
@@ -39,6 +39,6 @@ func TestCreateTrigger(t *testing.T) {
 		t.Errorf("createTrigger got\n----\n%v\n----\nWant to contain:\n----\n%v\n----", got, want)
 	}
 
-	fullID := fmt.Sprintf("projects/" + tc.ProjectID + "/locations/global/jobTriggers/" + triggerID)
+	fullID := fmt.Sprintf("projects/%s/locations/global/jobTriggers/%s", tc.ProjectID, triggerID)
 	cleanUpTrigger(t, tc.ProjectID, fullID)
 }

--- a/dlp/snippets/trigger/delete_test.go
+++ b/dlp/snippets/trigger/delete_test.go
@@ -36,7 +36,7 @@ func TestDeleteTrigger(t *testing.T) {
 		t.Fatalf("createTrigger: %v", err)
 	}
 
-	fullID := fmt.Sprintf("projects/" + tc.ProjectID + "/locations/global/jobTriggers/" + triggerID)
+	fullID := fmt.Sprintf("projects/%s/locations/global/jobTriggers/%s", tc.ProjectID, triggerID)
 
 	if err := deleteTrigger(&buf, fullID); err != nil {
 		t.Errorf("deleteTrigger: %v", err)

--- a/dlp/snippets/trigger/list_test.go
+++ b/dlp/snippets/trigger/list_test.go
@@ -36,7 +36,7 @@ func TestListTrigger(t *testing.T) {
 		t.Fatalf("createTrigger: %v", err)
 	}
 
-	fullID := fmt.Sprintf("projects/" + tc.ProjectID + "/locations/global/jobTriggers/" + triggerID)
+	fullID := fmt.Sprintf("projects/%s/locations/global/jobTriggers/%s", tc.ProjectID, triggerID)
 
 	if err := listTriggers(&buf, tc.ProjectID); err != nil {
 		t.Errorf("listTriggers: %v", err)

--- a/dlp/snippets/trigger/update_test.go
+++ b/dlp/snippets/trigger/update_test.go
@@ -36,7 +36,7 @@ func TestUpdateTrigger(t *testing.T) {
 		t.Fatalf("createTrigger: %v", err)
 	}
 
-	fullID := fmt.Sprintf("projects/" + tc.ProjectID + "/locations/global/jobTriggers/" + triggerID)
+	fullID := fmt.Sprintf("projects/%s/locations/global/jobTriggers/%s", tc.ProjectID, triggerID)
 
 	if err := updateTrigger(&buf, fullID); err != nil {
 		t.Errorf("UpdateTrigger: %v", err)

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/docs
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/GoogleCloudPlatform/golang-samples v0.0.0-20240724083556-7f760db013b7

--- a/documentai/go.mod
+++ b/documentai/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/documentai
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/documentai v1.35.1

--- a/endpoints/go.mod
+++ b/endpoints/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/endpoints
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/golang/protobuf v1.5.4

--- a/eventarc/audit_iam/go.mod
+++ b/eventarc/audit_iam/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/eventarc/audit_iam
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/cloudevents/sdk-go/v2 v2.15.2

--- a/eventarc/audit_iam/main.go
+++ b/eventarc/audit_iam/main.go
@@ -64,7 +64,7 @@ func HandleCloudEvent(w http.ResponseWriter, r *http.Request) {
 	keypath := logentry.ProtoPayload.GetResponse().AsMap()["name"]
 
 	s := fmt.Sprintf("New Service Account Key created for %s by %s: %v", principal, actor, keypath)
-	log.Printf(s)
+	log.Print(s)
 	fmt.Fprintln(w, s)
 }
 

--- a/eventarc/audit_storage/Dockerfile
+++ b/eventarc/audit_storage/Dockerfile
@@ -17,7 +17,7 @@
 # Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.23-bookworm as builder
+FROM golang:1.24-bookworm as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/eventarc/audit_storage/go.mod
+++ b/eventarc/audit_storage/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/eventarc/audit_storage
 
-go 1.23.0
+go 1.24.0
 
 require github.com/cloudevents/sdk-go/v2 v2.15.2
 

--- a/eventarc/generic/Dockerfile
+++ b/eventarc/generic/Dockerfile
@@ -16,7 +16,7 @@
 # Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.23-bookworm as builder
+FROM golang:1.24-bookworm as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/eventarc/generic/go.mod
+++ b/eventarc/generic/go.mod
@@ -1,3 +1,3 @@
 module github.com/GoogleCloudPlatform/golang-samples/eventarc/generic
 
-go 1.23.0
+go 1.24.0

--- a/eventarc/pubsub/Dockerfile
+++ b/eventarc/pubsub/Dockerfile
@@ -15,7 +15,7 @@
 # Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.23-bookworm as builder
+FROM golang:1.24-bookworm as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/eventarc/pubsub/go.mod
+++ b/eventarc/pubsub/go.mod
@@ -1,3 +1,3 @@
 module github.com/GoogleCloudPlatform/golang-samples/eventarc/pubsub
 
-go 1.23.0
+go 1.24.0

--- a/eventarc/pubsub/main.go
+++ b/eventarc/pubsub/main.go
@@ -49,7 +49,7 @@ func HelloEventsPubSub(w http.ResponseWriter, r *http.Request) {
 		name = "World"
 	}
 	s := fmt.Sprintf("Hello, %s! ID: %s", name, string(r.Header.Get("Ce-Id")))
-	log.Printf(s)
+	log.Print(s)
 	fmt.Fprintln(w, s)
 }
 

--- a/eventarc/storage_handler/go.mod
+++ b/eventarc/storage_handler/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/eventarc/storage_handler
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/cloudevents/sdk-go/v2 v2.15.2

--- a/eventarc/testing/go.mod
+++ b/eventarc/testing/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/eventarc/testing
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/GoogleCloudPlatform/golang-samples v0.0.0-20240724083556-7f760db013b7

--- a/firestore/go.mod
+++ b/firestore/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/firestore
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/firestore v1.18.0

--- a/functions/bigtable/go.mod
+++ b/functions/bigtable/go.mod
@@ -55,4 +55,4 @@ require (
 	google.golang.org/protobuf v1.36.3 // indirect
 )
 
-go 1.23.0
+go 1.24.0

--- a/functions/codelabs/gopher/go.mod
+++ b/functions/codelabs/gopher/go.mod
@@ -1,3 +1,3 @@
 module github.com/GoogleCloudPlatform/golang-samples/functions/codelabs/gopher
 
-go 1.23.0
+go 1.24.0

--- a/functions/console_snippets/firebase_auth/go.mod
+++ b/functions/console_snippets/firebase_auth/go.mod
@@ -2,4 +2,4 @@ module github.com/GoogleCloudPlatform/golang-samples/functions/console_snippets/
 
 require cloud.google.com/go/functions v1.19.3
 
-go 1.23.0
+go 1.24.0

--- a/functions/console_snippets/firebase_rtdb/go.mod
+++ b/functions/console_snippets/firebase_rtdb/go.mod
@@ -2,4 +2,4 @@ module github.com/GoogleCloudPlatform/golang-samples/functions/console_snippets/
 
 require cloud.google.com/go/functions v1.19.3
 
-go 1.23.0
+go 1.24.0

--- a/functions/console_snippets/firestore/go.mod
+++ b/functions/console_snippets/firestore/go.mod
@@ -2,4 +2,4 @@ module github.com/GoogleCloudPlatform/golang-samples/functions/console_snippets/
 
 require cloud.google.com/go/functions v1.19.3
 
-go 1.23.0
+go 1.24.0

--- a/functions/console_snippets/google_analytics/go.mod
+++ b/functions/console_snippets/google_analytics/go.mod
@@ -2,4 +2,4 @@ module github.com/GoogleCloudPlatform/golang-samples/functions/console_snippets/
 
 require cloud.google.com/go/functions v1.19.3
 
-go 1.23.0
+go 1.24.0

--- a/functions/firebase/hello/go.mod
+++ b/functions/firebase/hello/go.mod
@@ -2,4 +2,4 @@ module github.com/GoogleCloudPlatform/golang-samples/functions/firebase/hello
 
 require cloud.google.com/go/functions v1.19.3
 
-go 1.23.0
+go 1.24.0

--- a/functions/firebase/upper/go.mod
+++ b/functions/firebase/upper/go.mod
@@ -59,4 +59,4 @@ require (
 	google.golang.org/protobuf v1.36.3 // indirect
 )
 
-go 1.23.0
+go 1.24.0

--- a/functions/functionsv2/firebase/hellofirestore/go.mod
+++ b/functions/functionsv2/firebase/hellofirestore/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/functions/functionsv2/firebase/hellofirestore
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/GoogleCloudPlatform/functions-framework-go v1.8.1

--- a/functions/functionsv2/firebase/remoteconfig/go.mod
+++ b/functions/functionsv2/firebase/remoteconfig/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/functions/functionsv2/firebase/remoteconfig
 
-go 1.23.0
+go 1.24.0
 
 require github.com/GoogleCloudPlatform/functions-framework-go v1.8.1
 

--- a/functions/functionsv2/firebase/rtdb/go.mod
+++ b/functions/functionsv2/firebase/rtdb/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/functions/functionsv2/firebase/rtdb
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/GoogleCloudPlatform/functions-framework-go v1.8.1

--- a/functions/functionsv2/firebase/upper/go.mod
+++ b/functions/functionsv2/firebase/upper/go.mod
@@ -70,4 +70,4 @@ require (
 	google.golang.org/protobuf v1.36.3
 )
 
-go 1.23.0
+go 1.24.0

--- a/functions/functionsv2/helloauditlog/go.mod
+++ b/functions/functionsv2/helloauditlog/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/functions/functionsv2/helloauditlog
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/GoogleCloudPlatform/functions-framework-go v1.8.1

--- a/functions/functionsv2/hellopubsub/go.mod
+++ b/functions/functionsv2/hellopubsub/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/functions/functionsv2/hellopubsub
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/GoogleCloudPlatform/functions-framework-go v1.8.1

--- a/functions/functionsv2/hellostorage/go.mod
+++ b/functions/functionsv2/hellostorage/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/functions/functionsv2/hellostorage
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/GoogleCloudPlatform/functions-framework-go v1.8.1

--- a/functions/functionsv2/helloworld/go.mod
+++ b/functions/functionsv2/helloworld/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/functions/functionsv2/helloworld
 
-go 1.23.0
+go 1.24.0
 
 require github.com/GoogleCloudPlatform/functions-framework-go v1.8.1
 

--- a/functions/functionsv2/imagemagick/go.mod
+++ b/functions/functionsv2/imagemagick/go.mod
@@ -64,4 +64,4 @@ require (
 	google.golang.org/grpc v1.69.4 // indirect
 )
 
-go 1.23.0
+go 1.24.0

--- a/functions/functionsv2/label_gce_instance/go.mod
+++ b/functions/functionsv2/label_gce_instance/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/functions/functionsv2/label_gce_instance
 
-go 1.23.0
+go 1.24.0
 
 require github.com/cloudevents/sdk-go/v2 v2.15.2
 

--- a/functions/functionsv2/log/go.mod
+++ b/functions/functionsv2/log/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/functions/functionsv2/log
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/GoogleCloudPlatform/functions-framework-go v1.8.1

--- a/functions/functionsv2/ocr/app/go.mod
+++ b/functions/functionsv2/ocr/app/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/functions/functionsv2/ocr/app
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/pubsub v1.45.3

--- a/functions/functionsv2/response_streaming/go.mod
+++ b/functions/functionsv2/response_streaming/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/functions/functionsv2/response_streaming/responsestreaming
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/bigquery v1.65.0

--- a/functions/functionsv2/slack/go.mod
+++ b/functions/functionsv2/slack/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/functions/functionsv2/slack
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/GoogleCloudPlatform/functions-framework-go v1.8.1

--- a/functions/functionsv2/tips/go.mod
+++ b/functions/functionsv2/tips/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/functions/functionsv2/tips
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/GoogleCloudPlatform/functions-framework-go v1.8.1

--- a/functions/functionsv2/tips/infinite_retries/go.mod
+++ b/functions/functionsv2/tips/infinite_retries/go.mod
@@ -18,4 +18,4 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 )
 
-go 1.23.0
+go 1.24.0

--- a/functions/go.mod
+++ b/functions/go.mod
@@ -1,3 +1,3 @@
 module github.com/GoogleCloudPlatform/golang-samples/functions
 
-go 1.23.0
+go 1.24.0

--- a/functions/helloworld/go.mod
+++ b/functions/helloworld/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/functions/helloworld
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/functions v1.19.3

--- a/functions/http/go.mod
+++ b/functions/http/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/functions/http
 
-go 1.23.0
+go 1.24.0
 
 require github.com/GoogleCloudPlatform/functions-framework-go v1.8.1
 

--- a/functions/imagemagick/go.mod
+++ b/functions/imagemagick/go.mod
@@ -55,4 +55,4 @@ require (
 	google.golang.org/protobuf v1.36.3 // indirect
 )
 
-go 1.23.0
+go 1.24.0

--- a/functions/log/go.mod
+++ b/functions/log/go.mod
@@ -1,3 +1,3 @@
 module github.com/GoogleCloudPlatform/golang-samples/functions/log
 
-go 1.23.0
+go 1.24.0

--- a/functions/memorystore/redis/go.mod
+++ b/functions/memorystore/redis/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/functions/memorystore/redis
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/GoogleCloudPlatform/functions-framework-go v1.8.1

--- a/functions/ocr/app/go.mod
+++ b/functions/ocr/app/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/functions/ocr/app
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/pubsub v1.45.3

--- a/functions/security/go.mod
+++ b/functions/security/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/functions/security
 
-go 1.23.0
+go 1.24.0
 
 require google.golang.org/api v0.217.0
 

--- a/functions/slack/go.mod
+++ b/functions/slack/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/functions/slack
 
-go 1.23.0
+go 1.24.0
 
 require google.golang.org/api v0.217.0
 

--- a/functions/spanner/go.mod
+++ b/functions/spanner/go.mod
@@ -65,4 +65,4 @@ require (
 	google.golang.org/protobuf v1.36.3 // indirect
 )
 
-go 1.23.0
+go 1.24.0

--- a/functions/tips/go.mod
+++ b/functions/tips/go.mod
@@ -60,4 +60,4 @@ require (
 	google.golang.org/protobuf v1.36.3 // indirect
 )
 
-go 1.23.0
+go 1.24.0

--- a/functions/tips/infinite_retries/go.mod
+++ b/functions/tips/infinite_retries/go.mod
@@ -2,4 +2,4 @@ module github.com/GoogleCloudPlatform/golang-samples/functions/tips/infinite_ret
 
 require cloud.google.com/go/functions v1.19.3
 
-go 1.23.0
+go 1.24.0

--- a/functions/typed/greeting/go.mod
+++ b/functions/typed/greeting/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/functions/typed/greeting
 
-go 1.23.0
+go 1.24.0
 
 require github.com/GoogleCloudPlatform/functions-framework-go v1.8.1
 

--- a/genai/go.mod
+++ b/genai/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/genai
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/GoogleCloudPlatform/golang-samples v0.0.0-20250201051611-5fb145d1e974

--- a/getting-started/authenticating-users/go.mod
+++ b/getting-started/authenticating-users/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/getting-started/authenticating-users
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/compute/metadata v0.6.0

--- a/getting-started/background/go.mod
+++ b/getting-started/background/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/getting-started/background
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/firestore v1.18.0

--- a/getting-started/bookshelf/go.mod
+++ b/getting-started/bookshelf/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/getting-started/bookshelf
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/errorreporting v0.3.2

--- a/getting-started/bookshelf/main.go
+++ b/getting-started/bookshelf/main.go
@@ -294,7 +294,7 @@ func (b *Bookshelf) sendLog(w http.ResponseWriter, r *http.Request) *appError {
 func (b *Bookshelf) sendError(w http.ResponseWriter, r *http.Request) *appError {
 	msg := `<html>Logging an error. Check <a href="http://console.cloud.google.com/errors">Error Reporting</a> (it may take a minute or two for the error to appear).</html>`
 	err := errors.New("uh oh! an error occurred")
-	return b.appErrorf(r, err, msg)
+	return b.appErrorf(r, err, "%v", msg)
 }
 
 // https://blog.golang.org/error-handling-and-go

--- a/getting-started/devflowapp/Dockerfile
+++ b/getting-started/devflowapp/Dockerfile
@@ -1,4 +1,18 @@
-FROM golang:1.23
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.24
 
 COPY devflowapp.go .
 COPY services/ /go/src/github.com/GoogleCloudPlatform/golang-samples/getting-started/devflowapp/services/

--- a/getting-started/devflowapp/Dockerfile
+++ b/getting-started/devflowapp/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/getting-started/gce/go.mod
+++ b/getting-started/gce/go.mod
@@ -1,3 +1,3 @@
 module github.com/GoogleCloudPlatform/golang-samples/getting-started/gce
 
-go 1.23.0
+go 1.24.0

--- a/getting-started/go.mod
+++ b/getting-started/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/getting-started
 
-go 1.23.0
+go 1.24.0
 
 require github.com/go-sql-driver/mysql v1.8.1
 

--- a/getting-started/sessions/go.mod
+++ b/getting-started/sessions/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/getting-started/sessions
 
-go 1.23.0
+go 1.24.0
 
 require cloud.google.com/go/firestore v1.18.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/bigquery v1.65.0

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.5
+toolchain go1.24.7
 
 use (
 	.

--- a/healthcare/go.mod
+++ b/healthcare/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/healthcare
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/GoogleCloudPlatform/golang-samples v0.0.0-20240724083556-7f760db013b7

--- a/iam/go.mod
+++ b/iam/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/iam
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/iam v1.3.1

--- a/iap/go.mod
+++ b/iap/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/iap
 
-go 1.23.0
+go 1.24.0
 
 require google.golang.org/api v0.217.0
 

--- a/internal/cloudrunci/testingapp/Dockerfile
+++ b/internal/cloudrunci/testingapp/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.23 as builder
+FROM golang:1.24 as builder
 WORKDIR /app
 COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux go build -v -o server

--- a/internal/cloudrunci/testingapp/go.mod
+++ b/internal/cloudrunci/testingapp/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/internal/cloudrunci/testingapp
 
-go 1.23.0
+go 1.24.0
 
 require github.com/GoogleCloudPlatform/golang-samples v0.0.0-20240724083556-7f760db013b7
 

--- a/internal/gomodversiontest/go.mod
+++ b/internal/gomodversiontest/go.mod
@@ -1,3 +1,3 @@
 module github.com/GoogleCloudPlatform/internal/gomodversiontest
 
-go 1.23.0
+go 1.24.0

--- a/internal/managedkafka/go.mod
+++ b/internal/managedkafka/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/internal/managedkafka
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/longrunning v0.6.4

--- a/jobs/go.mod
+++ b/jobs/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/jobs
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/talent v1.8.0

--- a/kms/go.mod
+++ b/kms/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/kms
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/kms v1.20.5

--- a/language/go.mod
+++ b/language/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/language
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/language v1.14.3

--- a/logging/go.mod
+++ b/logging/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/logging
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/logging v1.13.0

--- a/managedkafka/go.mod
+++ b/managedkafka/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/managedkafka
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/managedkafka v0.1.3

--- a/media/go.mod
+++ b/media/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/media
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/storage v1.50.0

--- a/memorystore/go.mod
+++ b/memorystore/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/memorystore/redis
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/redis v1.17.3

--- a/memorystore/redis/cloud_run_deployment/Dockerfile
+++ b/memorystore/redis/cloud_run_deployment/Dockerfile
@@ -17,7 +17,7 @@
 # Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.23-bookworm as builder
+FROM golang:1.24-bookworm as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/memorystore/redis/gke_deployment/Dockerfile
+++ b/memorystore/redis/gke_deployment/Dockerfile
@@ -1,4 +1,18 @@
-FROM golang:1.23-alpine
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.24-alpine
 
 RUN apk update && apk add git
 

--- a/memorystore/redis/gke_deployment/Dockerfile
+++ b/memorystore/redis/gke_deployment/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modelarmor/go.mod
+++ b/modelarmor/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/modelarmor
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/dlp v1.21.0

--- a/monitoring/go.mod
+++ b/monitoring/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/monitoring
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/monitoring v1.23.0

--- a/monitoring/snippets/monitored_resource_get.go
+++ b/monitoring/snippets/monitored_resource_get.go
@@ -37,7 +37,7 @@ func getMonitoredResource(w io.Writer, resource string) error {
 	}
 	defer c.Close()
 	req := &monitoringpb.GetMonitoredResourceDescriptorRequest{
-		Name: fmt.Sprint(resource),
+        Name: resource,
 	}
 	resp, err := c.GetMonitoredResourceDescriptor(ctx, req)
 	if err != nil {

--- a/monitoring/snippets/monitored_resource_get.go
+++ b/monitoring/snippets/monitored_resource_get.go
@@ -37,7 +37,7 @@ func getMonitoredResource(w io.Writer, resource string) error {
 	}
 	defer c.Close()
 	req := &monitoringpb.GetMonitoredResourceDescriptorRequest{
-        Name: resource,
+		Name: resource,
 	}
 	resp, err := c.GetMonitoredResourceDescriptor(ctx, req)
 	if err != nil {

--- a/monitoring/snippets/monitored_resource_get.go
+++ b/monitoring/snippets/monitored_resource_get.go
@@ -37,7 +37,7 @@ func getMonitoredResource(w io.Writer, resource string) error {
 	}
 	defer c.Close()
 	req := &monitoringpb.GetMonitoredResourceDescriptorRequest{
-		Name: fmt.Sprintf(resource),
+		Name: fmt.Sprint(resource),
 	}
 	resp, err := c.GetMonitoredResourceDescriptor(ctx, req)
 	if err != nil {

--- a/opentelemetry/instrumentation/app/Dockerfile
+++ b/opentelemetry/instrumentation/app/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/opentelemetry/instrumentation/app/Dockerfile
+++ b/opentelemetry/instrumentation/app/Dockerfile
@@ -1,4 +1,18 @@
-FROM golang:1.23
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.24
 WORKDIR /usr/src/app
 COPY go.mod go.sum ./
 RUN go mod download && go mod verify

--- a/opentelemetry/instrumentation/app/go.mod
+++ b/opentelemetry/instrumentation/app/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/opentelemetry/instrumentation/app
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/GoogleCloudPlatform/golang-samples v0.0.0-20240724083556-7f760db013b7

--- a/opentelemetry/instrumentation/app/main_test.go
+++ b/opentelemetry/instrumentation/app/main_test.go
@@ -97,7 +97,7 @@ func TestWriteTelemetry(t *testing.T) {
 	testutil.Retry(t, 2*timeoutSeconds, 500*time.Millisecond, func(r *testutil.R) {
 		resp, err := http.Get("http://localhost:8080/multi")
 		if err != nil {
-			r.Errorf(err.Error())
+			r.Errorf("%v", err.Error())
 			r.Fail()
 		} else if resp == nil {
 			r.Errorf("status code was nil")

--- a/opentelemetry/trace/go.mod
+++ b/opentelemetry/trace/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/opentelemetry/trace
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/trace v1.11.3

--- a/parametermanager/go.mod
+++ b/parametermanager/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/parametermanager
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/kms v1.21.2

--- a/privateca/go.mod
+++ b/privateca/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/privateca
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/security v1.18.3

--- a/profiler/go.mod
+++ b/profiler/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/profiler
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/cloudprofiler v0.3.4

--- a/profiler/hotapp/Dockerfile
+++ b/profiler/hotapp/Dockerfile
@@ -1,4 +1,18 @@
-FROM golang:1.23-alpine
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.24-alpine
 
 WORKDIR /go/src
 COPY ./go.mod ./

--- a/profiler/hotapp/Dockerfile
+++ b/profiler/hotapp/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/profiler/hotmid/Dockerfile
+++ b/profiler/hotmid/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine
+FROM golang:1.24-alpine
 
 WORKDIR /go/src
 COPY ./go.mod .

--- a/profiler/shakesapp/go.mod
+++ b/profiler/shakesapp/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/profiler/shakesapp
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/profiler v0.4.1

--- a/pubsub/go.mod
+++ b/pubsub/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/pubsub
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/bigquery v1.69.0

--- a/pubsublite/go.mod
+++ b/pubsublite/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/pubsublite
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/pubsub v1.45.3

--- a/routeoptimization/go.mod
+++ b/routeoptimization/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/routeoptimization
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/maps v1.17.1

--- a/run/custom-metrics/Dockerfile
+++ b/run/custom-metrics/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # [START cloudrun_mc_custom_metrics_dockerfile]
-FROM golang:1.23 as builder
+FROM golang:1.24 as builder
 WORKDIR /app
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o sample-app

--- a/run/custom-metrics/go.mod
+++ b/run/custom-metrics/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/run/custom-metrics
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/GoogleCloudPlatform/golang-samples v0.0.0-20240724083556-7f760db013b7

--- a/run/go.mod
+++ b/run/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/run
 
-go 1.23.0
+go 1.24.0
 
 require cloud.google.com/go/compute/metadata v0.6.0
 

--- a/run/grpc-ping/Dockerfile
+++ b/run/grpc-ping/Dockerfile
@@ -15,7 +15,7 @@
 # Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.23-bookworm as builder
+FROM golang:1.24-bookworm as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/run/grpc-ping/go.mod
+++ b/run/grpc-ping/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/run/grpc-ping
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/golang/protobuf v1.5.4

--- a/run/grpc-server-streaming/Dockerfile
+++ b/run/grpc-server-streaming/Dockerfile
@@ -16,7 +16,7 @@
 # Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.23-bookworm as builder
+FROM golang:1.24-bookworm as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/run/grpc-server-streaming/go.mod
+++ b/run/grpc-server-streaming/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/run/grpc-server-streaming
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/golang/protobuf v1.5.4

--- a/run/h2c/go.mod
+++ b/run/h2c/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/run/h2c
 
-go 1.23.0
+go 1.24.0
 
 require golang.org/x/net v0.38.0
 

--- a/run/hello-broken/Dockerfile
+++ b/run/hello-broken/Dockerfile
@@ -17,7 +17,7 @@
 # Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.23-bookworm as builder
+FROM golang:1.24-bookworm as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/run/hello-broken/go.mod
+++ b/run/hello-broken/go.mod
@@ -1,3 +1,3 @@
 module github.com/GoogleCloudPlatform/golang-samples/run/hello-broken
 
-go 1.23.0
+go 1.24.0

--- a/run/helloworld/Dockerfile
+++ b/run/helloworld/Dockerfile
@@ -17,7 +17,7 @@
 # Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.23-bookworm AS builder
+FROM golang:1.24-bookworm AS builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/run/helloworld/go.mod
+++ b/run/helloworld/go.mod
@@ -1,3 +1,3 @@
 module github.com/GoogleCloudPlatform/golang-samples/run/helloworld
 
-go 1.23.0
+go 1.24.0

--- a/run/image-processing/Dockerfile
+++ b/run/image-processing/Dockerfile
@@ -15,7 +15,7 @@
 # Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.23-bookworm as builder
+FROM golang:1.24-bookworm as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/run/image-processing/go.mod
+++ b/run/image-processing/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/run/image-processing
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/storage v1.50.0

--- a/run/jobs/go.mod
+++ b/run/jobs/go.mod
@@ -1,3 +1,3 @@
 module github.com/GoogleCloudPlatform/golang-samples/run/jobs
 
-go 1.23.0
+go 1.24.0

--- a/run/logging-manual/Dockerfile
+++ b/run/logging-manual/Dockerfile
@@ -15,7 +15,7 @@
 # Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.23-bookworm as builder
+FROM golang:1.24-bookworm as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/run/logging-manual/go.mod
+++ b/run/logging-manual/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/run/logging-manual
 
-go 1.23.0
+go 1.24.0
 
 require cloud.google.com/go/compute/metadata v0.6.0
 

--- a/run/markdown-preview/editor/Dockerfile
+++ b/run/markdown-preview/editor/Dockerfile
@@ -15,7 +15,7 @@
 # Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.23-bookworm as builder
+FROM golang:1.24-bookworm as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/run/markdown-preview/editor/go.mod
+++ b/run/markdown-preview/editor/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/run/markdown-preview/editor
 
-go 1.23.0
+go 1.24.0
 
 require (
 	golang.org/x/oauth2 v0.25.0

--- a/run/markdown-preview/renderer/Dockerfile
+++ b/run/markdown-preview/renderer/Dockerfile
@@ -15,7 +15,7 @@
 # Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.23-bookworm as builder
+FROM golang:1.24-bookworm as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/run/markdown-preview/renderer/go.mod
+++ b/run/markdown-preview/renderer/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/run/markdown-preview/render
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/microcosm-cc/bluemonday v1.0.27

--- a/run/pubsub/Dockerfile
+++ b/run/pubsub/Dockerfile
@@ -17,7 +17,7 @@
 # Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.23-bookworm as builder
+FROM golang:1.24-bookworm as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/run/pubsub/go.mod
+++ b/run/pubsub/go.mod
@@ -1,3 +1,3 @@
 module github.com/GoogleCloudPlatform/golang-samples/run/pubsub
 
-go 1.23.0
+go 1.24.0

--- a/run/service-auth/go.mod
+++ b/run/service-auth/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/run/service-auth
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/GoogleCloudPlatform/golang-samples v0.0.0-20250414185348-49adefec1b88

--- a/run/sigterm-handler/Dockerfile
+++ b/run/sigterm-handler/Dockerfile
@@ -15,7 +15,7 @@
 # Use the official Go image to create a binary.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.23-bookworm as builder
+FROM golang:1.24-bookworm as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/run/sigterm-handler/go.mod
+++ b/run/sigterm-handler/go.mod
@@ -1,3 +1,3 @@
 module github.com/GoogleCloudPlatform/golang-samples/run/sigterm-handler
 
-go 1.23.0
+go 1.24.0

--- a/run/system_package/Dockerfile
+++ b/run/system_package/Dockerfile
@@ -14,7 +14,7 @@
 
 # Use the offical Go image to create a build artifact.
 # https://hub.docker.com/_/golang
-FROM golang:1.23-bookworm as builder
+FROM golang:1.24-bookworm as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/run/system_package/go.mod
+++ b/run/system_package/go.mod
@@ -1,3 +1,3 @@
 module github.com/GoogleCloudPlatform/golang-samples/run/system_package
 
-go 1.23.0
+go 1.24.0

--- a/run/testing/go.mod
+++ b/run/testing/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/run/testing
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/GoogleCloudPlatform/golang-samples v0.0.0-00010101000000-000000000000

--- a/secretmanager/go.mod
+++ b/secretmanager/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/secretmanager
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/resourcemanager v1.10.6

--- a/securitycenter/go.mod
+++ b/securitycenter/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/securitycenter
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/iam v1.3.1

--- a/securitycenter/muteconfig/mute_config_test.go
+++ b/securitycenter/muteconfig/mute_config_test.go
@@ -98,7 +98,7 @@ func createSource(w io.Writer, orgId string) error {
 	if err != nil {
 		return fmt.Errorf("CreateSource: %v", err)
 	}
-	fmt.Fprintf(w, source.Name)
+	fmt.Fprint(w, source.Name)
 	return nil
 }
 

--- a/securitycenter/muteconfigv2/mute_config_test.go
+++ b/securitycenter/muteconfigv2/mute_config_test.go
@@ -98,7 +98,7 @@ func createSource(w io.Writer, orgId string) error {
 	if err != nil {
 		return fmt.Errorf("CreateSource: %w", err)
 	}
-	fmt.Fprintf(w, source.Name)
+	fmt.Fprint(w, source.Name)
 	return nil
 }
 

--- a/servicedirectory/go.mod
+++ b/servicedirectory/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/servicedirectory
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/servicedirectory v1.12.3

--- a/spanner/go.mod
+++ b/spanner/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/spanner
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go v0.120.0

--- a/spanner/opentelemetry/go.mod
+++ b/spanner/opentelemetry/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/spanner/opentelemetry
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/spanner v1.73.0

--- a/spanner/opentelemetry/tracing/go.mod
+++ b/spanner/opentelemetry/tracing/go.mod
@@ -1,6 +1,6 @@
 module tracing
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/spanner v1.73.0

--- a/speech/go.mod
+++ b/speech/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/speech
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/speech v1.26.0

--- a/speech/snippets/transcribe_diarization.go
+++ b/speech/snippets/transcribe_diarization.go
@@ -95,7 +95,7 @@ func transcribe_diarization_gcs_beta(w io.Writer) error {
 			currentSpeakerTag = wordInfo.GetSpeakerTag()
 		}
 	}
-	fmt.Fprintf(w, speakerWords.String())
+	fmt.Fprint(w, speakerWords.String())
 	return nil
 }
 

--- a/speech/snippets/transcribe_diarization_beta.go
+++ b/speech/snippets/transcribe_diarization_beta.go
@@ -98,7 +98,7 @@ func transcribe_diarization(w io.Writer) error {
 			currentSpeakerTag = wordInfo.GetSpeakerTag()
 		}
 	}
-	fmt.Fprintf(w, speakerWords.String())
+	fmt.Fprint(w, speakerWords.String())
 	return nil
 }
 

--- a/storage/go.mod
+++ b/storage/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/storage
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/iam v1.4.1

--- a/storagetransfer/go.mod
+++ b/storagetransfer/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/storagetransfer
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/iam v1.3.1

--- a/storagetransfer/storagetransfer_test.go
+++ b/storagetransfer/storagetransfer_test.go
@@ -410,7 +410,7 @@ func TestCreateEventDrivenGCSTransfer(t *testing.T) {
 
 	topic, err := pubsubClient.CreateTopic(ctx, pubSubTopicId)
 	if err != nil {
-		log.Fatal("Coudln't create pubsub topic: " + err.Error())
+        log.Fatalf("Couldn't create pubsub topic: %v", err)
 	}
 	defer topic.Delete(ctx)
 

--- a/storagetransfer/storagetransfer_test.go
+++ b/storagetransfer/storagetransfer_test.go
@@ -430,7 +430,7 @@ func TestCreateEventDrivenGCSTransfer(t *testing.T) {
 		AckDeadline: 20 * time.Second,
 	})
 	if err != nil {
-		log.Fatal("Couldn't create pubsub subscription: " + err.Error())
+        log.Fatalf("Couldn't create pubsub subscription: %v", err)
 	}
 
 	pubSubSubscriptionID := sub.String()

--- a/storagetransfer/storagetransfer_test.go
+++ b/storagetransfer/storagetransfer_test.go
@@ -416,7 +416,7 @@ func TestCreateEventDrivenGCSTransfer(t *testing.T) {
 
 	policy, err := topic.IAM().Policy(ctx)
 	if err != nil {
-		log.Fatal("Couldn't get pubsub topic policy: " + err.Error())
+        log.Fatalf("Couldn't get pubsub topic policy: %v", err)
 	}
 	policy.Add("serviceAccount:"+stsServiceAccountEmail, "roles/pubsub.subscriber")
 	if err := topic.IAM().SetPolicy(ctx, policy); err != nil {

--- a/storagetransfer/storagetransfer_test.go
+++ b/storagetransfer/storagetransfer_test.go
@@ -404,7 +404,7 @@ func TestCreateEventDrivenGCSTransfer(t *testing.T) {
 
 	pubsubClient, err := pubsub.NewClient(ctx, tc.ProjectID)
 	if err != nil {
-		log.Fatal("Coudln't create pubsub client: " + err.Error())
+        log.Fatalf("Couldn't create pubsub client: %v", err)
 	}
 	defer pubsubClient.Close()
 

--- a/storagetransfer/storagetransfer_test.go
+++ b/storagetransfer/storagetransfer_test.go
@@ -404,23 +404,23 @@ func TestCreateEventDrivenGCSTransfer(t *testing.T) {
 
 	pubsubClient, err := pubsub.NewClient(ctx, tc.ProjectID)
 	if err != nil {
-		log.Fatalf("Coudln't create pubsub client: " + err.Error())
+		log.Fatal("Coudln't create pubsub client: " + err.Error())
 	}
 	defer pubsubClient.Close()
 
 	topic, err := pubsubClient.CreateTopic(ctx, pubSubTopicId)
 	if err != nil {
-		log.Fatalf("Coudln't create pubsub topic: " + err.Error())
+		log.Fatal("Coudln't create pubsub topic: " + err.Error())
 	}
 	defer topic.Delete(ctx)
 
 	policy, err := topic.IAM().Policy(ctx)
 	if err != nil {
-		log.Fatalf("Couldn't get pubsub topic policy: " + err.Error())
+		log.Fatal("Couldn't get pubsub topic policy: " + err.Error())
 	}
 	policy.Add("serviceAccount:"+stsServiceAccountEmail, "roles/pubsub.subscriber")
 	if err := topic.IAM().SetPolicy(ctx, policy); err != nil {
-		log.Fatalf("Couldn't set pubsub topic policy: " + err.Error())
+		log.Fatal("Couldn't set pubsub topic policy: " + err.Error())
 	}
 
 	subId := testutil.UniqueBucketName("pubsubsubscription")
@@ -430,7 +430,7 @@ func TestCreateEventDrivenGCSTransfer(t *testing.T) {
 		AckDeadline: 20 * time.Second,
 	})
 	if err != nil {
-		log.Fatalf("Couldn't create pubsub subscription: " + err.Error())
+		log.Fatal("Couldn't create pubsub subscription: " + err.Error())
 	}
 
 	pubSubSubscriptionID := sub.String()

--- a/storagetransfer/storagetransfer_test.go
+++ b/storagetransfer/storagetransfer_test.go
@@ -420,7 +420,7 @@ func TestCreateEventDrivenGCSTransfer(t *testing.T) {
 	}
 	policy.Add("serviceAccount:"+stsServiceAccountEmail, "roles/pubsub.subscriber")
 	if err := topic.IAM().SetPolicy(ctx, policy); err != nil {
-		log.Fatal("Couldn't set pubsub topic policy: " + err.Error())
+        log.Fatalf("Couldn't set pubsub topic policy: %v", err)
 	}
 
 	subId := testutil.UniqueBucketName("pubsubsubscription")

--- a/storagetransfer/storagetransfer_test.go
+++ b/storagetransfer/storagetransfer_test.go
@@ -404,23 +404,23 @@ func TestCreateEventDrivenGCSTransfer(t *testing.T) {
 
 	pubsubClient, err := pubsub.NewClient(ctx, tc.ProjectID)
 	if err != nil {
-        log.Fatalf("Couldn't create pubsub client: %v", err)
+		log.Fatalf("Couldn't create pubsub client: %v", err)
 	}
 	defer pubsubClient.Close()
 
 	topic, err := pubsubClient.CreateTopic(ctx, pubSubTopicId)
 	if err != nil {
-        log.Fatalf("Couldn't create pubsub topic: %v", err)
+		log.Fatalf("Couldn't create pubsub topic: %v", err)
 	}
 	defer topic.Delete(ctx)
 
 	policy, err := topic.IAM().Policy(ctx)
 	if err != nil {
-        log.Fatalf("Couldn't get pubsub topic policy: %v", err)
+		log.Fatalf("Couldn't get pubsub topic policy: %v", err)
 	}
 	policy.Add("serviceAccount:"+stsServiceAccountEmail, "roles/pubsub.subscriber")
 	if err := topic.IAM().SetPolicy(ctx, policy); err != nil {
-        log.Fatalf("Couldn't set pubsub topic policy: %v", err)
+		log.Fatalf("Couldn't set pubsub topic policy: %v", err)
 	}
 
 	subId := testutil.UniqueBucketName("pubsubsubscription")
@@ -430,7 +430,7 @@ func TestCreateEventDrivenGCSTransfer(t *testing.T) {
 		AckDeadline: 20 * time.Second,
 	})
 	if err != nil {
-        log.Fatalf("Couldn't create pubsub subscription: %v", err)
+		log.Fatalf("Couldn't create pubsub subscription: %v", err)
 	}
 
 	pubSubSubscriptionID := sub.String()

--- a/tasks/go.mod
+++ b/tasks/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/tasks
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/cloudtasks v1.13.3

--- a/testing/docker/cloudbuild.yaml
+++ b/testing/docker/cloudbuild.yaml
@@ -17,6 +17,6 @@ steps:
     args: [ 'build', '--build-arg', 'BASE_IMAGE=golang:${_GO_VERSION}', '-t', 'us-docker.pkg.dev/$PROJECT_ID/kokoro-images/${_IMAGE_NAME}', '.' ]
     waitFor: ['-']
 substitutions:
-  _GO_VERSION: "1.23"
-  _IMAGE_NAME: "go123"
+  _GO_VERSION: "1.24"
+  _IMAGE_NAME: "go124"
 images: ['us-docker.pkg.dev/$PROJECT_ID/kokoro-images/${_IMAGE_NAME}']

--- a/testing/gimmeproj/go.mod
+++ b/testing/gimmeproj/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/testing/gimmeproj
 
-go 1.23.0
+go 1.24.0
 
 require cloud.google.com/go/datastore v1.20.0
 

--- a/testing/kokoro/earliest-version.cfg
+++ b/testing/kokoro/earliest-version.cfg
@@ -3,5 +3,5 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "us-docker.pkg.dev/golang-samples-tests/kokoro-images/go123"
+    value: "us-docker.pkg.dev/golang-samples-tests/kokoro-images/go124"
 }

--- a/testing/kokoro/latest-version.cfg
+++ b/testing/kokoro/latest-version.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "us-docker.pkg.dev/golang-samples-tests/kokoro-images/go124"
+    value: "us-docker.pkg.dev/golang-samples-tests/kokoro-images/go125"
 }
 
 # Check `go vet` and `gofmt`.

--- a/texttospeech/go.mod
+++ b/texttospeech/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/texttospeech
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/texttospeech v1.11.0

--- a/trace/go.mod
+++ b/trace/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/trace
 
-go 1.23.0
+go 1.24.0
 
 require (
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.15-0.20230702191903-2de6d2748484

--- a/translate/go.mod
+++ b/translate/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/translate
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/storage v1.50.0

--- a/vertexai/batch-predict/go.mod
+++ b/vertexai/batch-predict/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/vertexai/batch-predict
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/aiplatform v1.70.0

--- a/vertexai/context-caching/go.mod
+++ b/vertexai/context-caching/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/vertexai/context-caching
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/vertexai v0.13.2

--- a/vertexai/controlled-generation/go.mod
+++ b/vertexai/controlled-generation/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/vertexai/controlled-generation
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/vertexai v0.13.2

--- a/vertexai/embeddings/go.mod
+++ b/vertexai/embeddings/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/vertexai/embeddings
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/aiplatform v1.70.0

--- a/vertexai/evaluation/go.mod
+++ b/vertexai/evaluation/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/vertexai/evaluation
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/aiplatform v1.70.0

--- a/vertexai/function-calling/go.mod
+++ b/vertexai/function-calling/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/vertexai/function-calling
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/vertexai v0.13.2

--- a/vertexai/gemma2/go.mod
+++ b/vertexai/gemma2/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/gemma2
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/aiplatform v1.70.0

--- a/vertexai/multimodal-video-with-audio/go.mod
+++ b/vertexai/multimodal-video-with-audio/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/vertexai/multimodal-video-with-audio
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/vertexai v0.13.2

--- a/vertexai/safety-settings/go.mod
+++ b/vertexai/safety-settings/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/vertexai/safety-settings
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/vertexai v0.13.2

--- a/vertexai/snippets/go.mod
+++ b/vertexai/snippets/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/vertexai/snippets
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/vertexai v0.13.2

--- a/vertexai/stream-multimodality-basic/go.mod
+++ b/vertexai/stream-multimodality-basic/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/vertexai/stream-multimodality-basic
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/vertexai v0.13.2

--- a/vertexai/stream-text-basic/go.mod
+++ b/vertexai/stream-text-basic/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/vertexai/stream-text-basic
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/vertexai v0.13.2

--- a/vertexai/token-count/go.mod
+++ b/vertexai/token-count/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/vertexai/token-count
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/vertexai v0.13.2

--- a/videointelligence/go.mod
+++ b/videointelligence/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/videointelligence
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/videointelligence v1.12.3

--- a/vision/go.mod
+++ b/vision/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/vision
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/storage v1.50.0

--- a/workflows/executions/go.mod
+++ b/workflows/executions/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/golang-samples/workflows/executions
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/GoogleCloudPlatform/golang-samples v0.0.0-20250401180849-ee847a2eb967


### PR DESCRIPTION
## Description

Bump supported Go versions from (1.23, 1.24) to (1.24, 1.25)

New minimum version is 1.24, so most versions in configs/toolchains, etc should point to 1.24


## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
