### PR TITLE
test(spanner): Add integration test to check that requests with large message sizes that are under the limit succeed

### DIFF
--- a/spanner/spanner_snippets/spanner/integration_test.go
+++ b/spanner/spanner_snippets/spanner/integration_test.go
@@ -1339,10 +1339,7 @@ func TestTxWithLargeMessageSize(t *testing.T) {
 	_, dbName, cleanup := initTest(t, randomID())
 	defer cleanup()
 
-	log.Printf("Starting TestTxWithLargeMessageSize: dbName: %s\n", dbName)
-
 	mustRunSample(t, createDatabase, dbName, "failed to create a database")
-
 	runSample(t, writeLargeData, dbName, "failed to write large data")
 }
 

--- a/spanner/spanner_snippets/spanner/integration_test.go
+++ b/spanner/spanner_snippets/spanner/integration_test.go
@@ -1332,6 +1332,20 @@ func TestAddSplitPointsSample(t *testing.T) {
 	assertContains(t, out, "Added split points")
 }
 
+func TestTxWithLargeMessageSize(t *testing.T) {
+	_ = testutil.SystemTest(t)
+	t.Parallel()
+
+	_, dbName, cleanup := initTest(t, randomID())
+	defer cleanup()
+
+	log.Printf("Starting TestTxWithLargeMessageSize: dbName: %s\n", dbName)
+
+	mustRunSample(t, createDatabase, dbName, "failed to create a database")
+
+	runSample(t, writeLargeData, dbName, "failed to write large data")
+}
+
 func maybeCreateKey(projectId, locationId, keyRingId, keyId string) error {
 	client, err := kms.NewKeyManagementClient(context.Background())
 	if err != nil {

--- a/spanner/spanner_snippets/spanner/spanner_insert_large_data.go
+++ b/spanner/spanner_snippets/spanner/spanner_insert_large_data.go
@@ -1,0 +1,55 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanner
+
+// [START spanner_insert_large_data]
+
+import (
+	"context"
+	"io"
+	"math/rand"
+	"time"
+
+	"cloud.google.com/go/spanner"
+)
+
+func writeLargeData(w io.Writer, db string) error {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	client, err := spanner.NewClient(ctx, db)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	singerColumns := []string{"SingerId", "FirstName", "LastName", "SingerInfo"}
+	token := make([]byte, 10000000)
+	rand.Read(token)
+	// Mution is under the 100MB limit
+	m := []*spanner.Mutation{
+		spanner.InsertOrUpdate("Singers", singerColumns, []interface{}{1, "Marc", "Richards", token}),
+		spanner.InsertOrUpdate("Singers", singerColumns, []interface{}{2, "Catalina", "Smith", token}),
+		spanner.InsertOrUpdate("Singers", singerColumns, []interface{}{3, "Alice", "Trentor", token}),
+		spanner.InsertOrUpdate("Singers", singerColumns, []interface{}{4, "Lea", "Martin", token}),
+		spanner.InsertOrUpdate("Singers", singerColumns, []interface{}{5, "David", "Lomond", token}),
+		spanner.InsertOrUpdate("Singers", singerColumns, []interface{}{6, "Marc", "Richards", token}),
+		spanner.InsertOrUpdate("Singers", singerColumns, []interface{}{7, "Catalina", "Smith", token}),
+	}
+	_, err = client.Apply(ctx, m)
+	return err
+}
+
+// [END spanner_insert_large_data]


### PR DESCRIPTION
## Description


## Checklist
- [X] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [X] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [X] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [X] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [X] Please **merge** this PR for me once it is approved
