### PR TITLE
chore(vertexai): Remove gemini_get_context_cache region tag

### DIFF
--- a/vertexai/context-caching/contextcaching_get.go
+++ b/vertexai/context-caching/contextcaching_get.go
@@ -15,7 +15,6 @@
 // contextcaching shows an example of caching the tokens of a mulitple PDF prompt
 package contextcaching
 
-// [START generativeaionvertexai_gemini_get_context_cache]
 import (
 	"context"
 	"fmt"
@@ -43,5 +42,3 @@ func getContextCache(w io.Writer, contentName string, projectID, location string
 	fmt.Fprintf(w, "Retrieved cached content %q", cachedContent.Name)
 	return nil
 }
-
-// [END generativeaionvertexai_gemini_get_context_cache]


### PR DESCRIPTION
## Description
Remove the region tag since it has a new sample that has been updated in the docs so we want to remove it from the legacy VertexAI documentation.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [ ] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [ ] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
