### PR TITLE
feat(storage): Added samples for anywhere cache

### DIFF
--- a/storage/control/anywhere_cache_test.go
+++ b/storage/control/anywhere_cache_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package control
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+)
+
+func TestAnywhereCache(t *testing.T) {
+	tc := testutil.SystemTest(t)
+	ctx := context.Background()
+
+	zone := os.Getenv("GOOGLE_SAMPLES_ZONE")
+	if zone == "" {
+		zone = "us-central1-a"
+	}
+
+	bucketName := testutil.UniqueBucketName(testPrefix + "ac")
+	b := client.Bucket(bucketName)
+	attrs := &storage.BucketAttrs{
+		UniformBucketLevelAccess: storage.UniformBucketLevelAccess{
+			Enabled: true,
+		},
+	}
+	if err := b.Create(ctx, tc.ProjectID, attrs); err != nil {
+		t.Fatalf("Bucket.Create(%q): %v", bucketName, err)
+	}
+	t.Cleanup(func() {
+		if err := testutil.DeleteBucketIfExists(ctx, client, bucketName); err != nil {
+			log.Printf("Bucket.Delete(%q): %v", bucketName, err)
+		}
+	})
+
+	anywhereCacheID := zone
+	anywhereCachePath := fmt.Sprintf("buckets/%s/anywhereCaches/%s", bucketName, anywhereCacheID)
+
+	// Create anywhere cache.
+	if ok := testutil.Retry(t, 5, time.Second, func(r *testutil.R) {
+		buf := &bytes.Buffer{}
+		if err := createAnywhereCache(buf, bucketName, zone); err != nil {
+			r.Errorf("createAnywhereCache: %v", err)
+		}
+		if got, want := buf.String(), anywhereCachePath; !strings.Contains(got, want) {
+			r.Errorf("createAnywhereCache: got %q, want to contain %q", got, want)
+		}
+	}); !ok {
+		t.Fatalf("failed to create anywhere cache; can't continue")
+	}
+
+	// Get anywhere cache.
+	if ok := testutil.Retry(t, 5, time.Second, func(r *testutil.R) {
+		buf := &bytes.Buffer{}
+		if err := getAnywhereCache(buf, bucketName, anywhereCacheID); err != nil {
+			r.Errorf("getAnywhereCache: %v", err)
+		}
+		if got, want := buf.String(), anywhereCachePath; !strings.Contains(got, want) {
+			r.Errorf("getAnywhereCache: got %q, want to contain %q", got, want)
+		}
+	}); !ok {
+		t.Fatalf("failed to get anywhere cache; can't continue")
+	}
+
+	// List anywhere caches.
+	if ok := testutil.Retry(t, 5, time.Second, func(r *testutil.R) {
+		buf := &bytes.Buffer{}
+		if err := listAnywhereCaches(buf, bucketName); err != nil {
+			r.Errorf("listAnywhereCaches: %v", err)
+		}
+		if got, want := buf.String(), anywhereCachePath; !strings.Contains(got, want) {
+			r.Errorf("listAnywhereCaches: got %q, want to contain %q", got, want)
+		}
+	}); !ok {
+		t.Fatalf("failed to list anywhere caches; can't continue")
+	}
+
+	// Update anywhere cache.
+	if ok := testutil.Retry(t, 5, time.Second, func(r *testutil.R) {
+		buf := &bytes.Buffer{}
+		if err := updateAnywhereCache(buf, bucketName, anywhereCacheID, "admit-on-second-miss"); err != nil {
+			r.Errorf("updateAnywhereCache: %v", err)
+		}
+		if got, want := buf.String(), anywhereCachePath; !strings.Contains(got, want) {
+			r.Errorf("updateAnywhereCache: got %q, want to contain %q", got, want)
+		}
+	}); !ok {
+		t.Fatalf("failed to update anywhere cache; can't continue")
+	}
+
+	// Pause anywhere cache.
+	if ok := testutil.Retry(t, 5, time.Second, func(r *testutil.R) {
+		buf := &bytes.Buffer{}
+		if err := pauseAnywhereCache(buf, bucketName, anywhereCacheID); err != nil {
+			r.Errorf("pauseAnywhereCache: %v", err)
+		}
+		if got, want := buf.String(), anywhereCachePath; !strings.Contains(got, want) {
+			r.Errorf("pauseAnywhereCache: got %q, want to contain %q", got, want)
+		}
+	}); !ok {
+		t.Fatalf("failed to pause anywhere cache; can't continue")
+	}
+
+	// Resume anywhere cache.
+	if ok := testutil.Retry(t, 5, time.Second, func(r *testutil.R) {
+		buf := &bytes.Buffer{}
+		if err := resumeAnywhereCache(buf, bucketName, anywhereCacheID); err != nil {
+			r.Errorf("resumeAnywhereCache: %v", err)
+		}
+		if got, want := buf.String(), anywhereCachePath; !strings.Contains(got, want) {
+			r.Errorf("resumeAnywhereCache: got %q, want to contain %q", got, want)
+		}
+	}); !ok {
+		t.Fatalf("failed to resume anywhere cache; can't continue")
+	}
+
+	// Disable anywhere cache.
+	if ok := testutil.Retry(t, 5, time.Second, func(r *testutil.R) {
+		buf := &bytes.Buffer{}
+		if err := disableAnywhereCache(buf, bucketName, anywhereCacheID); err != nil {
+			r.Errorf("disableAnywhereCache: %v", err)
+		}
+		if got, want := buf.String(), anywhereCachePath; !strings.Contains(got, want) {
+			r.Errorf("disableAnywhereCache: got %q, want to contain %q", got, want)
+		}
+	}); !ok {
+		t.Fatalf("failed to disable anywhere cache; can't continue")
+	}
+}

