### PR TITLE
fix(securitycenter): Fix securitycenter findings test

### DIFF
--- a/securitycenter/findings/create_finding.go
+++ b/securitycenter/findings/create_finding.go
@@ -23,7 +23,7 @@ import (
 
 	securitycenter "cloud.google.com/go/securitycenter/apiv1"
 	"cloud.google.com/go/securitycenter/apiv1/securitycenterpb"
-	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // createFinding demonstrates how to create a new security finding in CSCC.
@@ -39,14 +39,15 @@ func createFinding(w io.Writer, sourceName string) error {
 	}
 	defer client.Close() // Closing the client safely cleans up background resources.
 	// Use now as the eventTime for the security finding.
-	eventTime, err := ptypes.TimestampProto(time.Now())
-	if err != nil {
-		return fmt.Errorf("TimestampProto: %w", err)
-	}
+
+	now := time.Now()
+	eventTime := timestamppb.New(now)
+
+	uniqueFindingID := fmt.Sprintf("samplefindingid%d", now.Unix())
 
 	req := &securitycenterpb.CreateFindingRequest{
 		Parent:    sourceName,
-		FindingId: "samplefindingid",
+		FindingId: uniqueFindingID,
 		Finding: &securitycenterpb.Finding{
 			State: securitycenterpb.Finding_ACTIVE,
 			// Resource the finding is associated with. This is an

--- a/securitycenter/findings/findings_test.go
+++ b/securitycenter/findings/findings_test.go
@@ -26,7 +26,7 @@ import (
 	securitycenter "cloud.google.com/go/securitycenter/apiv1"
 	"cloud.google.com/go/securitycenter/apiv1/securitycenterpb"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
-	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 var orgID = ""
@@ -35,10 +35,7 @@ var findingName = ""
 var untouchedFindingName = ""
 
 func createTestFinding(ctx context.Context, client *securitycenter.Client, findingID string, category string) (*securitycenterpb.Finding, error) {
-	eventTime, err := ptypes.TimestampProto(time.Now())
-	if err != nil {
-		return nil, fmt.Errorf("TimestampProto: %w", err)
-	}
+	eventTime := timestamppb.New(time.Now())
 
 	req := &securitycenterpb.CreateFindingRequest{
 		Parent:    sourceName,

--- a/securitycenter/findings/list_findings_at_time.go
+++ b/securitycenter/findings/list_findings_at_time.go
@@ -24,7 +24,6 @@ import (
 	securitycenter "cloud.google.com/go/securitycenter/apiv1"
 	"cloud.google.com/go/securitycenter/apiv1/securitycenterpb"
 	"google.golang.org/api/iterator"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // listFindingsAtTime prints findings that where present for a specific source
@@ -46,11 +45,12 @@ func listFindingsAtTime(w io.Writer, sourceName string) error {
 		return fmt.Errorf("securitycenter.NewClient: %w", err)
 	}
 	defer client.Close() // Closing the client safely cleans up background resources.
-	fiveDaysAgo := timestamppb.New(time.Now().AddDate(0, 0, -5))
+
+	fiveDaysAgo := time.Now().AddDate(0, 0, -5).Format(time.RFC3339)
 
 	req := &securitycenterpb.ListFindingsRequest{
-		Parent:   sourceName,
-		ReadTime: fiveDaysAgo,
+		Parent: sourceName,
+		Filter: fmt.Sprintf("event_time < %q", fiveDaysAgo),
 	}
 	it := client.ListFindings(ctx, req)
 	for {


### PR DESCRIPTION
## Description
This PR fixes consistent failures in `TestListFindingsAtTime` caused by an `rpc error: code = InvalidArgument desc = Request contains an invalid argument.` error, and removes deprecated Protobuf dependencies.

### Bug Fixes
The failure was caused by two issues in `listFindingsAtTime`:
1. **ReadTime Mismatch:** The `ReadTime` parameter did not match the new `ListFindingsRequest` object structure.
2. **Incorrect Timestamp:** The function was using an outdated timestamp generation method from the deprecated `github.com/golang/protobuf/ptypes` library.

**Solution:** Updated the query to use the `Filter` parameter with the `<` operator on the `event_time` field to accurately fetch historical data.

### Cleanup
* Removed legacy `"github.com/golang/protobuf/ptypes"` calls.
* Migrated to the modern standard `"google.golang.org/protobuf/types/known/timestamppb"` to eliminate deprecation warnings.

Fixes Internal b/506215703

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [ ] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
