### PR TITLE
ci(github-actions): upgrade checkout to v4 and enforce read-only permissions

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -15,13 +15,15 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
         go-version: 'stable'
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Build code
       # Use find to build all modules. '-execdir ... ;' doesn't set an exit code
       # based on command results. So, create a file if a build fails and check
@@ -33,13 +35,15 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
         go-version: 'stable'
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     # #4374 Pin goimports at v0.22.0
     - name: Install goimports
       run: go install golang.org/x/tools/cmd/goimports@v0.22.0
@@ -61,13 +65,15 @@ jobs:
   vet:
     name: Vet
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
         go-version: 'stable'
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: go vet
       # Use find to build all modules. '-execdir ... ;' doesn't set an exit code
       # based on command results. So, create a file if a build fails and check
@@ -79,11 +85,13 @@ jobs:
   test:
     name: Root tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: 'stable'
       - name: Check code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - run: go test -v

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -23,7 +23,7 @@ jobs:
       with:
         go-version: 'stable'
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Build code
       # Use find to build all modules. '-execdir ... ;' doesn't set an exit code
       # based on command results. So, create a file if a build fails and check
@@ -39,11 +39,11 @@ jobs:
       contents: read
     steps:
     - name: Setup Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: 'stable'
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     # #4374 Pin goimports at v0.22.0
     - name: Install goimports
       run: go install golang.org/x/tools/cmd/goimports@v0.22.0
@@ -73,7 +73,7 @@ jobs:
       with:
         go-version: 'stable'
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: go vet
       # Use find to build all modules. '-execdir ... ;' doesn't set an exit code
       # based on command results. So, create a file if a build fails and check
@@ -93,5 +93,5 @@ jobs:
         with:
           go-version: 'stable'
       - name: Check code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - run: go test -v


### PR DESCRIPTION
## Description
This PR modernizes our CI pipeline by upgrading `actions/checkout@v2` to `v6`, ensuring our workflows run on the supported `Node 24` environment and avoiding deprecation warnings. Additionally, it explicitly defines `permissions: contents: read` on both the build and vet jobs to lock down the workflows and enforce least-privilege security practices.

Fixes Internal b/517173677

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
