### PR TITLE
feat(cloudkms): Add code samples for HPKE-based key import.

### DIFF
--- a/kms/go.mod
+++ b/kms/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	cloud.google.com/go/kms v1.26.0
+	filippo.io/hpke v0.4.0
 	github.com/GoogleCloudPlatform/golang-samples v0.0.0-20260211233957-36c1e7bd205a
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/google/tink/go v1.7.0

--- a/kms/go.sum
+++ b/kms/go.sum
@@ -22,6 +22,8 @@ cloud.google.com/go/storage v1.56.0 h1:iixmq2Fse2tqxMbWhLWC9HfBj1qdxqAmiK8/eqtsL
 cloud.google.com/go/storage v1.56.0/go.mod h1:Tpuj6t4NweCLzlNbw9Z9iwxEkrSem20AetIeH/shgVU=
 cloud.google.com/go/trace v1.11.7 h1:kDNDX8JkaAG3R2nq1lIdkb7FCSi1rCmsEtKVsty7p+U=
 cloud.google.com/go/trace v1.11.7/go.mod h1:TNn9d5V3fQVf6s4SCveVMIBS2LJUqo73GACmq/Tky0s=
+filippo.io/hpke v0.4.0 h1:p575VVQ6ted4pL+it6M00V/f2qTZITO0zgmdKCkd5+A=
+filippo.io/hpke v0.4.0/go.mod h1:EmAN849/P3qdeK+PCMkDpDm83vRHM5cDipBJ8xbQLVY=
 github.com/GoogleCloudPlatform/golang-samples v0.0.0-20260211233957-36c1e7bd205a h1:7nfSm7T5QsvMdymhV8hWoy7JYrdQXC0iyK7X832rdf0=
 github.com/GoogleCloudPlatform/golang-samples v0.0.0-20260211233957-36c1e7bd205a/go.mod h1:jkbBn2L5SwHPhu0LodX/Pvbu3ln6OexVi5lsuVbsRQk=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=

--- a/kms/hpke_wrap.go
+++ b/kms/hpke_wrap.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kms
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io"
+
+	"filippo.io/hpke"
+)
+
+func wrapHPKE(w io.Writer, publicKeyB64 string, targetKeyB64 string) error {
+	// publicKeyB64 is the base64-encoded key of the Cloud KMS ImportJob.
+	// targetKeyB64 is the key you want to wrap & import, base64-encoded.
+
+	// 1. Decode the ImportJob public key (obtained from Cloud KMS in NIST_PQC format)
+	pkBytes, err := base64.StdEncoding.DecodeString(publicKeyB64)
+	if err != nil {
+		return fmt.Errorf("failed to decode public key: %w", err)
+	}
+
+	// 2. Decode the target key material
+	targetKey, err := base64.StdEncoding.DecodeString(targetKeyB64)
+	if err != nil {
+		return fmt.Errorf("failed to decode target key: %w", err)
+	}
+
+	// 3. Define the HPKE suite for Cloud KMS quantum-safe import
+	// KEM: ML-KEM-768, KDF: HKDF-SHA256, AEAD: AES-256-GCM
+	//
+	// Note: you can replace MLKEM768 with MLKEM1024 or MLKEM768X25519
+	kem := hpke.MLKEM768()
+	kdf := hpke.HKDFSHA256()
+	aead := hpke.AES256GCM()
+
+	// 4. Load the public key into the KEM
+	pub, err := kem.NewPublicKey(pkBytes)
+	if err != nil {
+		return fmt.Errorf("failed to load public key: %w", err)
+	}
+
+	// 5. Perform One-Shot Seal (HPKE SetupSender + Seal)
+	// info is nil as Cloud KMS expect it to be empty.
+	// This function automatically returns the concatenation (enc || ciphertext).
+	wrappedKey, err := hpke.Seal(pub, kdf, aead, nil, targetKey)
+	if err != nil {
+		return fmt.Errorf("failed to wrap key: %w", err)
+	}
+
+	fmt.Fprintf(w, "Base64 wrappedKey:\n%s\n", base64.StdEncoding.EncodeToString(wrappedKey))
+	return nil
+}


### PR DESCRIPTION
## Description

Add a new sample to be used in quantum-safe key import public documentation for Cloud KMS.

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved
