### PR TITLE
feat(secretmanager): Adding delete secret annotation sample

### DIFF
--- a/secretmanager/delete_secret_annotation.go
+++ b/secretmanager/delete_secret_annotation.go
@@ -67,10 +67,11 @@ func deleteSecretAnnotation(w io.Writer, secretName string) error {
 		},
 	}
 
-	if _, err := client.UpdateSecret(ctx, updateRequest); err != nil {
+	updateResult, err := client.UpdateSecret(ctx, updateRequest)
+	if err != nil {
 		return fmt.Errorf("failed to update secret: %w", err)
 	}
-	fmt.Fprintf(w, "Deleted annotation %s from secret %s\n", annotationKey, secretName)
+	fmt.Fprintf(w, "Deleted annotation %s from secret %s\n", annotationKey, updateResult.Name)
 	return nil
 }
 

--- a/secretmanager/regional_samples/delete_regional_secret_annotation.go
+++ b/secretmanager/regional_samples/delete_regional_secret_annotation.go
@@ -72,10 +72,11 @@ func deleteRegionalSecretAnnotation(w io.Writer, secretName, locationID string) 
 		},
 	}
 
-	if _, err := client.UpdateSecret(ctx, updateRequest); err != nil {
+	updateResult, err := client.UpdateSecret(ctx, updateRequest)
+	if err != nil {
 		return fmt.Errorf("failed to update secret: %w", err)
 	}
-	fmt.Fprintf(w, "Deleted annotation %s from secret %s\n", annotationKey, secretName)
+	fmt.Fprintf(w, "Deleted annotation %s from secret %s\n", annotationKey, updateResult.Name)
 	return nil
 }
 

--- a/secretmanager/regional_samples/regional_secretmanager_test.go
+++ b/secretmanager/regional_samples/regional_secretmanager_test.go
@@ -496,6 +496,10 @@ func TestDeleteRegionalSecretAnnotation(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if got, want := b.String(), "Deleted annotation"; !strings.Contains(got, want) {
+		t.Errorf("deleteSecretAnnotation: expected %q to contain %q", got, want)
+	}
+
 	client, ctx := testRegionalClient(t)
 	s, err := client.GetSecret(ctx, &secretmanagerpb.GetSecretRequest{
 		Name: secret.Name,

--- a/secretmanager/secretmanager_test.go
+++ b/secretmanager/secretmanager_test.go
@@ -1689,6 +1689,10 @@ func TestDeleteSecretAnnotation(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if got, want := b.String(), "Deleted annotation"; !strings.Contains(got, want) {
+		t.Errorf("deleteSecretAnnotation: expected %q to contain %q", got, want)
+	}
+
 	client, ctx := testClient(t)
 	s, err := client.GetSecret(ctx, &secretmanagerpb.GetSecretRequest{
 		Name: secret.Name,


### PR DESCRIPTION
Adding samples for delete secret annotations

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [x] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [x] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
