### PR TITLE
samples(storage): Bidi naming samples

### DIFF
--- a/storage/bidi/bidi_test.go
+++ b/storage/bidi/bidi_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rapid
+package bidi
 
 import (
 	"bytes"
@@ -26,7 +26,6 @@ import (
 	"testing"
 
 	"cloud.google.com/go/storage"
-	"cloud.google.com/go/storage/experimental"
 	"github.com/GoogleCloudPlatform/golang-samples/internal/testutil"
 	"github.com/google/uuid"
 )
@@ -39,7 +38,7 @@ const (
 )
 
 var (
-	zonalBucketName string
+	bidiBucketName string
 	client          *storage.Client
 	downloadData    []byte
 )
@@ -48,24 +47,24 @@ func TestMain(m *testing.M) {
 	ctx := context.Background()
 
 	// Skip tests by default for now, until b/452725162 is resolved
-	if os.Getenv("STORAGE_RUN_RAPID_TESTS") == "" {
+	if os.Getenv("STORAGE_RUN_BIDI_TESTS") == "" {
 		os.Exit(0)
 	}
 
 	// Create fixture client & bucket to use across tests.
 	tc, _ := testutil.ContextMain(m)
 	var err error
-	client, err = storage.NewGRPCClient(context.Background(), experimental.WithZonalBucketAPIs())
+	client, err = storage.NewGRPCClient(context.Background(), storage.WithGRPCBidiReads(), storage.WithAppendableUploads())
 	if err != nil {
 		log.Fatalf("storage.NewGRPCClient: %v", err)
 	}
-	zonalBucketName = strings.Join([]string{testPrefix, uuid.NewString()}, "-")
-	if err := client.Bucket(zonalBucketName).Create(ctx, tc.ProjectID, &storage.BucketAttrs{
+	bidiBucketName = strings.Join([]string{testPrefix, uuid.NewString()}, "-")
+	if err := client.Bucket(bidiBucketName).Create(ctx, tc.ProjectID, &storage.BucketAttrs{
 		Location: testZonalLocation,
 		CustomPlacementConfig: &storage.CustomPlacementConfig{
 			DataLocations: []string{testZonalZone},
 		},
-		StorageClass: "RAPID",
+		StorageClass: "STANDARD",
 		HierarchicalNamespace: &storage.HierarchicalNamespace{
 			Enabled: true,
 		},
@@ -78,7 +77,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// Create object fixture for download tests
-	w := client.Bucket(zonalBucketName).Object(downloadObject).If(storage.Conditions{DoesNotExist: true}).NewWriter(ctx)
+	w := client.Bucket(bidiBucketName).Object(downloadObject).If(storage.Conditions{DoesNotExist: true}).NewWriter(ctx)
 	downloadData = make([]byte, 4*1024*1024)
 	_, _ = rand.Read(downloadData)
 	if _, err := io.Copy(w, bytes.NewReader(downloadData)); err != nil {
@@ -92,7 +91,7 @@ func TestMain(m *testing.M) {
 	exit := m.Run()
 
 	// Cleanup bucket and objects.
-	if err := testutil.DeleteBucketIfExists(ctx, client, zonalBucketName); err != nil {
+	if err := testutil.DeleteBucketIfExists(ctx, client, bidiBucketName); err != nil {
 		log.Printf("deleting bucket: %v", err)
 	}
 	os.Exit(exit)
@@ -101,12 +100,12 @@ func TestMain(m *testing.M) {
 func TestCreateAndWriteAppendableObject(t *testing.T) {
 	var b bytes.Buffer
 	object := "obj-appendable"
-	if err := createAndWriteAppendableObject(&b, zonalBucketName, object); err != nil {
+	if err := createAndWriteAppendableObject(&b, bidiBucketName, object); err != nil {
 		t.Fatalf("running sample: %v, output: %v", err, b.String())
 	}
 
 	// Check that object was created & is unfinalized
-	attrs, err := client.Bucket(zonalBucketName).Object(object).Attrs(context.Background())
+	attrs, err := client.Bucket(bidiBucketName).Object(object).Attrs(context.Background())
 	if err != nil {
 		t.Fatalf("object.Attrs: %v", err)
 	}
@@ -118,12 +117,12 @@ func TestCreateAndWriteAppendableObject(t *testing.T) {
 func TestFinalizeAppendableObject(t *testing.T) {
 	var b bytes.Buffer
 	object := "obj-finalize"
-	if err := finalizeAppendableObject(&b, zonalBucketName, object); err != nil {
+	if err := finalizeAppendableObject(&b, bidiBucketName, object); err != nil {
 		t.Fatalf("running sample: %v, output: %v", err, b.String())
 	}
 
 	// Check that object was created & is finalized
-	attrs, err := client.Bucket(zonalBucketName).Object(object).Attrs(context.Background())
+	attrs, err := client.Bucket(bidiBucketName).Object(object).Attrs(context.Background())
 	if err != nil {
 		t.Fatalf("object.Attrs: %v", err)
 	}
@@ -135,12 +134,12 @@ func TestFinalizeAppendableObject(t *testing.T) {
 func TestPauseAndResumeAppendableUpload(t *testing.T) {
 	var b bytes.Buffer
 	object := "obj-pause"
-	if err := pauseAndResumeAppendableUpload(&b, zonalBucketName, object); err != nil {
+	if err := pauseAndResumeAppendableUpload(&b, bidiBucketName, object); err != nil {
 		t.Fatalf("running sample: %v, output: %v", err, b.String())
 	}
 
 	// Check that object was created & is finalized
-	attrs, err := client.Bucket(zonalBucketName).Object(object).Attrs(context.Background())
+	attrs, err := client.Bucket(bidiBucketName).Object(object).Attrs(context.Background())
 	if err != nil {
 		t.Fatalf("object.Attrs: %v", err)
 	}
@@ -151,7 +150,7 @@ func TestPauseAndResumeAppendableUpload(t *testing.T) {
 
 func TestOpenObjectSingleRangedRead(t *testing.T) {
 	var b bytes.Buffer
-	data, err := openObjectSingleRangedRead(&b, zonalBucketName, downloadObject)
+	data, err := openObjectSingleRangedRead(&b, bidiBucketName, downloadObject)
 	if err != nil {
 		t.Fatalf("running sample: %v, output: %v", err, b.String())
 	}
@@ -162,7 +161,7 @@ func TestOpenObjectSingleRangedRead(t *testing.T) {
 
 func TestOpenObjectReadFullObject(t *testing.T) {
 	var b bytes.Buffer
-	data, err := openObjectReadFullObject(&b, zonalBucketName, downloadObject)
+	data, err := openObjectReadFullObject(&b, bidiBucketName, downloadObject)
 	if err != nil {
 		t.Fatalf("running sample: %v, output: %v", err, b.String())
 	}
@@ -173,7 +172,7 @@ func TestOpenObjectReadFullObject(t *testing.T) {
 
 func TestOpenObjectMultipleRangedRead(t *testing.T) {
 	var b bytes.Buffer
-	dataSlices, err := openObjectMultipleRangedRead(&b, zonalBucketName, downloadObject)
+	dataSlices, err := openObjectMultipleRangedRead(&b, bidiBucketName, downloadObject)
 	if err != nil {
 		t.Fatalf("running sample: %v, output: %v", err, b.String())
 	}
@@ -185,7 +184,7 @@ func TestOpenObjectMultipleRangedRead(t *testing.T) {
 
 func TestOpenMultipleObjectsRangedRead(t *testing.T) {
 	var b bytes.Buffer
-	dataSlices, err := openMultipleObjectsRangedRead(&b, zonalBucketName, []string{downloadObject, downloadObject, downloadObject})
+	dataSlices, err := openMultipleObjectsRangedRead(&b, bidiBucketName, []string{downloadObject, downloadObject, downloadObject})
 	if err != nil {
 		t.Fatalf("running sample: %v, output: %v", err, b.String())
 	}
@@ -196,13 +195,14 @@ func TestOpenMultipleObjectsRangedRead(t *testing.T) {
 	}
 }
 
+
 func TestReadAppendableObjectTail(t *testing.T) {
 	// Test passes locally but currently takes too long to run. Skipping
 	// on internal issue which will unblock running in CI.
 	t.Skip("b/440374150")
 	var b bytes.Buffer
 	object := "obj-tail"
-	data, err := readAppendableObjectTail(&b, zonalBucketName, object)
+	data, err := readAppendableObjectTail(&b, bidiBucketName, object)
 	if err != nil {
 		t.Fatalf("running sample: %v, output: %v", err, b.String())
 	}

--- a/storage/bidi/create_and_write_appendable_object.go
+++ b/storage/bidi/create_and_write_appendable_object.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rapid
+package bidi
 
 // [START storage_create_and_write_appendable_object]
 import (
@@ -22,16 +22,15 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"cloud.google.com/go/storage/experimental"
 )
 
 // createAndWriteAppendableObject creates and uploads a new appendable object in
-// a rapid bucket. The object will not be finalized.
+// a bucket. The object will not be finalized.
 func createAndWriteAppendableObject(w io.Writer, bucket, object string) error {
 	// bucket := "bucket-name"
 	// object := "object-name"
 	ctx := context.Background()
-	client, err := storage.NewGRPCClient(ctx, experimental.WithZonalBucketAPIs())
+	client, err := storage.NewGRPCClient(ctx, storage.WithAppendableUploads())
 	if err != nil {
 		return fmt.Errorf("storage.NewGRPCClient: %w", err)
 	}

--- a/storage/bidi/finalize_appendable_object_upload.go
+++ b/storage/bidi/finalize_appendable_object_upload.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rapid
+package bidi
 
 // [START storage_finalize_appendable_object_upload]
 import (
@@ -22,16 +22,15 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"cloud.google.com/go/storage/experimental"
 )
 
 // finalizeAppendableObject creates, uploads and finalizes a new object in
-// a rapid bucket.
+// a bucket.
 func finalizeAppendableObject(w io.Writer, bucket, object string) error {
 	// bucket := "bucket-name"
 	// object := "object-name"
 	ctx := context.Background()
-	client, err := storage.NewGRPCClient(ctx, experimental.WithZonalBucketAPIs())
+	client, err := storage.NewGRPCClient(ctx, storage.WithAppendableUploads())
 	if err != nil {
 		return fmt.Errorf("storage.NewGRPCClient: %w", err)
 	}

--- a/storage/bidi/open_multiple_objects_ranged_read.go
+++ b/storage/bidi/open_multiple_objects_ranged_read.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rapid
+package bidi
 
 // [START storage_open_multiple_objects_ranged_read]
 import (
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"cloud.google.com/go/storage/experimental"
 	"cloud.google.com/go/storage/transfermanager"
 )
 
@@ -32,7 +31,7 @@ func openMultipleObjectsRangedRead(w io.Writer, bucket string, objects []string)
 	// bucket := "bucket-name"
 	// objects := []string{"object-name1", "object-name2"}
 	ctx := context.Background()
-	client, err := storage.NewGRPCClient(ctx, experimental.WithZonalBucketAPIs())
+	client, err := storage.NewGRPCClient(ctx, storage.WithGRPCBidiReads())
 	if err != nil {
 		return nil, fmt.Errorf("storage.NewGRPCClient: %w", err)
 	}

--- a/storage/bidi/open_object_multiple_ranged_read.go
+++ b/storage/bidi/open_object_multiple_ranged_read.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rapid
+package bidi
 
 // [START storage_open_object_multiple_ranged_read]
 import (
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"cloud.google.com/go/storage/experimental"
 )
 
 // openObjectMultipleRangedRead opens a single object using
@@ -32,7 +31,7 @@ func openObjectMultipleRangedRead(w io.Writer, bucket, object string) ([][]byte,
 	// bucket := "bucket-name"
 	// object := "object-name"
 	ctx := context.Background()
-	client, err := storage.NewGRPCClient(ctx, experimental.WithZonalBucketAPIs())
+	client, err := storage.NewGRPCClient(ctx, storage.WithGRPCBidiReads())
 	if err != nil {
 		return nil, fmt.Errorf("storage.NewGRPCClient: %w", err)
 	}

--- a/storage/bidi/open_object_read_full_object.go
+++ b/storage/bidi/open_object_read_full_object.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rapid
+package bidi
 
 // [START storage_open_object_read_full_object]
 import (
@@ -23,16 +23,15 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"cloud.google.com/go/storage/experimental"
 )
 
 // OpenObjectReadFullObject reads a full object's data from a
-// rapid bucket.
+// standard bucket.
 func openObjectReadFullObject(w io.Writer, bucket, object string) ([]byte, error) {
 	// bucket := "bucket-name"
 	// object := "object-name"
 	ctx := context.Background()
-	client, err := storage.NewGRPCClient(ctx, experimental.WithZonalBucketAPIs())
+	client, err := storage.NewGRPCClient(ctx, storage.WithGRPCBidiReads())
 	if err != nil {
 		return nil, fmt.Errorf("storage.NewGRPCClient: %w", err)
 	}

--- a/storage/bidi/open_object_single_ranged_read.go
+++ b/storage/bidi/open_object_single_ranged_read.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rapid
+package bidi
 
 // [START storage_open_object_single_ranged_read]
 import (
@@ -23,16 +23,15 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"cloud.google.com/go/storage/experimental"
 )
 
 // openObjectSingleRangedRead reads a single range from an object in a
-// rapid bucket.
+// standard bucket.
 func openObjectSingleRangedRead(w io.Writer, bucket, object string) ([]byte, error) {
 	// bucket := "bucket-name"
 	// object := "object-name"
 	ctx := context.Background()
-	client, err := storage.NewGRPCClient(ctx, experimental.WithZonalBucketAPIs())
+	client, err := storage.NewGRPCClient(ctx, storage.WithGRPCBidiReads())
 	if err != nil {
 		return nil, fmt.Errorf("storage.NewGRPCClient: %w", err)
 	}

--- a/storage/bidi/pause_and_resume_appendable_upload.go
+++ b/storage/bidi/pause_and_resume_appendable_upload.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rapid
+package bidi
 
 // [START storage_pause_and_resume_appendable_upload]
 import (
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"cloud.google.com/go/storage/experimental"
 )
 
 // pauseAndResumeAppendableUpload creates a new unfinalized appendable object,
@@ -32,7 +31,7 @@ func pauseAndResumeAppendableUpload(w io.Writer, bucket, object string) error {
 	// bucket := "bucket-name"
 	// object := "object-name"
 	ctx := context.Background()
-	client, err := storage.NewGRPCClient(ctx, experimental.WithZonalBucketAPIs())
+	client, err := storage.NewGRPCClient(ctx, storage.WithAppendableUploads())
 	if err != nil {
 		return fmt.Errorf("storage.NewGRPCClient: %w", err)
 	}

--- a/storage/bidi/read_appendable_object_tail.go
+++ b/storage/bidi/read_appendable_object_tail.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rapid
+package bidi
 
 // [START storage_read_appendable_object_tail]
 import (
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"cloud.google.com/go/storage/experimental"
 )
 
 // readAppendableObjectTail simulates a "tail -f" command on a GCS object. It
@@ -34,7 +33,7 @@ func readAppendableObjectTail(w io.Writer, bucket, object string) ([]byte, error
 	// bucket := "bucket-name"
 	// object := "object-name"
 	ctx := context.Background()
-	client, err := storage.NewGRPCClient(ctx, experimental.WithZonalBucketAPIs())
+	client, err := storage.NewGRPCClient(ctx, storage.WithGRPCBidiReads(), storage.WithAppendableUploads())
 	if err != nil {
 		return nil, fmt.Errorf("storage.NewGRPCClient: %w", err)
 	}


### PR DESCRIPTION
## Description

Use new flags for GRPC Bidi reads and appendable uploads. 

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Contributing Guidelines from CONTRIBUTING.MD](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md)
- [x] **Tests** pass:   `go test -v ./..` (see [Testing](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#testing))
- [x] **Code formatted**:   `gofmt` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [x] **Vetting** pass:   `go vet` (see [Formatting](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/CONTRIBUTING.md#formatting))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/golang-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved
