### PR TITLE
feat(storage): Added samples for anywhere cache

### DIFF
--- a/storage/control/anywhere_cache_test.go
+++ b/storage/control/anywhere_cache_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestAnywhereCache(t *testing.T) {
 	tc := testutil.SystemTest(t)
-	zone := os.Getenv("GOOGLE_CLOUD_CPP_TEST_ZONE")
+	zone := os.Getenv("GOLANG_SAMPLES_ZONE")
 	if zone == "" {
 		zone = "us-central1-a"
 	}

--- a/storage/control/anywhere_cache_test.go
+++ b/storage/control/anywhere_cache_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package control
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+)
+
+func TestAnywhereCache(t *testing.T) {
+	tc := testutil.SystemTest(t)
+	zone := os.Getenv("GOOGLE_CLOUD_CPP_TEST_ZONE")
+	if zone == "" {
+		zone = "us-central1-a"
+	}
+	ctx := context.Background()
+
+	bucketName := testutil.UniqueBucketName(testPrefix)
+	b := client.Bucket(bucketName)
+	attrs := &storage.BucketAttrs{
+		UniformBucketLevelAccess: storage.UniformBucketLevelAccess{
+			Enabled: true,
+		},
+	}
+	if err := b.Create(ctx, tc.ProjectID, attrs); err != nil {
+		t.Fatalf("Bucket.Create(%q): %v", bucketName, err)
+	}
+	t.Cleanup(func() {
+		testutil.DeleteBucketIfExists(ctx, client, bucketName)
+	})
+
+	var cacheId string
+
+	// Create Anywhere Cache
+	t.Run("Create", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		if err := createAnywhereCache(buf, bucketName, zone); err != nil {
+			t.Fatalf("createAnywhereCache: %v", err)
+		}
+		got := buf.String()
+		if !strings.Contains(got, "Created anywhere cache:") {
+			t.Errorf("got %q, want it to contain 'Created anywhere cache:'", got)
+		}
+		// Extract cacheId from the name: projects/_/buckets/BUCKET/anywhereCaches/CACHE_ID
+		trimmedGot := strings.TrimSpace(got)
+		parts := strings.Split(trimmedGot, "/")
+		cacheId = parts[len(parts)-1]
+	})
+
+	if cacheId == "" {
+		t.Fatal("cacheId is empty, cannot continue tests")
+	}
+
+	// Get Anywhere Cache
+	t.Run("Get", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		if err := getAnywhereCache(buf, bucketName, cacheId); err != nil {
+			t.Errorf("getAnywhereCache: %v", err)
+		}
+		if got, want := buf.String(), cacheId; !strings.Contains(got, want) {
+			t.Errorf("getAnywhereCache: got %q, want to contain %q", got, want)
+		}
+	})
+
+	// List Anywhere Caches
+	t.Run("List", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		if err := listAnywhereCaches(buf, bucketName); err != nil {
+			t.Errorf("listAnywhereCaches: %v", err)
+		}
+		if got, want := buf.String(), cacheId; !strings.Contains(got, want) {
+			t.Errorf("listAnywhereCaches: got %q, want to contain %q", got, want)
+		}
+	})
+
+	// Update Anywhere Cache
+	t.Run("Update", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		if err := updateAnywhereCache(buf, bucketName, cacheId, "admit-on-second-miss"); err != nil {
+			t.Errorf("updateAnywhereCache: %v", err)
+		}
+		if got, want := buf.String(), cacheId; !strings.Contains(got, want) {
+			t.Errorf("updateAnywhereCache: got %q, want to contain %q", got, want)
+		}
+	})
+
+	// Pause Anywhere Cache
+	t.Run("Pause", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		if err := pauseAnywhereCache(buf, bucketName, cacheId); err != nil {
+			t.Errorf("pauseAnywhereCache: %v", err)
+		}
+		if got, want := buf.String(), cacheId; !strings.Contains(got, want) {
+			t.Errorf("pauseAnywhereCache: got %q, want to contain %q", got, want)
+		}
+	})
+
+	// Resume Anywhere Cache
+	t.Run("Resume", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		if err := resumeAnywhereCache(buf, bucketName, cacheId); err != nil {
+			t.Errorf("resumeAnywhereCache: %v", err)
+		}
+		if got, want := buf.String(), cacheId; !strings.Contains(got, want) {
+			t.Errorf("resumeAnywhereCache: got %q, want to contain %q", got, want)
+		}
+	})
+
+	// Disable Anywhere Cache
+	t.Run("Disable", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		if err := disableAnywhereCache(buf, bucketName, cacheId); err != nil {
+			t.Errorf("disableAnywhereCache: %v", err)
+		}
+		if got, want := buf.String(), cacheId; !strings.Contains(got, want) {
+			t.Errorf("disableAnywhereCache: got %q, want to contain %q", got, want)
+		}
+	})
+}

