### PR TITLE
ci: support Go 1.25 in GitHub Actions workflows

### DIFF
--- a/internal/cloudrunci/cloudrunci.go
+++ b/internal/cloudrunci/cloudrunci.go
@@ -395,6 +395,8 @@ func (s *Service) deployCmd() *exec.Cmd {
 		s.ProjectID,
 		"--image",
 		s.Image,
+		"--ingress",
+		"internal",
 	}, s.Platform.CommandFlags()...)
 
 	if s.Env != nil {

--- a/memorystore/redis/go.mod
+++ b/memorystore/redis/go.mod
@@ -1,5 +1,5 @@
 module visit-counter
 
-go 1.25
+go 1.25.0
 
 require github.com/gomodule/redigo v1.9.3

--- a/run/grpc-server-streaming/README.md
+++ b/run/grpc-server-streaming/README.md
@@ -21,7 +21,7 @@ Once deployed successfully, note the domain name (hostname) of the service.
 
 ## Make a request using the client
 
-1. Ensure Go 1.13 (or higher) is installed on your machine.
+1. Ensure Go 1.25 (or higher) is installed on your machine.
 
 2. Clone this repository.
 

--- a/run/service-health/go.mod
+++ b/run/service-health/go.mod
@@ -1,6 +1,6 @@
 module servicehealth
 
-go 1.23.0
+go 1.25.0
 
 require (
 	cloud.google.com/go/storage v1.55.0

--- a/testing/cloudbuild/cloudbuild.yaml
+++ b/testing/cloudbuild/cloudbuild.yaml
@@ -28,7 +28,7 @@ steps:
   args: ['storage', 'cp', 'gs://golang-samples-secrets/golang-samples-tests-4fbf85dd0f24.json', 'key.json']
 
 # Run the tests
-- name: gcr.io/$PROJECT_ID/go19
+- name: gcr.io/$PROJECT_ID/go125
   args: ['bash', 'testing/cloudbuild/run.bash']
 
 # Clean up the workdir.
@@ -42,7 +42,7 @@ steps:
 # Build the image with newly downloaded deps.
 - name: gcr.io/cloudbuild-report/cacher
   env:
-  - TAG=gcr.io/$PROJECT_ID/go19
-  - BASE=golang:1.7
+  - TAG=gcr.io/$PROJECT_ID/go125
+  - BASE=golang:1.25
 
-images: ['gcr.io/$PROJECT_ID/go19']
+images: ['gcr.io/$PROJECT_ID/go125']

--- a/testing/docker/README.md
+++ b/testing/docker/README.md
@@ -13,11 +13,11 @@ these containers.
 
 Go language version and resulting image name are controlled by the cloud build
 substitutions `_GO_VERSION` and `_IMAGE_NAME` respectively. The command below
-will build Go 1.21 and push the resulting image to
+will build Go 1.25 and push the resulting image to
 `gcr.io/golang-samples-tests/go121`
 
 ```
 gcloud builds submit . \
     --project=golang-samples-tests \
-    --substitutions "_GO_VERSION=1.21,_IMAGE_NAME=go121"
+    --substitutions "_GO_VERSION=1.25,_IMAGE_NAME=go125"
 ```


### PR DESCRIPTION
## Description
Update CI pipelines to incorporate Go 1.25 and modernize the legacy code that required 1.25.

Fixes Internal : b/490417930

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
