### PR TITLE
fix(dataproc): fix inner err2 reference

### DIFF
--- a/dataproc/quickstart/quickstart_test.go
+++ b/dataproc/quickstart/quickstart_test.go
@@ -65,7 +65,7 @@ func setup(t *testing.T, projectID string) {
 	w := obj.NewWriter(ctx)
 
 	if _, err := fmt.Fprint(w, code); err != nil {
-		if err2 := w.Close(); err != nil {
+		if err2 := w.Close(); err2 != nil {
 			t.Errorf("Error writing to file and closing it: %v", err2)
 		}
 		t.Errorf("Error writing to file: %v", err)


### PR DESCRIPTION
## Description

Fix layered error handling in one test in `quickstart_test.go`

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] Please **merge** this PR for me once it is approved