--- a/storage/control/create_anywhere_cache.go
+++ b/storage/control/create_anywhere_cache.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package control
+
+// [START storage_control_create_anywhere_cache]
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	storagecontrol "cloud.google.com/go/storage/control/apiv2"
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
+)
+
+// createAnywhereCache creates an Anywhere Cache instance in the specified zone for the given bucket.
+func createAnywhereCache(w io.Writer, bucket, zone string) error {
+	// bucket := "bucket-name"
+	// zone := "us-central1-a"
+
+	ctx := context.Background()
+	client, err := storagecontrol.NewStorageControlClient(ctx)
+	if err != nil {
+		return fmt.Errorf("NewStorageControlClient: %w", err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*20)
+	defer cancel()
+
+	req := &controlpb.CreateAnywhereCacheRequest{
+		Parent: fmt.Sprintf("projects/_/buckets/%v", bucket),
+		AnywhereCache: &controlpb.AnywhereCache{
+			Zone: zone,
+		},
+	}
+
+	// Start a create operation and block until it completes. Real applications
+	// may want to setup a callback, wait on a coroutine, or poll until it
+	// completes.
+	op, err := client.CreateAnywhereCache(ctx, req)
+	if err != nil {
+		return fmt.Errorf("CreateAnywhereCache: %w", err)
+	}
+
+	cache, err := op.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("Wait: %w", err)
+	}
+
+	fmt.Fprintf(w, "Created anywhere cache: %v\n", cache.GetName())
+	return nil
+}
+
+// [END storage_control_create_anywhere_cache]

