### PR TITLE
chore(vertexai): Decommission create context cache region tag

### DIFF
--- a/vertexai/context-caching/contextcaching_create.go
+++ b/vertexai/context-caching/contextcaching_create.go
@@ -15,7 +15,6 @@
 // contextcaching shows an example of caching the tokens of a multimodal PDF prompt
 package contextcaching
 
-// [START generativeaionvertexai_gemini_create_context_cache]
 import (
 	"context"
 	"fmt"
@@ -77,5 +76,3 @@ func createContextCache(w io.Writer, projectID, location, modelName string) (str
 	fmt.Fprint(w, result.Name)
 	return result.Name, nil
 }
-
-// [END generativeaionvertexai_gemini_create_context_cache]

--- a/vertexai/context-caching/contextcaching_test.go
+++ b/vertexai/context-caching/contextcaching_test.go
@@ -28,6 +28,7 @@ import (
 // TestContextCaching tests createContextCache, getContextCache, useContextCache,
 // updateContextCache, deleteContextCache.
 func TestContextCaching(t *testing.T) {
+	t.Skip("Skipped while waiting to decommission vertexai")
 	tc := testutil.SystemTest(t)
 
 	buf := new(bytes.Buffer)


### PR DESCRIPTION
## Description

Fixes Internal b/526630469

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