--- a/storage/control/create_anywhere_cache.go
+++ b/storage/control/create_anywhere_cache.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package control
+
+// [START storage_control_create_anywhere_cache]
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	storagecontrol "cloud.google.com/go/storage/control/apiv2"
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
+)
+
+// createAnywhereCache creates an anywhere cache for the bucket and zone.
+func createAnywhereCache(w io.Writer, bucket, zone string) error {
+	// bucket := "bucket-name"
+	// zone := "us-central1-a"
+
+	ctx := context.Background()
+	client, err := storagecontrol.NewStorageControlClient(ctx)
+	if err != nil {
+		return fmt.Errorf("storagecontrol.NewStorageControlClient: %w", err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*20)
+	defer cancel()
+
+	req := &controlpb.CreateAnywhereCacheRequest{
+		Parent: fmt.Sprintf("projects/_/buckets/%s", bucket),
+		AnywhereCache: &controlpb.AnywhereCache{
+			Zone: zone,
+		},
+	}
+
+	// CreateAnywhereCache is a long-running operation.
+	// Real applications may want to setup a callback or wait for the operation to complete.
+	// Blocking with .Wait(ctx) is for simplicity and real applications may prefer callbacks, coroutines, or polling.
+	op, err := client.CreateAnywhereCache(ctx, req)
+	if err != nil {
+		return fmt.Errorf("CreateAnywhereCache: %w", err)
+	}
+
+	anywhereCache, err := op.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("Wait: %w", err)
+	}
+
+	fmt.Fprintf(w, "Created anywhere cache: %v\n", anywhereCache.GetName())
+	return nil
+}
+
+// [END storage_control_create_anywhere_cache]