--- a/storage/control/disable_anywhere_cache.go
+++ b/storage/control/disable_anywhere_cache.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package control
+
+// [START storage_control_disable_anywhere_cache]
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	storagecontrol "cloud.google.com/go/storage/control/apiv2"
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
+)
+
+// disableAnywhereCache disables an Anywhere Cache instance.
+func disableAnywhereCache(w io.Writer, bucket, cacheId string) error {
+	// bucket := "bucket-name"
+	// cacheId := "00b0c000-0000-0000-0000-000000000000"
+
+	ctx := context.Background()
+	client, err := storagecontrol.NewStorageControlClient(ctx)
+	if err != nil {
+		return fmt.Errorf("NewStorageControlClient: %w", err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	name := fmt.Sprintf("projects/_/buckets/%v/anywhereCaches/%v", bucket, cacheId)
+	req := &controlpb.DisableAnywhereCacheRequest{
+		Name: name,
+	}
+
+	cache, err := client.DisableAnywhereCache(ctx, req)
+	if err != nil {
+		return fmt.Errorf("DisableAnywhereCache: %w", err)
+	}
+
+	fmt.Fprintf(w, "Disabled anywhere cache: %v\n", cache.GetName())
+	return nil
+}
+
+// [END storage_control_disable_anywhere_cache]

--- a/storage/control/get_anywhere_cache.go
+++ b/storage/control/get_anywhere_cache.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package control
+
+// [START storage_control_get_anywhere_cache]
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	storagecontrol "cloud.google.com/go/storage/control/apiv2"
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
+)
+
+// getAnywhereCache gets the metadata of an Anywhere Cache instance.
+func getAnywhereCache(w io.Writer, bucket, cacheId string) error {
+	// bucket := "bucket-name"
+	// cacheId := "00b0c000-0000-0000-0000-000000000000"
+
+	ctx := context.Background()
+	client, err := storagecontrol.NewStorageControlClient(ctx)
+	if err != nil {
+		return fmt.Errorf("NewStorageControlClient: %w", err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	name := fmt.Sprintf("projects/_/buckets/%v/anywhereCaches/%v", bucket, cacheId)
+	req := &controlpb.GetAnywhereCacheRequest{
+		Name: name,
+	}
+
+	cache, err := client.GetAnywhereCache(ctx, req)
+	if err != nil {
+		return fmt.Errorf("GetAnywhereCache: %w", err)
+	}
+
+	fmt.Fprintf(w, "Got anywhere cache: %v\n", cache.GetName())
+	return nil
+}
+
+// [END storage_control_get_anywhere_cache]

--- a/storage/control/list_anywhere_caches.go
+++ b/storage/control/list_anywhere_caches.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package control
+
+// [START storage_control_list_anywhere_caches]
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	storagecontrol "cloud.google.com/go/storage/control/apiv2"
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
+	"google.golang.org/api/iterator"
+)
+
+// listAnywhereCaches lists the Anywhere Cache instances for a given bucket.
+func listAnywhereCaches(w io.Writer, bucket string) error {
+	// bucket := "bucket-name"
+
+	ctx := context.Background()
+	client, err := storagecontrol.NewStorageControlClient(ctx)
+	if err != nil {
+		return fmt.Errorf("NewStorageControlClient: %w", err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	parent := fmt.Sprintf("projects/_/buckets/%v", bucket)
+	req := &controlpb.ListAnywhereCachesRequest{
+		Parent: parent,
+	}
+
+	it := client.ListAnywhereCaches(ctx, req)
+	for {
+		cache, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("Next: %w", err)
+		}
+		fmt.Fprintf(w, "%v\n", cache.GetName())
+	}
+
+	return nil
+}
+
+// [END storage_control_list_anywhere_caches]

--- a/storage/control/pause_anywhere_cache.go
+++ b/storage/control/pause_anywhere_cache.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package control
+
+// [START storage_control_pause_anywhere_cache]
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	storagecontrol "cloud.google.com/go/storage/control/apiv2"
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
+)
+
+// pauseAnywhereCache pauses an Anywhere Cache instance.
+func pauseAnywhereCache(w io.Writer, bucket, cacheId string) error {
+	// bucket := "bucket-name"
+	// cacheId := "00b0c000-0000-0000-0000-000000000000"
+
+	ctx := context.Background()
+	client, err := storagecontrol.NewStorageControlClient(ctx)
+	if err != nil {
+		return fmt.Errorf("NewStorageControlClient: %w", err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	name := fmt.Sprintf("projects/_/buckets/%v/anywhereCaches/%v", bucket, cacheId)
+	req := &controlpb.PauseAnywhereCacheRequest{
+		Name: name,
+	}
+
+	cache, err := client.PauseAnywhereCache(ctx, req)
+	if err != nil {
+		return fmt.Errorf("PauseAnywhereCache: %w", err)
+	}
+
+	fmt.Fprintf(w, "Paused anywhere cache: %v\n", cache.GetName())
+	return nil
+}
+
+// [END storage_control_pause_anywhere_cache]

--- a/storage/control/resume_anywhere_cache.go
+++ b/storage/control/resume_anywhere_cache.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package control
+
+// [START storage_control_resume_anywhere_cache]
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	storagecontrol "cloud.google.com/go/storage/control/apiv2"
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
+)
+
+// resumeAnywhereCache resumes a paused Anywhere Cache instance.
+func resumeAnywhereCache(w io.Writer, bucket, cacheId string) error {
+	// bucket := "bucket-name"
+	// cacheId := "00b0c000-0000-0000-0000-000000000000"
+
+	ctx := context.Background()
+	client, err := storagecontrol.NewStorageControlClient(ctx)
+	if err != nil {
+		return fmt.Errorf("NewStorageControlClient: %w", err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	name := fmt.Sprintf("projects/_/buckets/%v/anywhereCaches/%v", bucket, cacheId)
+	req := &controlpb.ResumeAnywhereCacheRequest{
+		Name: name,
+	}
+
+	cache, err := client.ResumeAnywhereCache(ctx, req)
+	if err != nil {
+		return fmt.Errorf("ResumeAnywhereCache: %w", err)
+	}
+
+	fmt.Fprintf(w, "Resumed anywhere cache: %v\n", cache.GetName())
+	return nil
+}
+
+// [END storage_control_resume_anywhere_cache]

--- a/storage/control/update_anywhere_cache.go
+++ b/storage/control/update_anywhere_cache.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package control
+
+// [START storage_control_update_anywhere_cache]
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	storagecontrol "cloud.google.com/go/storage/control/apiv2"
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+)
+
+// updateAnywhereCache updates the admission policy of an Anywhere Cache instance.
+func updateAnywhereCache(w io.Writer, bucket, cacheId, admissionPolicy string) error {
+	// bucket := "bucket-name"
+	// cacheId := "00b0c000-0000-0000-0000-000000000000"
+	// admissionPolicy := "admit-on-second-miss"
+
+	ctx := context.Background()
+	client, err := storagecontrol.NewStorageControlClient(ctx)
+	if err != nil {
+		return fmt.Errorf("NewStorageControlClient: %w", err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*20)
+	defer cancel()
+
+	name := fmt.Sprintf("projects/_/buckets/%v/anywhereCaches/%v", bucket, cacheId)
+	req := &controlpb.UpdateAnywhereCacheRequest{
+		AnywhereCache: &controlpb.AnywhereCache{
+			Name:            name,
+			AdmissionPolicy: admissionPolicy,
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{
+			Paths: []string{"admission_policy"},
+		},
+	}
+
+	// Start an update operation and block until it completes. Real applications
+	// may want to setup a callback, wait on a coroutine, or poll until it
+	// completes.
+	op, err := client.UpdateAnywhereCache(ctx, req)
+	if err != nil {
+		return fmt.Errorf("UpdateAnywhereCache: %w", err)
+	}
+
+	cache, err := op.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("Wait: %w", err)
+	}
+
+	fmt.Fprintf(w, "Updated anywhere cache: %v\n", cache.GetName())
+	return nil
+}
+
+// [END storage_control_update_anywhere_cache]


### PR DESCRIPTION
Implement seven new code samples for the Storage Control API's 'Anywhere Cache' feature in Go. These samples cover the full lifecycle of an Anywhere Cache instance: creation (handling LRO), retrieval, listing, updating (with field mask), pausing, resuming, and disabling.

Key features:

Uses cloud.google.com/go/storage/control/apiv2 with storagecontrol alias.
Handles LROs with synchronous .Wait(ctx) for simplicity in samples.
Strictly follows region tag and 2026 copyright requirements.
Provides a comprehensive integration test ensuring all operations work in sequence.
Verified compilation and passing (skipping) tests locally.
