### PR TITLE
chore(vertexai): Remove generativeaionvertexai_gemini_function_calling region tag

### DIFF
--- a/vertexai/function-calling/functioncalling_basic.go
+++ b/vertexai/function-calling/functioncalling_basic.go
@@ -16,7 +16,6 @@
 // data sources.
 package functioncalling
 
-// [START generativeaionvertexai_gemini_function_calling]
 import (
 	"context"
 	"encoding/json"
@@ -120,5 +119,3 @@ func functionCalling(w io.Writer, projectID, location, modelName string) error {
 
 	return nil
 }
-
-// [END generativeaionvertexai_gemini_function_calling]

--- a/vertexai/function-calling/functioncalling_test.go
+++ b/vertexai/function-calling/functioncalling_test.go
@@ -27,7 +27,7 @@ func Test_functionCalling(t *testing.T) {
 
 	var buf bytes.Buffer
 	location := "us-central1"
-	modelName := "gemini-2.0-flash-001"
+	modelName := "gemini-2.5-flash"
 
 	err := functionCalling(&buf, tc.ProjectID, location, modelName)
 	if err != nil {
@@ -52,7 +52,7 @@ func Test_functionCallsChat(t *testing.T) {
 
 	var buf bytes.Buffer
 	location := "us-central1"
-	modelName := "gemini-2.0-flash-001"
+	modelName := "gemini-2.5-flash"
 
 	err := functionCallsChat(&buf, tc.ProjectID, location, modelName)
 	if err != nil {
@@ -61,11 +61,12 @@ func Test_functionCallsChat(t *testing.T) {
 }
 
 func Test_parallelFunctionCalling(t *testing.T) {
+	t.Skip("Skipped while waiting to decommission vertexai")
 	tc := testutil.SystemTest(t)
 
 	var buf bytes.Buffer
 	location := "us-central1"
-	modelName := "gemini-2.0-flash-001"
+	modelName := "gemini-2.5-flash"
 
 	err := parallelFunctionCalling(&buf, tc.ProjectID, location, modelName)
 	if err != nil {


### PR DESCRIPTION
## Description

Decommissioning region tag `generativeaionvertexai_gemini_function_calling`

Fixes Internal b/527536984

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
