### PR TITLE
feat(storage): Added samples for Anywhere Cache

### DIFF
--- a/storage/control/anywhere_caches_test.go
+++ b/storage/control/anywhere_caches_test.go
@@ -60,7 +60,7 @@ func TestAnywhereCaches(t *testing.T) {
 	// Create
 	if ok := testutil.Retry(t, 5, time.Second, func(r *testutil.R) {
 		buf := &bytes.Buffer{}
-		if err := createAnywhereCache(buf, bucketName, cacheName, zoneName); err != nil {
+		if err := createAnywhereCache(buf, bucketName, zoneName); err != nil {
 			r.Errorf("createAnywhereCache: %v", err)
 		}
 		// Match partial resource name to handle project numbers/IDs as per memory.
@@ -87,48 +87,72 @@ func TestAnywhereCaches(t *testing.T) {
 	}
 
 	// List
-	buf := &bytes.Buffer{}
-	if err := listAnywhereCaches(buf, bucketName); err != nil {
-		t.Fatalf("listAnywhereCaches: %v", err)
-	}
-	want := fmt.Sprintf("buckets/%s/anywhereCaches/%s", bucketName, zoneName)
-	if got := buf.String(); !strings.Contains(got, want) {
-		t.Errorf("listAnywhereCaches: got %q, want to contain %q", got, want)
+	if ok := testutil.Retry(t, 5, time.Second, func(r *testutil.R) {
+		buf := &bytes.Buffer{}
+		if err := listAnywhereCaches(buf, bucketName); err != nil {
+			r.Errorf("listAnywhereCaches: %v", err)
+		}
+		want := fmt.Sprintf("buckets/%s/anywhereCaches/%s", bucketName, zoneName)
+		if got := buf.String(); !strings.Contains(got, want) {
+			r.Errorf("listAnywhereCaches: got %q, want to contain %q", got, want)
+		}
+	}); !ok {
+		t.Errorf("failed to list anywhere caches")
 	}
 
 	// Update
-	buf.Reset()
-	if err := updateAnywhereCache(buf, cacheName, "admit-on-second-miss"); err != nil {
-		t.Fatalf("updateAnywhereCache: %v", err)
-	}
-	if got := buf.String(); !strings.Contains(got, want) {
-		t.Errorf("updateAnywhereCache: got %q, want to contain %q", got, want)
+	if ok := testutil.Retry(t, 5, time.Second, func(r *testutil.R) {
+		buf := &bytes.Buffer{}
+		if err := updateAnywhereCache(buf, cacheName, "admit-on-second-miss"); err != nil {
+			r.Errorf("updateAnywhereCache: %v", err)
+		}
+		want := fmt.Sprintf("buckets/%s/anywhereCaches/%s", bucketName, zoneName)
+		if got := buf.String(); !strings.Contains(got, want) {
+			r.Errorf("updateAnywhereCache: got %q, want to contain %q", got, want)
+		}
+	}); !ok {
+		t.Errorf("failed to update anywhere cache")
 	}
 
 	// Pause
-	buf.Reset()
-	if err := pauseAnywhereCache(buf, cacheName); err != nil {
-		t.Fatalf("pauseAnywhereCache: %v", err)
-	}
-	if got := buf.String(); !strings.Contains(got, want) {
-		t.Errorf("pauseAnywhereCache: got %q, want to contain %q", got, want)
+	if ok := testutil.Retry(t, 5, time.Second, func(r *testutil.R) {
+		buf := &bytes.Buffer{}
+		if err := pauseAnywhereCache(buf, cacheName); err != nil {
+			r.Errorf("pauseAnywhereCache: %v", err)
+		}
+		want := fmt.Sprintf("buckets/%s/anywhereCaches/%s", bucketName, zoneName)
+		if got := buf.String(); !strings.Contains(got, want) {
+			r.Errorf("pauseAnywhereCache: got %q, want to contain %q", got, want)
+		}
+	}); !ok {
+		t.Errorf("failed to pause anywhere cache")
 	}
 
 	// Resume
-	buf.Reset()
-	if err := resumeAnywhereCache(buf, cacheName); err != nil {
-		t.Fatalf("resumeAnywhereCache: %v", err)
-	}
-	if got := buf.String(); !strings.Contains(got, want) {
-		t.Errorf("resumeAnywhereCache: got %q, want to contain %q", got, want)
+	if ok := testutil.Retry(t, 5, time.Second, func(r *testutil.R) {
+		buf := &bytes.Buffer{}
+		if err := resumeAnywhereCache(buf, cacheName); err != nil {
+			r.Errorf("resumeAnywhereCache: %v", err)
+		}
+		want := fmt.Sprintf("buckets/%s/anywhereCaches/%s", bucketName, zoneName)
+		if got := buf.String(); !strings.Contains(got, want) {
+			r.Errorf("resumeAnywhereCache: got %q, want to contain %q", got, want)
+		}
+	}); !ok {
+		t.Errorf("failed to resume anywhere cache")
 	}
 
 	// Disable
-	buf.Reset()
-	if err := disableAnywhereCache(buf, cacheName); err != nil {
-		t.Fatalf("disableAnywhereCache: %v", err)
-	}
-	if got := buf.String(); !strings.Contains(got, want) {
-		t.Errorf("disableAnywhereCache: got %q, want to contain %q", got, want)
+	if ok := testutil.Retry(t, 5, time.Second, func(r *testutil.R) {
+		buf := &bytes.Buffer{}
+		if err := disableAnywhereCache(buf, cacheName); err != nil {
+			r.Errorf("disableAnywhereCache: %v", err)
+		}
+		want := fmt.Sprintf("buckets/%s/anywhereCaches/%s", bucketName, zoneName)
+		if got := buf.String(); !strings.Contains(got, want) {
+			r.Errorf("disableAnywhereCache: got %q, want to contain %q", got, want)
+		}
+	}); !ok {
+		t.Errorf("failed to disable anywhere cache")
 	}
 }

--- a/storage/control/anywhere_caches_test.go
+++ b/storage/control/anywhere_caches_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package control
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
+)
+
+func TestAnywhereCaches(t *testing.T) {
+	tc := testutil.SystemTest(t)
+	ctx := context.Background()
+
+	// Use a local client to ensure isolation as per memory.
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		t.Fatalf("storage.NewClient: %v", err)
+	}
+	defer client.Close()
+
+	const testPrefix = "storage-control-ac-test"
+
+	bucketName := testutil.UniqueBucketName(testPrefix)
+	b := client.Bucket(bucketName)
+	attrs := &storage.BucketAttrs{
+		UniformBucketLevelAccess: storage.UniformBucketLevelAccess{Enabled: true},
+	}
+	if err := b.Create(ctx, tc.ProjectID, attrs); err != nil {
+		t.Fatalf("Bucket.Create(%q): %v", bucketName, err)
+	}
+	t.Cleanup(func() {
+		if err := testutil.DeleteBucketIfExists(ctx, client, bucketName); err != nil {
+			log.Printf("Bucket.Delete(%q): %v", bucketName, err)
+		}
+	})
+
+	zoneName := "us-central1-a"
+	cacheName := fmt.Sprintf("projects/_/buckets/%s/anywhereCaches/%s", bucketName, zoneName)
+
+	// Create
+	if ok := testutil.Retry(t, 5, time.Second, func(r *testutil.R) {
+		buf := &bytes.Buffer{}
+		if err := createAnywhereCache(buf, bucketName, cacheName, zoneName); err != nil {
+			r.Errorf("createAnywhereCache: %v", err)
+		}
+		// Match partial resource name to handle project numbers/IDs as per memory.
+		want := fmt.Sprintf("buckets/%s/anywhereCaches/%s", bucketName, zoneName)
+		if got := buf.String(); !strings.Contains(got, want) {
+			r.Errorf("createAnywhereCache: got %q, want to contain %q", got, want)
+		}
+	}); !ok {
+		t.Fatalf("failed to create anywhere cache; can't continue")
+	}
+
+	// Get
+	if ok := testutil.Retry(t, 5, time.Second, func(r *testutil.R) {
+		buf := &bytes.Buffer{}
+		if err := getAnywhereCache(buf, cacheName); err != nil {
+			r.Errorf("getAnywhereCache: %v", err)
+		}
+		want := fmt.Sprintf("buckets/%s/anywhereCaches/%s", bucketName, zoneName)
+		if got := buf.String(); !strings.Contains(got, want) {
+			r.Errorf("getAnywhereCache: got %q, want to contain %q", got, want)
+		}
+	}); !ok {
+		t.Fatalf("failed to get anywhere cache; can't continue")
+	}
+
+	// List
+	buf := &bytes.Buffer{}
+	if err := listAnywhereCaches(buf, bucketName); err != nil {
+		t.Fatalf("listAnywhereCaches: %v", err)
+	}
+	want := fmt.Sprintf("buckets/%s/anywhereCaches/%s", bucketName, zoneName)
+	if got := buf.String(); !strings.Contains(got, want) {
+		t.Errorf("listAnywhereCaches: got %q, want to contain %q", got, want)
+	}
+
+	// Update
+	buf.Reset()
+	if err := updateAnywhereCache(buf, cacheName, "admit-on-second-miss"); err != nil {
+		t.Fatalf("updateAnywhereCache: %v", err)
+	}
+	if got := buf.String(); !strings.Contains(got, want) {
+		t.Errorf("updateAnywhereCache: got %q, want to contain %q", got, want)
+	}
+
+	// Pause
+	buf.Reset()
+	if err := pauseAnywhereCache(buf, cacheName); err != nil {
+		t.Fatalf("pauseAnywhereCache: %v", err)
+	}
+	if got := buf.String(); !strings.Contains(got, want) {
+		t.Errorf("pauseAnywhereCache: got %q, want to contain %q", got, want)
+	}
+
+	// Resume
+	buf.Reset()
+	if err := resumeAnywhereCache(buf, cacheName); err != nil {
+		t.Fatalf("resumeAnywhereCache: %v", err)
+	}
+	if got := buf.String(); !strings.Contains(got, want) {
+		t.Errorf("resumeAnywhereCache: got %q, want to contain %q", got, want)
+	}
+
+	// Disable
+	buf.Reset()
+	if err := disableAnywhereCache(buf, cacheName); err != nil {
+		t.Fatalf("disableAnywhereCache: %v", err)
+	}
+	if got := buf.String(); !strings.Contains(got, want) {
+		t.Errorf("disableAnywhereCache: got %q, want to contain %q", got, want)
+	}
+}

--- a/storage/control/create_anywhere_cache.go
+++ b/storage/control/create_anywhere_cache.go
@@ -26,9 +26,8 @@ import (
 )
 
 // createAnywhereCache creates an anywhere cache in the bucket and zone.
-func createAnywhereCache(w io.Writer, bucket, cacheName, zone string) error {
+func createAnywhereCache(w io.Writer, bucket, zone string) error {
 	// bucket := "bucket-name"
-	// cacheName := "projects/_/buckets/bucket-name/anywhereCaches/us-central1-a"
 	// zone := "us-central1-a"
 
 	ctx := context.Background()
@@ -44,7 +43,6 @@ func createAnywhereCache(w io.Writer, bucket, cacheName, zone string) error {
 	req := &controlpb.CreateAnywhereCacheRequest{
 		Parent: fmt.Sprintf("projects/_/buckets/%s", bucket),
 		AnywhereCache: &controlpb.AnywhereCache{
-			Name: cacheName,
 			Zone: zone,
 		},
 	}
@@ -53,7 +51,7 @@ func createAnywhereCache(w io.Writer, bucket, cacheName, zone string) error {
 	// Blocking with .Wait(ctx) is for simplicity and real applications may prefer callbacks, coroutines, or polling.
 	op, err := client.CreateAnywhereCache(ctx, req)
 	if err != nil {
-		return fmt.Errorf("CreateAnywhereCache(%q): %w", cacheName, err)
+		return fmt.Errorf("CreateAnywhereCache: %w", err)
 	}
 
 	anywhereCache, err := op.Wait(ctx)

--- a/storage/control/create_anywhere_cache.go
+++ b/storage/control/create_anywhere_cache.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package control
+
+// [START storage_control_create_anywhere_cache]
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	storagecontrol "cloud.google.com/go/storage/control/apiv2"
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
+)
+
+// createAnywhereCache creates an anywhere cache in the bucket and zone.
+func createAnywhereCache(w io.Writer, bucket, cacheName, zone string) error {
+	// bucket := "bucket-name"
+	// cacheName := "projects/_/buckets/bucket-name/anywhereCaches/us-central1-a"
+	// zone := "us-central1-a"
+
+	ctx := context.Background()
+	client, err := storagecontrol.NewStorageControlClient(ctx)
+	if err != nil {
+		return fmt.Errorf("storagecontrol.NewStorageControlClient: %w", err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*20)
+	defer cancel()
+
+	req := &controlpb.CreateAnywhereCacheRequest{
+		Parent: fmt.Sprintf("projects/_/buckets/%s", bucket),
+		AnywhereCache: &controlpb.AnywhereCache{
+			Name: cacheName,
+			Zone: zone,
+		},
+	}
+
+	// Start a create operation and block until it completes.
+	// Blocking with .Wait(ctx) is for simplicity and real applications may prefer callbacks, coroutines, or polling.
+	op, err := client.CreateAnywhereCache(ctx, req)
+	if err != nil {
+		return fmt.Errorf("CreateAnywhereCache(%q): %w", cacheName, err)
+	}
+
+	anywhereCache, err := op.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("Wait: %w", err)
+	}
+
+	fmt.Fprintf(w, "Created anywhere cache: %s\n", anywhereCache.GetName())
+	return nil
+}
+
+// [END storage_control_create_anywhere_cache]

--- a/storage/control/disable_anywhere_cache.go
+++ b/storage/control/disable_anywhere_cache.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package control
+
+// [START storage_control_disable_anywhere_cache]
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	storagecontrol "cloud.google.com/go/storage/control/apiv2"
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
+)
+
+// disableAnywhereCache disables an anywhere cache.
+func disableAnywhereCache(w io.Writer, cacheName string) error {
+	// cacheName := "projects/_/buckets/bucket-name/anywhereCaches/us-central1-a"
+
+	ctx := context.Background()
+	client, err := storagecontrol.NewStorageControlClient(ctx)
+	if err != nil {
+		return fmt.Errorf("storagecontrol.NewStorageControlClient: %w", err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	req := &controlpb.DisableAnywhereCacheRequest{
+		Name: cacheName,
+	}
+
+	anywhereCache, err := client.DisableAnywhereCache(ctx, req)
+	if err != nil {
+		return fmt.Errorf("DisableAnywhereCache(%q): %w", cacheName, err)
+	}
+
+	fmt.Fprintf(w, "Disabled anywhere cache: %s\n", anywhereCache.GetName())
+	return nil
+}
+
+// [END storage_control_disable_anywhere_cache]

--- a/storage/control/get_anywhere_cache.go
+++ b/storage/control/get_anywhere_cache.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package control
+
+// [START storage_control_get_anywhere_cache]
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	storagecontrol "cloud.google.com/go/storage/control/apiv2"
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
+)
+
+// getAnywhereCache gets an anywhere cache by its name.
+func getAnywhereCache(w io.Writer, cacheName string) error {
+	// cacheName := "projects/_/buckets/bucket-name/anywhereCaches/us-central1-a"
+
+	ctx := context.Background()
+	client, err := storagecontrol.NewStorageControlClient(ctx)
+	if err != nil {
+		return fmt.Errorf("storagecontrol.NewStorageControlClient: %w", err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	req := &controlpb.GetAnywhereCacheRequest{
+		Name: cacheName,
+	}
+
+	anywhereCache, err := client.GetAnywhereCache(ctx, req)
+	if err != nil {
+		return fmt.Errorf("GetAnywhereCache(%q): %w", cacheName, err)
+	}
+
+	fmt.Fprintf(w, "Got anywhere cache: %s\n", anywhereCache.GetName())
+	return nil
+}
+
+// [END storage_control_get_anywhere_cache]

--- a/storage/control/list_anywhere_caches.go
+++ b/storage/control/list_anywhere_caches.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package control
+
+// [START storage_control_list_anywhere_caches]
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	storagecontrol "cloud.google.com/go/storage/control/apiv2"
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
+	"google.golang.org/api/iterator"
+)
+
+// listAnywhereCaches lists all anywhere caches in the given bucket.
+func listAnywhereCaches(w io.Writer, bucket string) error {
+	// bucket := "bucket-name"
+
+	ctx := context.Background()
+	client, err := storagecontrol.NewStorageControlClient(ctx)
+	if err != nil {
+		return fmt.Errorf("storagecontrol.NewStorageControlClient: %w", err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	req := &controlpb.ListAnywhereCachesRequest{
+		Parent: fmt.Sprintf("projects/_/buckets/%s", bucket),
+	}
+
+	it := client.ListAnywhereCaches(ctx, req)
+	for {
+		anywhereCache, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("it.Next: %w", err)
+		}
+		fmt.Fprintf(w, "%s\n", anywhereCache.GetName())
+	}
+
+	return nil
+}
+
+// [END storage_control_list_anywhere_caches]

--- a/storage/control/pause_anywhere_cache.go
+++ b/storage/control/pause_anywhere_cache.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package control
+
+// [START storage_control_pause_anywhere_cache]
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	storagecontrol "cloud.google.com/go/storage/control/apiv2"
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
+)
+
+// pauseAnywhereCache pauses an anywhere cache.
+func pauseAnywhereCache(w io.Writer, cacheName string) error {
+	// cacheName := "projects/_/buckets/bucket-name/anywhereCaches/us-central1-a"
+
+	ctx := context.Background()
+	client, err := storagecontrol.NewStorageControlClient(ctx)
+	if err != nil {
+		return fmt.Errorf("storagecontrol.NewStorageControlClient: %w", err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	req := &controlpb.PauseAnywhereCacheRequest{
+		Name: cacheName,
+	}
+
+	anywhereCache, err := client.PauseAnywhereCache(ctx, req)
+	if err != nil {
+		return fmt.Errorf("PauseAnywhereCache(%q): %w", cacheName, err)
+	}
+
+	fmt.Fprintf(w, "Paused anywhere cache: %s\n", anywhereCache.GetName())
+	return nil
+}
+
+// [END storage_control_pause_anywhere_cache]

--- a/storage/control/resume_anywhere_cache.go
+++ b/storage/control/resume_anywhere_cache.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package control
+
+// [START storage_control_resume_anywhere_cache]
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	storagecontrol "cloud.google.com/go/storage/control/apiv2"
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
+)
+
+// resumeAnywhereCache resumes an anywhere cache.
+func resumeAnywhereCache(w io.Writer, cacheName string) error {
+	// cacheName := "projects/_/buckets/bucket-name/anywhereCaches/us-central1-a"
+
+	ctx := context.Background()
+	client, err := storagecontrol.NewStorageControlClient(ctx)
+	if err != nil {
+		return fmt.Errorf("storagecontrol.NewStorageControlClient: %w", err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	req := &controlpb.ResumeAnywhereCacheRequest{
+		Name: cacheName,
+	}
+
+	anywhereCache, err := client.ResumeAnywhereCache(ctx, req)
+	if err != nil {
+		return fmt.Errorf("ResumeAnywhereCache(%q): %w", cacheName, err)
+	}
+
+	fmt.Fprintf(w, "Resumed anywhere cache: %s\n", anywhereCache.GetName())
+	return nil
+}
+
+// [END storage_control_resume_anywhere_cache]

--- a/storage/control/update_anywhere_cache.go
+++ b/storage/control/update_anywhere_cache.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package control
+
+// [START storage_control_update_anywhere_cache]
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	storagecontrol "cloud.google.com/go/storage/control/apiv2"
+	"cloud.google.com/go/storage/control/apiv2/controlpb"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+)
+
+// updateAnywhereCache updates an anywhere cache with a new admission policy.
+func updateAnywhereCache(w io.Writer, cacheName, admissionPolicy string) error {
+	// cacheName := "projects/_/buckets/bucket-name/anywhereCaches/us-central1-a"
+	// admissionPolicy := "admit-on-second-miss"
+
+	ctx := context.Background()
+	client, err := storagecontrol.NewStorageControlClient(ctx)
+	if err != nil {
+		return fmt.Errorf("storagecontrol.NewStorageControlClient: %w", err)
+	}
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*20)
+	defer cancel()
+
+	req := &controlpb.UpdateAnywhereCacheRequest{
+		AnywhereCache: &controlpb.AnywhereCache{
+			Name:            cacheName,
+			AdmissionPolicy: admissionPolicy,
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{
+			Paths: []string{"admission_policy"},
+		},
+	}
+
+	// Start an update operation and block until it completes.
+	// Blocking with .Wait(ctx) is for simplicity and real applications may prefer callbacks, coroutines, or polling.
+	op, err := client.UpdateAnywhereCache(ctx, req)
+	if err != nil {
+		return fmt.Errorf("UpdateAnywhereCache(%q): %w", cacheName, err)
+	}
+
+	anywhereCache, err := op.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("Wait: %w", err)
+	}
+
+	fmt.Fprintf(w, "Updated anywhere cache: %s\n", anywhereCache.GetName())
+	return nil
+}
+
+// [END storage_control_update_anywhere_cache]


### PR DESCRIPTION
This commit adds Go code samples and integration tests for the Storage Control Anywhere Cache API.

Operations included:
- CreateAnywhereCache
- GetAnywhereCache
- ListAnywhereCaches
- UpdateAnywhereCache
- PauseAnywhereCache
- ResumeAnywhereCache
- DisableAnywhereCache

The implementation follows the repository's patterns for LRO handling, field masks, and integration testing. 