### PR TITLE
samples(storage): use the correct region tag for download_chunks_concurrently

### DIFF
--- a/storage/transfer_manager/download_chunks_concurrently.go
+++ b/storage/transfer_manager/download_chunks_concurrently.go
@@ -59,6 +59,7 @@ func downloadChunksConcurrently(w io.Writer, bucketName, blobName, filename stri
 	if err != nil {
 		return fmt.Errorf("os.Create: %w", err)
 	}
+	defer f.Close()
 
 	in := &transfermanager.DownloadObjectInput{
 		Bucket:      bucketName,
@@ -84,6 +85,7 @@ func downloadChunksConcurrently(w io.Writer, bucketName, blobName, filename stri
 	result := results[0]
 	if result.Err != nil {
 		fmt.Fprintf(w, "download of %v failed with error %v\n", result.Object, result.Err)
+		return result.Err
 	}
 	fmt.Fprintf(w, "Downloaded %v to %v.\n", blobName, filename)
 


### PR DESCRIPTION
## Fix the region tag for this sample.

Fixes #

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
