### PR TITLE
chore: remove Kokoro build status from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Google Cloud Platform Go Samples
 
-[![Kokoro Build Status][kokoro_badge]][kokoro_link]
-
 This repository holds sample code written in Go that demonstrates the Google
 Cloud Platform.
 
@@ -29,6 +27,3 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute.
 ## Licensing
 
 Code in this repository is licensed under the Apache 2.0. See [LICENSE](LICENSE).
-
-[kokoro_badge]: https://storage.googleapis.com/cloud-devrel-kokoro-resources/go/golang-samples/system_tests-ubuntu.png
-[kokoro_link]: https://fusion.corp.google.com/projectanalysis/current/KOKORO/prod%3Acloud-devrel%2Fgo%2Fgolang-samples%2Fsystem_tests


### PR DESCRIPTION
Removed Kokoro build status badge and link from README.

This is similar to https://github.com/GoogleCloudPlatform/java-docs-samples/pull/10209.

b/468409424