--- a/storage/control/disable_anywhere_cache.go
+++ b/storage/control/disable_anywhere_cache.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package control
+
+// [START storage_control_disable_anywhere_cache]
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	storagecontrol "cloud.google.com/go/storage/control/apiv2"
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
+)
+
+// disableAnywhereCache disables an anywhere cache.
+func disableAnywhereCache(w io.Writer, bucket, anywhereCacheID string) error {
+	// bucket := "bucket-name"
+	// anywhereCacheID := "us-central1-a"
+
+	ctx := context.Background()
+	client, err := storagecontrol.NewStorageControlClient(ctx)
+	if err != nil {
+		return fmt.Errorf("storagecontrol.NewStorageControlClient: %w", err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	name := fmt.Sprintf("projects/_/buckets/%s/anywhereCaches/%s", bucket, anywhereCacheID)
+	req := &controlpb.DisableAnywhereCacheRequest{
+		Name: name,
+	}
+
+	anywhereCache, err := client.DisableAnywhereCache(ctx, req)
+	if err != nil {
+		return fmt.Errorf("DisableAnywhereCache: %w", err)
+	}
+
+	fmt.Fprintf(w, "Disabled anywhere cache: %v\n", anywhereCache.GetName())
+	return nil
+}
+
+// [END storage_control_disable_anywhere_cache]

--- a/storage/control/get_anywhere_cache.go
+++ b/storage/control/get_anywhere_cache.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package control
+
+// [START storage_control_get_anywhere_cache]
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	storagecontrol "cloud.google.com/go/storage/control/apiv2"
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
+)
+
+// getAnywhereCache gets an anywhere cache.
+func getAnywhereCache(w io.Writer, bucket, anywhereCacheID string) error {
+	// bucket := "bucket-name"
+	// anywhereCacheID := "us-central1-a"
+
+	ctx := context.Background()
+	client, err := storagecontrol.NewStorageControlClient(ctx)
+	if err != nil {
+		return fmt.Errorf("storagecontrol.NewStorageControlClient: %w", err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	name := fmt.Sprintf("projects/_/buckets/%s/anywhereCaches/%s", bucket, anywhereCacheID)
+	req := &controlpb.GetAnywhereCacheRequest{
+		Name: name,
+	}
+
+	anywhereCache, err := client.GetAnywhereCache(ctx, req)
+	if err != nil {
+		return fmt.Errorf("GetAnywhereCache: %w", err)
+	}
+
+	fmt.Fprintf(w, "Got anywhere cache: %v\n", anywhereCache.GetName())
+	return nil
+}
+
+// [END storage_control_get_anywhere_cache]

--- a/storage/control/list_anywhere_caches.go
+++ b/storage/control/list_anywhere_caches.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package control
+
+// [START storage_control_list_anywhere_caches]
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	storagecontrol "cloud.google.com/go/storage/control/apiv2"
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
+	"google.golang.org/api/iterator"
+)
+
+// listAnywhereCaches lists anywhere caches for a bucket.
+func listAnywhereCaches(w io.Writer, bucket string) error {
+	// bucket := "bucket-name"
+
+	ctx := context.Background()
+	client, err := storagecontrol.NewStorageControlClient(ctx)
+	if err != nil {
+		return fmt.Errorf("storagecontrol.NewStorageControlClient: %w", err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	req := &controlpb.ListAnywhereCachesRequest{
+		Parent: fmt.Sprintf("projects/_/buckets/%s", bucket),
+	}
+
+	it := client.ListAnywhereCaches(ctx, req)
+	for {
+		resp, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("ListAnywhereCaches: %w", err)
+		}
+		fmt.Fprintf(w, "Anywhere cache: %v\n", resp.GetName())
+	}
+
+	return nil
+}
+
+// [END storage_control_list_anywhere_caches]

--- a/storage/control/pause_anywhere_cache.go
+++ b/storage/control/pause_anywhere_cache.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package control
+
+// [START storage_control_pause_anywhere_cache]
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	storagecontrol "cloud.google.com/go/storage/control/apiv2"
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
+)
+
+// pauseAnywhereCache pauses an anywhere cache.
+func pauseAnywhereCache(w io.Writer, bucket, anywhereCacheID string) error {
+	// bucket := "bucket-name"
+	// anywhereCacheID := "us-central1-a"
+
+	ctx := context.Background()
+	client, err := storagecontrol.NewStorageControlClient(ctx)
+	if err != nil {
+		return fmt.Errorf("storagecontrol.NewStorageControlClient: %w", err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	name := fmt.Sprintf("projects/_/buckets/%s/anywhereCaches/%s", bucket, anywhereCacheID)
+	req := &controlpb.PauseAnywhereCacheRequest{
+		Name: name,
+	}
+
+	anywhereCache, err := client.PauseAnywhereCache(ctx, req)
+	if err != nil {
+		return fmt.Errorf("PauseAnywhereCache: %w", err)
+	}
+
+	fmt.Fprintf(w, "Paused anywhere cache: %v\n", anywhereCache.GetName())
+	return nil
+}
+
+// [END storage_control_pause_anywhere_cache]

--- a/storage/control/resume_anywhere_cache.go
+++ b/storage/control/resume_anywhere_cache.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package control
+
+// [START storage_control_resume_anywhere_cache]
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	storagecontrol "cloud.google.com/go/storage/control/apiv2"
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
+)
+
+// resumeAnywhereCache resumes an anywhere cache.
+func resumeAnywhereCache(w io.Writer, bucket, anywhereCacheID string) error {
+	// bucket := "bucket-name"
+	// anywhereCacheID := "us-central1-a"
+
+	ctx := context.Background()
+	client, err := storagecontrol.NewStorageControlClient(ctx)
+	if err != nil {
+		return fmt.Errorf("storagecontrol.NewStorageControlClient: %w", err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	name := fmt.Sprintf("projects/_/buckets/%s/anywhereCaches/%s", bucket, anywhereCacheID)
+	req := &controlpb.ResumeAnywhereCacheRequest{
+		Name: name,
+	}
+
+	anywhereCache, err := client.ResumeAnywhereCache(ctx, req)
+	if err != nil {
+		return fmt.Errorf("ResumeAnywhereCache: %w", err)
+	}
+
+	fmt.Fprintf(w, "Resumed anywhere cache: %v\n", anywhereCache.GetName())
+	return nil
+}
+
+// [END storage_control_resume_anywhere_cache]

--- a/storage/control/update_anywhere_cache.go
+++ b/storage/control/update_anywhere_cache.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package control
+
+// [START storage_control_update_anywhere_cache]
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	storagecontrol "cloud.google.com/go/storage/control/apiv2"
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+)
+
+// updateAnywhereCache updates an anywhere cache admission policy.
+func updateAnywhereCache(w io.Writer, bucket, anywhereCacheID, admissionPolicy string) error {
+	// bucket := "bucket-name"
+	// anywhereCacheID := "us-central1-a"
+	// admissionPolicy := "admit-on-first-miss"
+
+	ctx := context.Background()
+	client, err := storagecontrol.NewStorageControlClient(ctx)
+	if err != nil {
+		return fmt.Errorf("storagecontrol.NewStorageControlClient: %w", err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*20)
+	defer cancel()
+
+	name := fmt.Sprintf("projects/_/buckets/%s/anywhereCaches/%s", bucket, anywhereCacheID)
+	req := &controlpb.UpdateAnywhereCacheRequest{
+		AnywhereCache: &controlpb.AnywhereCache{
+			Name:            name,
+			AdmissionPolicy: admissionPolicy,
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{
+			Paths: []string{"admission_policy"},
+		},
+	}
+
+	// UpdateAnywhereCache is a long-running operation.
+	// Real applications may want to setup a callback or wait for the operation to complete.
+	// Blocking with .Wait(ctx) is for simplicity and real applications may prefer callbacks, coroutines, or polling.
+	op, err := client.UpdateAnywhereCache(ctx, req)
+	if err != nil {
+		return fmt.Errorf("UpdateAnywhereCache: %w", err)
+	}
+
+	anywhereCache, err := op.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("Wait: %w", err)
+	}
+
+	fmt.Fprintf(w, "Updated anywhere cache: %v\n", anywhereCache.GetName())
+	return nil
+}
+
+// [END storage_control_update_anywhere_cache]


### PR DESCRIPTION
Implemented 7 new code samples for Google Cloud Storage Anywhere Cache in the `storage/control` directory. Each sample is in its own file:
- create_anywhere_cache.go
- get_anywhere_cache.go
- list_anywhere_caches.go
- update_anywhere_cache.go
- pause_anywhere_cache.go
- resume_anywhere_cache.go
- disable_anywhere_cache.go

Additionally, comprehensive integration tests were added in `storage/control/anywhere_cache_test.go`. The implementation follows repository standards, includes LRO commentary, and strictly avoids modifying `go.mod` and `go.sum`.

