### PR TITLE
feat(secretmanager): Adding secretmanager expiration samples

### DIFF
--- a/secretmanager/create_secret_with_expire_time.go
+++ b/secretmanager/create_secret_with_expire_time.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secretmanager
+
+// [START secretmanager_create_secret_with_expire_time]
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	secretmanagerpb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// createSecretWithExpireTime creates a new secret with an expiration time.
+func createSecretWithExpireTime(w io.Writer, projectID, secretID string) error {
+	// projectID := "my-project"
+	// secretID := "my-secret-with-expiry"
+	expireTime := time.Now().Add(time.Hour)
+
+	ctx := context.Background()
+	client, err := secretmanager.NewClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create secretmanager client: %w", err)
+	}
+	defer client.Close()
+
+	req := &secretmanagerpb.CreateSecretRequest{
+		Parent:   fmt.Sprintf("projects/%s", projectID),
+		SecretId: secretID,
+		Secret: &secretmanagerpb.Secret{
+			Replication: &secretmanagerpb.Replication{
+				Replication: &secretmanagerpb.Replication_Automatic_{
+					Automatic: &secretmanagerpb.Replication_Automatic{},
+				},
+			},
+			Expiration: &secretmanagerpb.Secret_ExpireTime{
+				ExpireTime: timestamppb.New(expireTime),
+			},
+		},
+	}
+
+	secret, err := client.CreateSecret(ctx, req)
+	if err != nil {
+		return fmt.Errorf("failed to create secret: %w", err)
+	}
+
+	fmt.Fprintf(w, "Created secret %s with expiration time %v\n", secret.Name, expireTime)
+	return nil
+}
+
+// [END secretmanager_create_secret_with_expire_time]

--- a/secretmanager/delete_secret_expiration.go
+++ b/secretmanager/delete_secret_expiration.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secretmanager
+
+// [START secretmanager_delete_secret_expiration]
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+)
+
+// deleteExpiration removes the expiration time from a secret.
+func deleteExpiration(w io.Writer, secretName string) error {
+	// secretName := "projects/my-project/secrets/my-secret"
+
+	ctx := context.Background()
+	client, err := secretmanager.NewClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create secretmanager client: %w", err)
+	}
+	defer client.Close()
+
+	req := &secretmanagerpb.UpdateSecretRequest{
+		Secret: &secretmanagerpb.Secret{
+			Name: secretName,
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{
+			Paths: []string{"expire_time"},
+		},
+	}
+
+	secret, err := client.UpdateSecret(ctx, req)
+	if err != nil {
+		return fmt.Errorf("failed to update secret: %w", err)
+	}
+
+	fmt.Fprintf(w, "Removed expiration from secret %s\n", secret.Name)
+	return nil
+}
+
+// [END secretmanager_delete_secret_expiration]

--- a/secretmanager/regional_samples/create_regional_secret_with_expire_time.go
+++ b/secretmanager/regional_samples/create_regional_secret_with_expire_time.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package regional_secretmanager
+
+// [START secretmanager_create_regional_secret_with_expire_time]
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	secretmanagerpb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"google.golang.org/api/option"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// createRegionalSecretWithExpireTime creates a new regional secret with an expiration time.
+func createRegionalSecretWithExpireTime(w io.Writer, projectID, secretID, locationID string) error {
+	// projectID := "my-project"
+	// secretID := "my-secret-with-expiry"
+	// locationID := "us-central1"
+	expireTime := time.Now().Add(time.Hour)
+
+	ctx := context.Background()
+	endpoint := fmt.Sprintf("secretmanager.%s.rep.googleapis.com:443", locationID)
+	client, err := secretmanager.NewClient(ctx, option.WithEndpoint(endpoint))
+	if err != nil {
+		return fmt.Errorf("failed to create secretmanager client: %w", err)
+	}
+	defer client.Close()
+
+	req := &secretmanagerpb.CreateSecretRequest{
+		Parent:   fmt.Sprintf("projects/%s/locations/%s", projectID, locationID),
+		SecretId: secretID,
+		Secret: &secretmanagerpb.Secret{
+			Expiration: &secretmanagerpb.Secret_ExpireTime{
+				ExpireTime: timestamppb.New(expireTime),
+			},
+		},
+	}
+
+	secret, err := client.CreateSecret(ctx, req)
+	if err != nil {
+		return fmt.Errorf("failed to create secret: %w", err)
+	}
+
+	fmt.Fprintf(w, "Created secret %s with expiration time %v\n", secret.Name, expireTime)
+	return nil
+}
+
+// [END secretmanager_create_regional_secret_with_expire_time]

