### PR TITLE
docs(vision): fix broken "Go Code" link for label detection

### DIFF
--- a/vision/README.md
+++ b/vision/README.md
@@ -8,7 +8,7 @@ This directory contains [Cloud Vision API](https://cloud.google.com/vision/) Go 
 
 See the [label detection](https://cloud.google.com/vision/docs/label-tutorial) tutorial in the docs.
 
-[Go Code](label)
+[Go Code](detect)
 
 ### Detect Content
 


### PR DESCRIPTION
The label-detection section of `vision/README.md` links to `label`, but there is no `label/` directory. The label-detection sample lives in `detect/` (`detectLabels` in `detect/detect.go`, under the `vision_label_detection` region — the sibling "Detect Content" section already links to `detect`). This points the link at `detect` so it resolves.

Docs-only, one line.