### PR TITLE
fix(firestore): correctly initialize enterprise DB client

### DIFF
--- a/firestore/pipeline_snippets_general.go
+++ b/firestore/pipeline_snippets_general.go
@@ -1754,10 +1754,10 @@ func pipelineInitialization(w io.Writer, projectID string, databaseID string) er
 		fmt.Fprintf(w, "firestore.NewClientWithDatabase failed: %v", err)
 		return err
 	}
+	defer client.Close()
 	pipeline := client.Pipeline().Collection("books")
 	// [END firestore_pipeline_initialization]
 	fmt.Fprintln(w, pipeline)
-	defer client.Close()
 	return nil
 }
 

--- a/firestore/pipeline_snippets_general.go
+++ b/firestore/pipeline_snippets_general.go
@@ -1746,12 +1746,12 @@ func basicRead(w io.Writer, client *firestore.Client) error {
 	return nil
 }
 
-func pipelineInitialization(w io.Writer, projectID string) error {
+func pipelineInitialization(w io.Writer, projectID string, databaseID string) error {
 	ctx := context.Background()
 	// [START firestore_pipeline_initialization]
-	client, err := firestore.NewClient(ctx, projectID)
+	client, err := firestore.NewClientWithDatabase(ctx, projectID, databaseID)
 	if err != nil {
-		fmt.Fprintf(w, "firestore.NewClient failed: %v", err)
+		fmt.Fprintf(w, "firestore.NewClientWithDatabase failed: %v", err)
 		return err
 	}
 	pipeline := client.Pipeline().Collection("books")

--- a/firestore/pipeline_snippets_test.go
+++ b/firestore/pipeline_snippets_test.go
@@ -44,6 +44,13 @@ func TestPipelineSnippets(t *testing.T) {
 
 	buf := new(bytes.Buffer)
 
+	t.Run("pipelineInitialization", func(t *testing.T) {
+		buf.Reset()
+		if err := pipelineInitialization(buf, projectID, databaseID); err != nil {
+			t.Errorf("pipelineInitialization failed: %v", err)
+		}
+	})
+
 	t.Run("pipelineConcepts", func(t *testing.T) {
 		buf.Reset()
 		if err := pipelineConcepts(buf, client); err != nil {


### PR DESCRIPTION
## Description

Pipeline queries can only be run on enterprise DB. All enterprise DBs are named. To create Firestore client for named DB, NewClientWithDatabase should be used.



## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