--- a/secretmanager/regional_samples/delete_regional_secret_expiration.go
+++ b/secretmanager/regional_samples/delete_regional_secret_expiration.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package regional_secretmanager
+
+// [START secretmanager_delete_regional_secret_expiration]
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"google.golang.org/api/option"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+)
+
+// deleteRegionalExpiration removes the expiration time from a regional secret.
+func deleteRegionalExpiration(w io.Writer, secretName, locationID string) error {
+	// secretName := "projects/my-project/locations/us-central1/secrets/my-secret"
+	// locationID := "us-central1"
+
+	ctx := context.Background()
+	endpoint := fmt.Sprintf("secretmanager.%s.rep.googleapis.com:443", locationID)
+	client, err := secretmanager.NewClient(ctx, option.WithEndpoint(endpoint))
+	if err != nil {
+		return fmt.Errorf("failed to create secretmanager client: %w", err)
+	}
+	defer client.Close()
+
+	req := &secretmanagerpb.UpdateSecretRequest{
+		Secret: &secretmanagerpb.Secret{
+			Name: secretName,
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{
+			Paths: []string{"expire_time"},
+		},
+	}
+
+	secret, err := client.UpdateSecret(ctx, req)
+	if err != nil {
+		return fmt.Errorf("failed to update secret: %w", err)
+	}
+
+	fmt.Fprintf(w, "Removed expiration from secret %s\n", secret.Name)
+	return nil
+}
+
+// [END secretmanager_delete_regional_secret_expiration]

--- a/secretmanager/regional_samples/update_regional_secret_expiration.go
+++ b/secretmanager/regional_samples/update_regional_secret_expiration.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package regional_secretmanager
+
+// [START secretmanager_update_regional_secret_expiration]
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	secretmanagerpb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"google.golang.org/api/option"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// updateRegionalSecretExpiration updates the expiration time of a regional secret.
+func updateRegionalSecretExpiration(w io.Writer, secretName, locationID string) error {
+	// secretName := "projects/my-project/locations/us-central1/secrets/my-secret"
+	// locationID := "us-central1"
+	newExpire := time.Now().Add(2 * time.Hour)
+
+	ctx := context.Background()
+	endpoint := fmt.Sprintf("secretmanager.%s.rep.googleapis.com:443", locationID)
+	client, err := secretmanager.NewClient(ctx, option.WithEndpoint(endpoint))
+	if err != nil {
+		return fmt.Errorf("failed to create secretmanager client: %w", err)
+	}
+	defer client.Close()
+
+	req := &secretmanagerpb.UpdateSecretRequest{
+		Secret: &secretmanagerpb.Secret{
+			Name: secretName,
+			Expiration: &secretmanagerpb.Secret_ExpireTime{
+				ExpireTime: timestamppb.New(newExpire),
+			},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{
+			Paths: []string{"expire_time"},
+		},
+	}
+
+	secret, err := client.UpdateSecret(ctx, req)
+	if err != nil {
+		return fmt.Errorf("failed to update secret: %w", err)
+	}
+
+	fmt.Fprintf(w, "Updated secret %s expiration time to %v\n", secret.Name, newExpire)
+	return nil
+}
+
+// [END secretmanager_update_regional_secret_expiration]

--- a/secretmanager/secretmanager_test.go
+++ b/secretmanager/secretmanager_test.go
@@ -1675,3 +1675,115 @@ func TestCreateSecretWithTags(t *testing.T) {
 	}
 
 }
+
+func TestCreateSecretWithExpireTime(t *testing.T) {
+	tc := testutil.SystemTest(t)
+	secretId := testName(t)
+	secretName := fmt.Sprintf("projects/%s/secrets/%s", tc.ProjectID, secretId)
+	defer testCleanupSecret(t, secretName)
+
+	// Expire time in 1 hour.
+	expire := time.Now().Add(time.Hour)
+
+	var b bytes.Buffer
+	if err := createSecretWithExpireTime(&b, tc.ProjectID, secretId); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := b.String(), "Created secret"; !strings.Contains(got, want) {
+		t.Errorf("createSecretWithExpireTime: expected %q to contain %q", got, want)
+	}
+
+	// Verify expire time with GetSecret.
+	client, ctx := testClient(t)
+
+	secret, err := client.GetSecret(ctx, &secretmanagerpb.GetSecretRequest{
+		Name: secretName,
+	})
+	if err != nil {
+		t.Fatalf("failed to get secret for verification: %v", err)
+	}
+
+	if secret.GetExpireTime() == nil {
+		t.Fatal("GetSecret: ExpireTime is nil, expected non-nil")
+	}
+
+	if diff := secret.GetExpireTime().AsTime().Unix() - expire.Unix(); diff > 1 || diff < -1 {
+		t.Errorf("ExpireTime mismatch: got %v, want %v", secret.GetExpireTime().AsTime(), expire)
+	}
+}
+
+func TestUpdateSecretExpiration(t *testing.T) {
+	tc := testutil.SystemTest(t)
+	secretId := testName(t)
+	secretName := fmt.Sprintf("projects/%s/secrets/%s", tc.ProjectID, secretId)
+	defer testCleanupSecret(t, secretName)
+
+	// Create with expire time in 1 hour.
+	var b bytes.Buffer
+	if err := createSecretWithExpireTime(&b, tc.ProjectID, secretId); err != nil {
+		t.Fatal(err)
+	}
+
+	// Update expire time to 2 hours.
+	newExpire := time.Now().Add(2 * time.Hour)
+	if err := updateSecretExpiration(&b, secretName); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := b.String(), "Updated secret"; !strings.Contains(got, want) {
+		t.Errorf("updateSecretExpiration: expected %q to contain %q", got, want)
+	}
+
+	// Verify expire time with GetSecret.
+	client, ctx := testClient(t)
+	secret, err := client.GetSecret(ctx, &secretmanagerpb.GetSecretRequest{
+		Name: secretName,
+	})
+	if err != nil {
+		t.Fatalf("failed to get secret for verification: %v", err)
+	}
+
+	if secret.GetExpireTime() == nil {
+		t.Fatal("GetSecret: ExpireTime is nil, expected non-nil")
+	}
+
+	if diff := secret.GetExpireTime().AsTime().Unix() - newExpire.Unix(); diff > 1 || diff < -1 {
+		t.Errorf("ExpireTime mismatch: got %v, want %v", secret.GetExpireTime().AsTime(), newExpire)
+	}
+}
+
+func TestRemoveExpiration(t *testing.T) {
+	tc := testutil.SystemTest(t)
+	secretId := testName(t)
+	secretName := fmt.Sprintf("projects/%s/secrets/%s", tc.ProjectID, secretId)
+	defer testCleanupSecret(t, secretName)
+
+	var b bytes.Buffer
+	if err := createSecretWithExpireTime(&b, tc.ProjectID, secretId); err != nil {
+		t.Fatal(err)
+	}
+
+	// Remove expire time.
+	b.Reset()
+	if err := deleteExpiration(&b, secretName); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := b.String(), "Removed expiration"; !strings.Contains(got, want) {
+		t.Errorf("deleteExpiration: expected %q to contain %q", got, want)
+	}
+
+	// Verify expire time is removed with GetSecret.
+	client, ctx := testClient(t)
+
+	secret, err := client.GetSecret(ctx, &secretmanagerpb.GetSecretRequest{
+		Name: secretName,
+	})
+	if err != nil {
+		t.Fatalf("failed to get secret for verification: %v", err)
+	}
+
+	if secret.GetExpireTime() != nil {
+		t.Errorf("GetSecret: ExpireTime is %v, expected nil", secret.GetExpireTime())
+	}
+}

--- a/secretmanager/update_secret_expiration.go
+++ b/secretmanager/update_secret_expiration.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secretmanager
+
+// [START secretmanager_update_secret_expiration]
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	secretmanagerpb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// updateSecretExpiration updates the expiration time of a secret.
+func updateSecretExpiration(w io.Writer, secretName string) error {
+	// secretName := "projects/my-project/secrets/my-secret"
+	newExpire := time.Now().Add(2 * time.Hour)
+
+	ctx := context.Background()
+	client, err := secretmanager.NewClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create secretmanager client: %w", err)
+	}
+	defer client.Close()
+
+	req := &secretmanagerpb.UpdateSecretRequest{
+		Secret: &secretmanagerpb.Secret{
+			Name: secretName,
+			Expiration: &secretmanagerpb.Secret_ExpireTime{
+				ExpireTime: timestamppb.New(newExpire),
+			},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{
+			Paths: []string{"expire_time"},
+		},
+	}
+
+	secret, err := client.UpdateSecret(ctx, req)
+	if err != nil {
+		return fmt.Errorf("failed to update secret: %w", err)
+	}
+
+	fmt.Fprintf(w, "Updated secret %s expiration time to %v\n", secret.Name, newExpire)
+	return nil
+}
+
+// [END secretmanager_update_secret_expiration]


### PR DESCRIPTION
Adding secretmanager expiration samples

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [x] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [x] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
